### PR TITLE
Adds a ServiceAction queue

### DIFF
--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -181,21 +181,21 @@ internal class ServiceNotification(
         builder.addAction(
             imageNetworkEnabled,
             "New Identity",
-            getActionPendingIntent(torService, ServiceAction.ACTION_NEW_ID)
+            getActionPendingIntent(torService, NotificationAction.NEW_ID)
         )
 
         if (enableRestartButton)
             builder.addAction(
                 imageNetworkEnabled,
                 "Restart Tor",
-                getActionPendingIntent(torService, ServiceAction.ACTION_RESTART)
+                getActionPendingIntent(torService, NotificationAction.RESTART_TOR)
             )
 
         if (enableStopButton)
             builder.addAction(
                 imageNetworkEnabled,
                 "Stop Tor",
-                getActionPendingIntent(torService, ServiceAction.ACTION_STOP)
+                getActionPendingIntent(torService, NotificationAction.STOP_SERVICE)
             )
         notify(builder)
     }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -181,21 +181,21 @@ internal class ServiceNotification(
         builder.addAction(
             imageNetworkEnabled,
             "New Identity",
-            getActionPendingIntent(torService, NotificationAction.NEW_ID)
+            getActionPendingIntent(torService, ServiceAction.NEW_ID)
         )
 
         if (enableRestartButton)
             builder.addAction(
                 imageNetworkEnabled,
                 "Restart Tor",
-                getActionPendingIntent(torService, NotificationAction.RESTART_TOR)
+                getActionPendingIntent(torService, ServiceAction.RESTART_TOR)
             )
 
         if (enableStopButton)
             builder.addAction(
                 imageNetworkEnabled,
                 "Stop Tor",
-                getActionPendingIntent(torService, NotificationAction.STOP_SERVICE)
+                getActionPendingIntent(torService, ServiceAction.STOP)
             )
         notify(builder)
     }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceEventBroadcaster.kt
@@ -23,6 +23,7 @@ import io.matthewnelson.topl_service.notification.ServiceNotification
 import io.matthewnelson.topl_service.service.TorService
 import io.matthewnelson.topl_service.util.ServiceConsts.NotificationImage
 import io.matthewnelson.topl_service.util.ServiceUtilities
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -43,6 +44,8 @@ import java.util.*
 internal class ServiceEventBroadcaster(private val torService: TorService): EventBroadcaster() {
 
     private val serviceNotification = ServiceNotification.get()
+    private val scopeMain: CoroutineScope
+        get() = torService.scopeMain
 
     /////////////////
     /// Bandwidth ///
@@ -83,7 +86,7 @@ internal class ServiceEventBroadcaster(private val torService: TorService): Even
         }
 
         TorServiceController.appEventBroadcaster?.let {
-            torService.scopeMain.launch { it.broadcastBandwidth(bytesRead, bytesWritten) }
+            scopeMain.launch { it.broadcastBandwidth(bytesRead, bytesWritten) }
         }
     }
 
@@ -105,7 +108,7 @@ internal class ServiceEventBroadcaster(private val torService: TorService): Even
     /////////////
     override fun broadcastDebug(msg: String) {
         TorServiceController.appEventBroadcaster?.let {
-            torService.scopeMain.launch { it.broadcastDebug(msg) }
+            scopeMain.launch { it.broadcastDebug(msg) }
         }
     }
 
@@ -125,7 +128,7 @@ internal class ServiceEventBroadcaster(private val torService: TorService): Even
         }
 
         TorServiceController.appEventBroadcaster?.let {
-            torService.scopeMain.launch { it.broadcastException(msg, e) }
+            scopeMain.launch { it.broadcastException(msg, e) }
         }
     }
 
@@ -135,7 +138,7 @@ internal class ServiceEventBroadcaster(private val torService: TorService): Even
     ///////////////////
     override fun broadcastLogMessage(logMessage: String?) {
         TorServiceController.appEventBroadcaster?.let {
-            torService.scopeMain.launch { it.broadcastLogMessage(logMessage) }
+            scopeMain.launch { it.broadcastLogMessage(logMessage) }
         }
     }
 
