### PR TITLE
Fixes issue with the Tor Process not completing setup before executing next start/stop

### DIFF
--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/ActionCommands.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/ActionCommands.kt
@@ -76,32 +76,25 @@ internal sealed class ActionCommands {
             get() = arrayOf(
                 ActionCommand.STOP_TOR,
                 ActionCommand.DELAY,
-                ActionCommand.START_TOR,
-                ActionCommand.DELAY
+                ActionCommand.START_TOR
             )
         override val delayLengthQueue =
-            mutableListOf(200L, 100L)
+            mutableListOf(700L)
     }
 
     class Start: ServiceActionObject() {
         override val commands: Array<String>
             get() = arrayOf(
-                ActionCommand.START_TOR,
-                ActionCommand.DELAY
+                ActionCommand.START_TOR
             )
-        override val delayLengthQueue=
-            mutableListOf(100L)
     }
 
     class Stop: ServiceActionObject() {
         override val commands: Array<String>
             get() = arrayOf(
                 ActionCommand.STOP_TOR,
-                ActionCommand.DELAY,
                 ActionCommand.STOP_SERVICE
             )
-        override val delayLengthQueue =
-            mutableListOf(200L)
     }
 
     /**

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/ServiceActionProcessor.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/ServiceActionProcessor.kt
@@ -172,12 +172,14 @@ internal class ServiceActionProcessor(private val torService: TorService): Servi
                             }
                             ActionCommand.START_TOR -> {
                                 startTor()
+                                delay(300L)
                             }
                             ActionCommand.STOP_SERVICE -> {
                                 stopService()
                             }
                             ActionCommand.STOP_TOR -> {
                                 stopTor()
+                                delay(300L)
                             }
                         }
                         if (index == actionObject.commands.lastIndex) {


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR fixes an issue where the Tor OP was getting stuck and inhibiting execution of other methods within OnionProxyManager. It takes the ActionCommand calls for DELAY after START_TOR and STOP_TOR and moves them to a statically present delay within the `ServiceActionProcessor.launchProcessQueueJob` where they are called.