@@ -193,7 +196,7 @@ internal class ServiceEventBroadcaster(private val torService: TorService): Even
         }
 
         TorServiceController.appEventBroadcaster?.let {
-            torService.scopeMain.launch { it.broadcastNotice(msg) }
+            scopeMain.launch { it.broadcastNotice(msg) }
         }
     }
 
@@ -203,7 +206,7 @@ internal class ServiceEventBroadcaster(private val torService: TorService): Even
      * ContentText the most recently broadcast bandwidth via [bytesRead] && [bytesWritten].
      * */
     private fun displayMessageToContentText(message: String, delayMilliSeconds: Long) {
-        noticeMsgToContentTextJob = torService.scopeMain.launch {
+        noticeMsgToContentTextJob = scopeMain.launch {
             serviceNotification.updateContentText(message)
             delay(delayMilliSeconds)
 
@@ -254,7 +257,7 @@ internal class ServiceEventBroadcaster(private val torService: TorService): Even
         }
 
         TorServiceController.appEventBroadcaster?.let {
-            torService.scopeMain.launch { it.broadcastTorState(state, networkState) }
+            scopeMain.launch { it.broadcastTorState(state, networkState) }
         }
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefsListener.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefsListener.kt
@@ -19,21 +19,26 @@ package io.matthewnelson.topl_service.prefs
 import android.content.SharedPreferences
 import io.matthewnelson.topl_core.OnionProxyManager
 import io.matthewnelson.topl_core.broadcaster.BroadcastLogger
+import io.matthewnelson.topl_service.service.ServiceActionProcessor
 import io.matthewnelson.topl_service.service.TorService
 import io.matthewnelson.topl_service.util.ServiceConsts.PrefKeyBoolean
 
 /**
  * Listens to [TorServicePrefs] for changes such that while Tor is running, it can
  * query [onionProxyManager] to have it updated immediately (if the setting doesn't
- * require a restart).
+ * require a restart), as well as submit Actions to [ServiceActionProcessor] to be queued
+ * for execution.
  *
  * @param [torService] To instantiate [TorServicePrefs]
- * @param [onionProxyManager]
  * */
 internal class TorServicePrefsListener(
-    private val torService: TorService,
-    private val onionProxyManager: OnionProxyManager
+    private val torService: TorService
 ): SharedPreferences.OnSharedPreferenceChangeListener {
+
+    private val onionProxyManager: OnionProxyManager
+        get() = torService.onionProxyManager
+    private val serviceActionProcessor: ServiceActionProcessor
+        get() = torService.serviceActionProcessor
 
     private val torServicePrefs = TorServicePrefs(torService)
     private val broadcastLogger: BroadcastLogger =

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/ActionCommands.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/ActionCommands.kt
@@ -1,0 +1,141 @@
+/*
+* Copyright (C) 2020 Matthew Nelson
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* */
+package io.matthewnelson.topl_service.service
+
+import android.content.Intent
+import io.matthewnelson.topl_service.util.ServiceConsts.ActionCommand
+import io.matthewnelson.topl_service.util.ServiceConsts.ServiceAction
+
+/**
+ * Facilitates mapping of a [ServiceAction] to an object which allows for individual command
+ * execution by [io.matthewnelson.topl_service.service.ServiceActionProcessor] in a repeatable
+ * manner. This allows for structured execution depending on the [ServiceAction] passed to
+ * [TorService] via Intent, while still maintaining an easy way to interrupt coroutine command
+ * execution for quickly responding to user actions.
+ *
+ * Think, running machine code to grok.
+ * */
+internal sealed class ActionCommands {
+
+    abstract class ServiceActionObject: ActionCommands() {
+
+        /**
+         * Individual [ActionCommand]'s to executed sequentially by
+         * [io.matthewnelson.topl_service.service.ServiceActionProcessor].
+         * */
+        abstract val commands: Array<@ActionCommand String>
+
+        /**
+         * For every ActionCommand.DELAY called for, a value will be consumed
+         * when executing the DELAY command.
+         *
+         * Override this to define the values for each DELAY call.
+         * */
+        open val delayLengthQueue: MutableList<Long> = mutableListOf()
+
+        /**
+         * Consumes the 0th element within [delayLengthQueue], removes, then returns it.
+         * If [delayLengthQueue] is empty, returns 0L.
+         *
+         * @return The 0th element within [delayLengthQueue], or 0L if empty
+         * */
+        fun consumeDelayLength(): Long {
+            return if (!delayLengthQueue.isNullOrEmpty()) {
+                val delayLength = delayLengthQueue[0]
+                delayLengthQueue.removeAt(0)
+                delayLength
+            } else {
+                0L
+            }
+        }
+    }
+
+    class NewId: ServiceActionObject() {
+        override val commands: Array<String>
+            get() = arrayOf(
+                ActionCommand.NEW_ID
+            )
+    }
+
+    class RestartTor: ServiceActionObject() {
+        override val commands: Array<String>
+            get() = arrayOf(
+                ActionCommand.STOP_TOR,
+                ActionCommand.DELAY,
+                ActionCommand.START_TOR,
+                ActionCommand.DELAY
+            )
+        override val delayLengthQueue =
+            mutableListOf(200L, 100L)
+    }
+
+    class Start: ServiceActionObject() {
+        override val commands: Array<String>
+            get() = arrayOf(
+                ActionCommand.START_TOR,
+                ActionCommand.DELAY
+            )
+        override val delayLengthQueue=
+            mutableListOf(100L)
+    }
+
+    class Stop: ServiceActionObject() {
+        override val commands: Array<String>
+            get() = arrayOf(
+                ActionCommand.STOP_TOR,
+                ActionCommand.DELAY,
+                ActionCommand.STOP_SERVICE
+            )
+        override val delayLengthQueue =
+            mutableListOf(200L)
+    }
+
+    /**
+     *
+     * */
+    class ServiceActionObjectGetter {
+
+        /**
+         * Processes an Intent by it's contained action and returns a
+         * [ServiceActionObject] for the passed [ServiceAction]
+         *
+         * @param [intent] The intent from [TorService.onStartCommand]
+         * @return [ServiceActionObject] associated with the intent's action (a [ServiceAction])
+         * @throws [IllegalArgumentException] if the intent's action isn't a [ServiceAction]
+         * */
+        @Throws(IllegalArgumentException::class)
+        fun get(intent: Intent): ServiceActionObject {
+            return when (intent.action) {
+                ServiceAction.NEW_ID -> {
+                    NewId()
+                }
+                ServiceAction.RESTART_TOR -> {
+                    RestartTor()
+                }
+                ServiceAction.START -> {
+                    Start()
+                }
+                ServiceAction.STOP -> {
+                    Stop()
+                }
+                else -> {
+                    throw (IllegalArgumentException())
+                }
+            }
+        }
+    }
+}

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/ServiceActionProcessor.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/ServiceActionProcessor.kt
@@ -1,0 +1,236 @@
+/*
+* Copyright (C) 2020 Matthew Nelson
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* */
+package io.matthewnelson.topl_service.service
+
+import android.content.Intent
+import androidx.annotation.WorkerThread
+import io.matthewnelson.topl_core.OnionProxyManager
+import io.matthewnelson.topl_service.util.ServiceConsts
+import kotlinx.coroutines.*
+import java.io.IOException
+import java.lang.reflect.InvocationTargetException
+
+internal class ServiceActionProcessor(private val torService: TorService): ServiceConsts() {
+
+    companion object {
+
+        // Needed to inhibit all TorServiceController methods except for startTor()
+        // from sending such that startService isn't called without properly
+        // starting Tor first.
+        @Volatile
+        var isAcceptingActions = false
+            private set
+    }
+
+    private val onionProxyManager: OnionProxyManager
+        get() = torService.onionProxyManager
+
+    private val broadcastLogger = onionProxyManager.getBroadcastLogger(ServiceActionProcessor::class.java)
+    private val serviceActionObjectGetter = ActionCommands.ServiceActionObjectGetter()
+
+    fun processIntent(intent: Intent) {
+        val actionObject = try {
+            serviceActionObjectGetter.get(intent)
+        } catch (e: IllegalArgumentException) {
+            broadcastLogger.exception(e)
+            return
+        }
+        processActionObject(actionObject)
+    }
+
+    fun processActionObject(serviceActionObject: ActionCommands.ServiceActionObject) {
+        addActionToQueue(serviceActionObject)
+
+        if (serviceActionObject is ActionCommands.Stop) {
+            isAcceptingActions = false
+
+            // If there are actions queued previous to Stop, clear them.
+            if (actionQueue.size > 1)
+                launchClearQueueJob()
+
+        } else if (serviceActionObject is ActionCommands.Start) {
+            isAcceptingActions = true
+        }
+
+        launchProcessQueueJob()
+    }
+
+    private fun broadcastDebugObjectDetailsMsg(prefix: String, something: Any) {
+        broadcastLogger.debug(
+            "$prefix${something.javaClass.simpleName}@${something.hashCode()}"
+        )
+    }
+
+
+    ////////////////////
+    /// Action Queue ///
+    ////////////////////
+    private val actionQueueLock = Object()
+    private val actionQueue = mutableListOf<ActionCommands.ServiceActionObject>()
+
+    private fun addActionToQueue(serviceActionObject: ActionCommands.ServiceActionObject) =
+        synchronized(actionQueueLock) {
+            if (actionQueue.add(serviceActionObject))
+                broadcastDebugObjectDetailsMsg(
+                    "Added to queue: ServiceActionObject.", serviceActionObject
+                )
+        }
+
+    private fun removeActionFromQueue(serviceActionObject: ActionCommands.ServiceActionObject) {
+        synchronized(actionQueueLock) {
+            if (actionQueue.remove(serviceActionObject))
+                broadcastDebugObjectDetailsMsg(
+                    "Removed from queue: ServiceActionObject.", serviceActionObject
+                )
+        }
+    }
+
+
+    //////////////////
+    /// Coroutines ///
+    //////////////////
+    private val scopeMain: CoroutineScope
+        get() = torService.scopeMain
+    private lateinit var clearQueueJob: Job
+    private lateinit var processQueueJob: Job
+
+    /**
+     * Will clear [actionQueue] up to the [ActionCommands.Stop] insertion
+     * */
+    private fun launchClearQueueJob() {
+        synchronized(actionQueueLock) {
+            if (!::clearQueueJob.isInitialized || !clearQueueJob.isActive) {
+                clearQueueJob = scopeMain.launch(Dispatchers.Default) {
+                    val iterator = actionQueue.listIterator()
+                    while (iterator.hasNext() && isActive) {
+                        val serviceActionObject = iterator.next()
+                        if (serviceActionObject is ActionCommands.Stop) {
+                            return@launch
+                        }
+                        iterator.remove()
+                        broadcastDebugObjectDetailsMsg(
+                            "Removed from queue: ServiceActionObject.", serviceActionObject
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Processes the [actionQueue]. Checks to see if [clearQueueJob] is active before executing
+     * every [ServiceConsts.ActionCommand], will finish processing the current command and then
+     * wait for completion of [clearQueueJob] before continuing to process [actionQueue].
+     * */
+    private fun launchProcessQueueJob() {
+        if (!::processQueueJob.isInitialized || !processQueueJob.isActive) {
+            processQueueJob = scopeMain.launch(Dispatchers.IO) {
+
+                // Hold processing the queue until after clearQueueJob is done.
+                if (::clearQueueJob.isInitialized && clearQueueJob.isActive) {
+                    clearQueueJob.join()
+                    delay(25L)
+                }
+
+                while (actionQueue.size > 0 && isActive) {
+
+                    val actionObject = actionQueue[0]
+                    actionObject.commands.forEachIndexed { index, command ->
+
+                        // If clearQueueJob is active, stop the for loop and wait for it to finish
+                        // before processing the next action.
+                        if (::clearQueueJob.isInitialized && clearQueueJob.isActive) return@launch
+                        when (command) {
+                            ActionCommand.DELAY -> {
+                                val delayLength = actionObject.consumeDelayLength()
+                                delay(delayLength)
+                            }
+                            ActionCommand.NEW_ID -> {
+                                onionProxyManager.signalNewNym()
+                            }
+                            ActionCommand.START_TOR -> {
+                                startTor()
+                            }
+                            ActionCommand.STOP_SERVICE -> {
+                                stopService()
+                            }
+                            ActionCommand.STOP_TOR -> {
+                                stopTor()
+                            }
+                        }
+                        if (index == actionObject.commands.lastIndex) {
+                            removeActionFromQueue(actionObject)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+    /////////////////////////
+    /// Execution Methods ///
+    /////////////////////////
+    private fun stopService() {
+        if (!isAcceptingActions) {
+            broadcastDebugObjectDetailsMsg("Stopping: ", torService)
+            torService.stopSelf()
+        }
+    }
+
+    @WorkerThread
+    private fun startTor() {
+        if (onionProxyManager.hasControlConnection) return
+        try {
+            onionProxyManager.setup()
+            generateTorrcFile()
+
+            onionProxyManager.start()
+        } catch (e: Exception) {
+            broadcastLogger.exception(e)
+        }
+    }
+
+    @WorkerThread
+    private fun stopTor() {
+        try {
+            onionProxyManager.stop()
+        } catch (e: Exception) {
+            broadcastLogger.exception(e)
+        }
+    }
+
+    @WorkerThread
+    @Throws(
+        SecurityException::class,
+        IllegalAccessException::class,
+        IllegalArgumentException::class,
+        InvocationTargetException::class,
+        NullPointerException::class,
+        ExceptionInInitializerError::class,
+        IOException::class
+    )
+    private fun generateTorrcFile() {
+        onionProxyManager.getNewSettingsBuilder()
+            .updateTorSettings()
+            .setGeoIpFiles()
+            .finishAndWriteToTorrcFile()
+    }
+
+
+
+}

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
@@ -161,18 +161,40 @@ abstract class ServiceConsts: BaseConsts() {
     /// ServiceActions ///
     //////////////////////
     @StringDef(
-        ServiceAction.ACTION_START,
-        ServiceAction.ACTION_STOP,
-        ServiceAction.ACTION_RESTART,
-        ServiceAction.ACTION_NEW_ID
+        ServiceAction.DELAY,
+        ServiceAction.NEW_ID,
+        ServiceAction.START_TOR,
+        ServiceAction.STOP_TOR,
+        ServiceAction.STOP_SERVICE
     )
     @kotlin.annotation.Retention(AnnotationRetention.SOURCE)
     internal annotation class ServiceAction {
         companion object {
-            const val ACTION_START = "ACTION_START"
-            const val ACTION_STOP = "ACTION_STOP"
-            const val ACTION_RESTART = "ACTION_RESTART"
-            const val ACTION_NEW_ID = "ACTION_NEW_ID"
+            private const val SERVICE_ACTION = "ServiceAction_"
+            const val DELAY = "${SERVICE_ACTION}DELAY"
+            const val NEW_ID = "${SERVICE_ACTION}NEW_ID"
+            const val START_TOR = "${SERVICE_ACTION}START_TOR"
+            const val STOP_TOR = "${SERVICE_ACTION}STOP_TOR"
+            const val STOP_SERVICE = "${SERVICE_ACTION}STOP_SERVICE"
+        }
+    }
+
+
+    ///////////////////////////
+    /// NotificationActions ///
+    ///////////////////////////
+    @StringDef(
+        NotificationAction.NEW_ID,
+        NotificationAction.RESTART_TOR,
+        NotificationAction.STOP_SERVICE
+    )
+    @kotlin.annotation.Retention(AnnotationRetention.SOURCE)
+    internal annotation class NotificationAction {
+        companion object {
+            private const val NOTIFICATION_ACTION = "NotificationAction_"
+            const val NEW_ID = "${NOTIFICATION_ACTION}NEW_ID"
+            const val RESTART_TOR = "${NOTIFICATION_ACTION}RESTART_TOR"
+            const val STOP_SERVICE = "${NOTIFICATION_ACTION}STOP_SERVICE"
         }
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
@@ -161,40 +161,45 @@ abstract class ServiceConsts: BaseConsts() {
     /// ServiceActions ///
     //////////////////////
     @StringDef(
-        ServiceAction.DELAY,
         ServiceAction.NEW_ID,
-        ServiceAction.START_TOR,
-        ServiceAction.STOP_TOR,
-        ServiceAction.STOP_SERVICE
+        ServiceAction.RESTART_TOR,
+        ServiceAction.START,
+        ServiceAction.STOP
     )
     @kotlin.annotation.Retention(AnnotationRetention.SOURCE)
     internal annotation class ServiceAction {
         companion object {
             private const val SERVICE_ACTION = "ServiceAction_"
-            const val DELAY = "${SERVICE_ACTION}DELAY"
             const val NEW_ID = "${SERVICE_ACTION}NEW_ID"
-            const val START_TOR = "${SERVICE_ACTION}START_TOR"
-            const val STOP_TOR = "${SERVICE_ACTION}STOP_TOR"
-            const val STOP_SERVICE = "${SERVICE_ACTION}STOP_SERVICE"
+            const val RESTART_TOR = "${SERVICE_ACTION}RESTART_TOR"
+            const val START = "${SERVICE_ACTION}START"
+            const val STOP = "${SERVICE_ACTION}STOP"
         }
     }
 
 
-    ///////////////////////////
-    /// NotificationActions ///
-    ///////////////////////////
+    //////////////////////
+    /// ActionCommands ///
+    //////////////////////
+    @Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS, AnnotationTarget.VALUE_PARAMETER)
     @StringDef(
-        NotificationAction.NEW_ID,
-        NotificationAction.RESTART_TOR,
-        NotificationAction.STOP_SERVICE
+        ActionCommand.DELAY,
+        ActionCommand.NEW_ID,
+        ActionCommand.START_TOR,
+        ActionCommand.STOP_SERVICE,
+        ActionCommand.STOP_TOR
     )
     @kotlin.annotation.Retention(AnnotationRetention.SOURCE)
-    internal annotation class NotificationAction {
+    internal annotation class ActionCommand {
         companion object {
-            private const val NOTIFICATION_ACTION = "NotificationAction_"
-            const val NEW_ID = "${NOTIFICATION_ACTION}NEW_ID"
-            const val RESTART_TOR = "${NOTIFICATION_ACTION}RESTART_TOR"
-            const val STOP_SERVICE = "${NOTIFICATION_ACTION}STOP_SERVICE"
+            private const val ACTION_COMMAND = "ActionCommand_"
+            const val DELAY = "${ACTION_COMMAND}DELAY"
+            const val NEW_ID = "${ACTION_COMMAND}NEW_ID"
+            const val START_TOR = "${ACTION_COMMAND}START_TOR"
+            const val STOP_SERVICE = "${ACTION_COMMAND}STOP_SERVICE"
+            const val STOP_TOR = "${ACTION_COMMAND}STOP_TOR"
         }
     }
+
+
 }


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR adds a queue for Intents containing ServiceActions to TorService. Functionality adds are:
 - Sequential execution of ServiceActions only after previous ServiceAction has been executed
 - Sequential execution of individual commands for each ServiceAction.
 - Immediate interruption of command execution when Stop is called (command finishes executing, but remaining commands for the ServiceAction will not).
 - Clears the queue when Stop is called (by removal of task, or from the TorServiceController) for immediate shutdown of the Service

Resolves #29