### PR TITLE
Refactors TorConfigFiles class uses

### DIFF
--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -24,10 +24,6 @@ import io.matthewnelson.topl_service.TorServiceController
  * */
 class App: Application() {
 
-    companion object {
-        val myTorSettings = MyTorSettings()
-    }
-
     override fun onCreate() {
         super.onCreate()
         setupTorServices()
@@ -37,7 +33,7 @@ class App: Application() {
         TorServiceController.Builder(
             application = this,
             buildConfigVersionCode = BuildConfig.VERSION_CODE,
-            torSettings = myTorSettings,
+            torSettings = MyTorSettings(),
             geoipAssetPath = "common/geoip",
             geoip6AssetPath = "common/geoip6"
         )

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/MainActivity.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/MainActivity.kt
@@ -51,7 +51,7 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         torServicePrefs = TorServicePrefs(this)
         hasDebugLogs = torServicePrefs.getBoolean(
-            PrefKeyBoolean.HAS_DEBUG_LOGS, App.myTorSettings.hasDebugLogs
+            PrefKeyBoolean.HAS_DEBUG_LOGS, TorServiceController.getTorSettings().hasDebugLogs
         )
         findViews()
         initButtons()

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/samplecode/SampleCode.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/samplecode/SampleCode.kt
@@ -3,10 +3,7 @@ package io.matthewnelson.sampleapp.samplecode
 import android.app.Application
 import android.content.Context
 import androidx.core.app.NotificationCompat
-import io.matthewnelson.sampleapp.App
-import io.matthewnelson.sampleapp.BuildConfig
-import io.matthewnelson.sampleapp.MainActivity
-import io.matthewnelson.sampleapp.R
+import io.matthewnelson.sampleapp.*
 import io.matthewnelson.topl_core_base.EventBroadcaster
 import io.matthewnelson.topl_core_base.TorConfigFiles
 import io.matthewnelson.topl_service.TorServiceController
@@ -35,7 +32,7 @@ object SampleCode {
             TorServiceController.Builder(
                 application = application,
                 buildConfigVersionCode = BuildConfig.VERSION_CODE,
-                torSettings = App.myTorSettings,
+                torSettings = MyTorSettings(),
 
                 // These should live somewhere in your project application's assets directory
                 geoipAssetPath = "common/geoip",

--- a/topl-core-base/src/androidTest/java/io/matthewnelson/topl_core_base/TorConfigFilesAndroidTest.kt
+++ b/topl-core-base/src/androidTest/java/io/matthewnelson/topl_core_base/TorConfigFilesAndroidTest.kt
@@ -105,7 +105,7 @@ class TorConfigFilesAndroidTest {
         val config = torConfigFilesBuilder.torExecutable(File(sampleFile, "exedir/tor.real")).build()
         assertEquals(
             File(sampleFile, "exedir").path,
-            config.libraryPath.path
+            config.libraryPath?.path
         )
     }
 
@@ -114,7 +114,7 @@ class TorConfigFilesAndroidTest {
         val config = torConfigFilesBuilder.build()
         assertEquals(
             appContext.applicationInfo.nativeLibraryDir,
-            config.libraryPath.path
+            config.libraryPath?.path
         )
     }
 

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/FileExtensions.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/FileExtensions.kt
@@ -1,0 +1,32 @@
+package io.matthewnelson.topl_core_base
+
+import java.io.EOFException
+import java.io.File
+import java.io.FileInputStream
+import java.io.IOException
+
+/**
+ * Reads a [File]
+ *
+ * @return a [ByteArray] of the contents of the [File]
+ * @throws [IOException] File errors
+ * @throws [EOFException] File errors
+ * @throws [SecurityException] Unauthorized access to file/directory.
+ * */
+@Throws(IOException::class, EOFException::class, SecurityException::class)
+fun File.readTorConfigFile(): ByteArray {
+    val b = ByteArray(this.length().toInt())
+    val `in` = FileInputStream(this)
+
+    return `in`.use { inputStream ->
+        var offset = 0
+
+        while (offset < b.size) {
+            val read = inputStream.read(b, offset, b.size - offset)
+            if (read == -1) throw EOFException()
+            offset += read
+        }
+
+        b
+    }
+}

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorConfigFiles.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorConfigFiles.kt
@@ -359,7 +359,7 @@ class TorConfigFiles private constructor(
             if (!::mDataDir.isInitialized)
                 mDataDir = File(configDir, ConfigFileName.DATA_DIR)
 
-            if (mLibraryPath != null)
+            if (mLibraryPath == null)
                 mLibraryPath = mTorExecutableFile.parentFile
 
             if (!::mHostnameFile.isInitialized)

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorConfigFiles.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorConfigFiles.kt
@@ -52,6 +52,12 @@ import java.io.IOException
  * Holds Tor configuration information for files and directories that Tor will use.
  *
  * See [Companion.createConfig] or [Builder] to instantiate.
+ *
+ * When modifying/querying Files, ensure you are using `synchronized` and acquiring
+ * the appropriate `FileLock` object pertaining to that File. This inhibits errors
+ * across the library.
+ *
+ * See extension function [readTorConfigFile].
  * */
 class TorConfigFiles private constructor(
     val geoIpFile: File,
@@ -124,9 +130,21 @@ class TorConfigFiles private constructor(
             createConfig(context, context.getDir("torservice", Context.MODE_PRIVATE))
     }
 
-    private val configLock = Object()
     var torrcFile = torrcFile
         private set
+
+
+    //////////////////
+    /// File Locks ///
+    //////////////////
+    val torrcFileLock = Object()
+    val controlPortFileLock = Object()
+    val cookieAuthFileLock = Object()
+    val dataDirLock = Object()
+    val geoIpFileLock = Object()
+    val geoIpv6FileLock = Object()
+    val resolvConfFileLock = Object()
+    val hostnameFileLock = Object()
 
     /**
      * Resolves the tor configuration file. If the torrc file hasn't been set, then
@@ -139,7 +157,7 @@ class TorConfigFiles private constructor(
      * */
     @Throws(IOException::class, SecurityException::class)
     fun resolveTorrcFile(): File {
-        synchronized(configLock) {
+        synchronized(torrcFileLock) {
             if (torrcFile.exists()) {
                 return torrcFile
             }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
@@ -52,6 +52,7 @@ import io.matthewnelson.topl_core.util.CoreConsts
 import io.matthewnelson.topl_core.util.TorInstaller
 import io.matthewnelson.topl_core.util.WriteObserver
 import io.matthewnelson.topl_core_base.TorConfigFiles
+import io.matthewnelson.topl_core_base.readTorConfigFile
 import java.io.*
 
 /**
@@ -208,17 +209,17 @@ internal class OnionProxyContext(
         return when (configFileReference) {
             ConfigFile.CONTROL_PORT_FILE -> {
                 synchronized(controlPortFileLock) {
-                    FileUtilities.read(torConfigFiles.controlPortFile)
+                    torConfigFiles.controlPortFile.readTorConfigFile()
                 }
             }
             ConfigFile.COOKIE_AUTH_FILE -> {
                 synchronized(cookieAuthFileLock) {
-                    FileUtilities.read(torConfigFiles.cookieAuthFile)
+                    torConfigFiles.cookieAuthFile.readTorConfigFile()
                 }
             }
             ConfigFile.HOSTNAME_FILE -> {
                 synchronized(hostnameFileLock) {
-                    FileUtilities.read(torConfigFiles.hostnameFile)
+                    torConfigFiles.hostnameFile.readTorConfigFile()
                 }
             }
             else -> {

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
@@ -86,11 +86,16 @@ internal class OnionProxyContext(
             broadcastLogger = onionProxyBroadcastLogger
     }
 
-    private val controlPortFileLock = Object()
-    private val cookieAuthFileLock = Object()
-    private val dataDirLock = Object()
-    private val resolvConfFileLock = Object()
-    private val hostnameFileLock = Object()
+    private val controlPortFileLock: Any
+        get() = torConfigFiles.controlPortFileLock
+    private val cookieAuthFileLock: Any
+        get() = torConfigFiles.cookieAuthFileLock
+    private val dataDirLock: Any
+        get() = torConfigFiles.dataDirLock
+    private val resolvConfFileLock: Any
+        get() = torConfigFiles.resolvConfFileLock
+    private val hostnameFileLock: Any
+        get() = torConfigFiles.hostnameFileLock
 
     /**
      * Creates an observer for the file referenced. See [CoreConsts.ConfigFile] annotation class

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/FileUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/FileUtilities.kt
@@ -92,7 +92,6 @@
 package io.matthewnelson.topl_core.util
 
 import java.io.*
-import java.util.logging.Logger
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/FileUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/FileUtilities.kt
@@ -159,24 +159,6 @@ object FileUtilities {
         }
     }
 
-    @Throws(IOException::class, EOFException::class, SecurityException::class)
-    fun read(f: File): ByteArray {
-        val b = ByteArray(f.length().toInt())
-        val `in` = FileInputStream(f)
-
-        return `in`.use { inputStream ->
-            var offset = 0
-
-            while (offset < b.size) {
-                val read = inputStream.read(b, offset, b.size - offset)
-                if (read == -1) throw EOFException()
-                offset += read
-            }
-
-            b
-        }
-    }
-
     /**
      * Reads the input stream, deletes fileToWriteTo if it exists and over writes it with the stream.
      * @param readFrom Stream to read from

--- a/topl-service/build.gradle
+++ b/topl-service/build.gradle
@@ -7,6 +7,7 @@ android {
     compileSdkVersion versions.compileSdk
     buildToolsVersion versions.buildTools
 
+    testOptions.unitTests.includeAndroidResources = true
     defaultConfig {
         minSdkVersion versions.minSdk
         targetSdkVersion versions.compileSdk

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -71,10 +71,14 @@ class TorServiceController private constructor(): ServiceConsts() {
     class Builder(
         private val application: Application,
         private val buildConfigVersionCode: Int,
-        private val torSettings: TorSettings,
+        torSettings: TorSettings,
         private val geoipAssetPath: String,
         private val geoip6AssetPath: String
     ) {
+
+        init {
+            Companion.torSettings = torSettings
+        }
 
         private lateinit var torConfigFiles: TorConfigFiles
 
@@ -370,15 +374,14 @@ class TorServiceController private constructor(): ServiceConsts() {
          * See [Builder] for code samples.
          * */
         fun build() {
-            val torConfigFiles: TorConfigFiles =
+
+            Companion.torConfigFiles =
                 if (::torConfigFiles.isInitialized)
-                    this.torConfigFiles
+                    torConfigFiles
                 else
                     TorConfigFiles.createConfig(application.applicationContext)
 
             TorService.initialize(
-                torConfigFiles,
-                torSettings,
                 buildConfigVersionCode,
                 buildConfigDebug,
                 geoipAssetPath,
@@ -399,6 +402,35 @@ class TorServiceController private constructor(): ServiceConsts() {
         private lateinit var appContext: Context
         var appEventBroadcaster: EventBroadcaster? = null
             private set
+        private lateinit var torConfigFiles: TorConfigFiles
+        private lateinit var torSettings: TorSettings
+
+        /**
+         * Get the [TorConfigFiles] that have been set after calling [Builder.build]
+         *
+         * @return Instance of [TorConfigFiles] that are being used throughout TOPL-Android
+         * @throws [UninitializedPropertyAccessException] if called before [Builder.build]
+         * */
+        @Throws(UninitializedPropertyAccessException::class)
+        fun getTorConfigFiles(): TorConfigFiles =
+            if (::torConfigFiles.isInitialized)
+                torConfigFiles
+            else
+                throw UninitializedPropertyAccessException("TorConfigFiles hasn't been initialized")
+
+        /**
+         * Get the [TorSettings] that have been set after calling [Builder.build]. These are
+         * the [TorSettings] you initialized [TorServiceController.Builder] with.
+         *
+         * @return Instance of [TorSettings] that are being used throughout TOPL-Android
+         * @throws [UninitializedPropertyAccessException] if called before [Builder.build]
+         * */
+        @Throws(UninitializedPropertyAccessException::class)
+        fun getTorSettings(): TorSettings =
+            if (::torSettings.isInitialized)
+                torSettings
+            else
+                throw UninitializedPropertyAccessException("TorSettings hasn't been initialized")
 
         // Needed to inhibit all TorServiceController methods except for startTor()
         // from sending such that startService isn't called and Tor isn't properly

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceTorInstaller.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceTorInstaller.kt
@@ -64,11 +64,11 @@ internal class ServiceTorInstaller(
     @Throws(IOException::class, SecurityException::class)
     override fun setup() {
         if (!torConfigFiles.geoIpFile.exists()) {
-            copyAsset(geoIpAssetPath, torConfigFiles.geoIpFile)
+            copyGeoIpAsset()
             geoIpFileCopied = ""
         }
         if (!torConfigFiles.geoIpv6File.exists()) {
-            copyAsset(geoIp6AssetPath, torConfigFiles.geoIpv6File)
+            copyGeoIpv6Asset()
             geoIpv6FileCopied = ""
         }
 
@@ -77,14 +77,24 @@ internal class ServiceTorInstaller(
         // mitigates copying to be done only if a version upgrade is had.
         if (buildConfigDebug || buildConfigVersionCode > localPrefs.getInt(APP_VERSION_CODE, -1)) {
             if (!::geoIpFileCopied.isInitialized) {
-                copyAsset(geoIpAssetPath, torConfigFiles.geoIpFile)
+                copyGeoIpAsset()
             }
             if (!::geoIpv6FileCopied.isInitialized) {
-                copyAsset(geoIp6AssetPath, torConfigFiles.geoIpv6File)
+                copyGeoIpv6Asset()
             }
             localPrefs.edit().putInt(APP_VERSION_CODE, buildConfigVersionCode).apply()
         }
     }
+
+    private fun copyGeoIpAsset() =
+        synchronized(torConfigFiles.geoIpFileLock) {
+            copyAsset(geoIpAssetPath, torConfigFiles.geoIpFile)
+        }
+
+    private fun copyGeoIpv6Asset() =
+        synchronized(torConfigFiles.geoIpv6FileLock) {
+            copyAsset(geoIp6AssetPath, torConfigFiles.geoIpv6File)
+        }
 
     @Throws(IOException::class)
     private fun copyAsset(assetPath: String, file: File) {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceTorInstaller.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceTorInstaller.kt
@@ -19,8 +19,8 @@ package io.matthewnelson.topl_service.onionproxy
 import io.matthewnelson.topl_core.util.FileUtilities
 import io.matthewnelson.topl_core.util.TorInstaller
 import io.matthewnelson.topl_core_base.TorConfigFiles
-import io.matthewnelson.topl_service.BuildConfig
 import io.matthewnelson.topl_service.R
+import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.service.TorService
 import io.matthewnelson.topl_service.util.ServiceConsts.PrefKeyList
 import io.matthewnelson.topl_service.prefs.TorServicePrefs
@@ -28,27 +28,27 @@ import java.io.*
 import java.util.concurrent.TimeoutException
 
 /**
- * Installs assets needed for Tor.
- *
- * @param [torService] for context.
- * @param [torConfigFiles] [TorConfigFiles] to know where files/directories are.
- * @param [buildConfigVersionCode] Use [BuildConfig.VERSION_CODE]
- * @param [buildConfigDebug] Use [BuildConfig.DEBUG]
- * @param [geoIpAssetPath] The path to geoip file within the application, ex: "common/geoip"
- * @param [geoIp6AssetPath] The path to geoip6 file within the application, ex: "common/geoip6"
+ * Installs things needed for Tor.
  *
  * See [io.matthewnelson.topl_service.TorServiceController.Builder]
+ *
+ * @param [torService] for context
  * */
-internal class ServiceTorInstaller(
-    private val torService: TorService,
-    private val torConfigFiles: TorConfigFiles,
-    private val buildConfigVersionCode: Int,
-    private val buildConfigDebug: Boolean,
-    private val geoIpAssetPath: String,
+internal class ServiceTorInstaller(private val torService: TorService): TorInstaller() {
+
+    private val torConfigFiles: TorConfigFiles
+        get() = TorServiceController.getTorConfigFiles()
+    private val buildConfigVersionCode: Int
+        get() = TorService.buildConfigVersionCode
+    private val buildConfigDebug: Boolean
+        get() = TorService.buildConfigDebug ?: false
+    private val geoIpAssetPath: String
+        get() = TorService.geoipAssetPath
     private val geoIp6AssetPath: String
-): TorInstaller() {
+        get() = TorService.geoip6AssetPath
 
     private val torServicePrefs = TorServicePrefs(torService)
+
     private val localPrefs = TorService.getLocalPrefs(torService.applicationContext)
     private lateinit var geoIpFileCopied: String
     private lateinit var geoIpv6FileCopied: String

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/ActionCommands.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/ActionCommands.kt
@@ -45,7 +45,7 @@ internal sealed class ActionCommands {
          *
          * Override this to define the values for each DELAY call.
          * */
-        open val delayLengthQueue: MutableList<Long> = mutableListOf()
+        protected open val delayLengthQueue: MutableList<Long> = mutableListOf()
 
         /**
          * Consumes the 0th element within [delayLengthQueue], removes, then returns it.
@@ -54,7 +54,7 @@ internal sealed class ActionCommands {
          * @return The 0th element within [delayLengthQueue], or 0L if empty
          * */
         fun consumeDelayLength(): Long {
-            return if (!delayLengthQueue.isNullOrEmpty()) {
+            return if (delayLengthQueue.isNotEmpty()) {
                 val delayLength = delayLengthQueue[0]
                 delayLengthQueue.removeAt(0)
                 delayLength
@@ -97,9 +97,6 @@ internal sealed class ActionCommands {
             )
     }
 
-    /**
-     *
-     * */
     class ServiceActionObjectGetter {
 
         /**

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -24,9 +24,8 @@ import android.os.IBinder
 import io.matthewnelson.topl_core.OnionProxyManager
 import io.matthewnelson.topl_core.broadcaster.BroadcastLogger
 import io.matthewnelson.topl_service.notification.ServiceNotification
-import io.matthewnelson.topl_core_base.TorConfigFiles
 import io.matthewnelson.topl_core_base.TorSettings
-import io.matthewnelson.topl_service.BuildConfig
+import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.onionproxy.ServiceEventBroadcaster
 import io.matthewnelson.topl_service.onionproxy.ServiceEventListener
 import io.matthewnelson.topl_service.onionproxy.ServiceTorInstaller
@@ -37,27 +36,30 @@ import kotlinx.coroutines.*
 internal class TorService: Service() {
 
     companion object {
-        private lateinit var torConfigFiles: TorConfigFiles
-        private lateinit var torSettings: TorSettings
-        private var buildConfigVersionCode: Int = -1
-        private var buildConfigDebug: Boolean? = null
-        private lateinit var geoipAssetPath: String
-        private lateinit var geoip6AssetPath: String
+        var buildConfigVersionCode: Int = -1
+            private set
+        var buildConfigDebug: Boolean? = null
+            private set
+        lateinit var geoipAssetPath: String
+            private set
+        lateinit var geoip6AssetPath: String
+            private set
+
+        private fun isInitialized(): Boolean =
+            ::geoipAssetPath.isInitialized
 
         fun initialize(
-            torConfigFiles: TorConfigFiles,
-            torSettings: TorSettings,
             buildConfigVersionCode: Int,
             buildConfigDebug: Boolean,
             geoipAssetPath: String,
             geoip6AssetPath: String
         ) {
-            this.torConfigFiles = torConfigFiles
-            this.torSettings = torSettings
-            this.buildConfigVersionCode = buildConfigVersionCode
-            this.buildConfigDebug = buildConfigDebug
-            this.geoipAssetPath = geoipAssetPath
-            this.geoip6AssetPath = geoip6AssetPath
+            if (!isInitialized()) {
+                this.buildConfigVersionCode = buildConfigVersionCode
+                this.buildConfigDebug = buildConfigDebug
+                this.geoipAssetPath = geoipAssetPath
+                this.geoip6AssetPath = geoip6AssetPath
+            }
         }
 
         // For things that can't be saved to TorServicePrefs, such as BuildConfig.VERSION_CODE
@@ -78,7 +80,7 @@ internal class TorService: Service() {
     override fun onCreate() {
         super.onCreate()
         ServiceNotification.get().startForegroundNotification(this)
-        initTOPLCore(this)
+        initTOPLCore()
         serviceActionProcessor = ServiceActionProcessor(this)
         torServicePrefsListener = TorServicePrefsListener(this)
     }
@@ -116,22 +118,14 @@ internal class TorService: Service() {
     lateinit var onionProxyManager: OnionProxyManager
         private set
 
-    private fun initTOPLCore(torService: TorService) {
-        val serviceTorInstaller = ServiceTorInstaller(
-            torService,
-            torConfigFiles,
-            buildConfigVersionCode,
-            buildConfigDebug ?: BuildConfig.DEBUG,
-            geoipAssetPath,
-            geoip6AssetPath
-        )
+    private fun initTOPLCore() {
         onionProxyManager = OnionProxyManager(
-            torService,
-            torConfigFiles,
-            serviceTorInstaller,
-            ServiceTorSettings(torSettings, torService),
+            this,
+            TorServiceController.getTorConfigFiles(),
+            ServiceTorInstaller(this),
+            ServiceTorSettings(TorServiceController.getTorSettings(), this),
             ServiceEventListener(),
-            ServiceEventBroadcaster(torService),
+            ServiceEventBroadcaster(this),
             buildConfigDebug
         )
         broadcastLogger = onionProxyManager.getBroadcastLogger(TorService::class.java)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -24,7 +24,6 @@ import android.os.IBinder
 import io.matthewnelson.topl_core.OnionProxyManager
 import io.matthewnelson.topl_core.broadcaster.BroadcastLogger
 import io.matthewnelson.topl_service.notification.ServiceNotification
-import io.matthewnelson.topl_core_base.TorSettings
 import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.onionproxy.ServiceEventBroadcaster
 import io.matthewnelson.topl_service.onionproxy.ServiceEventListener


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR Refactors TorConfigFiles use by:
 - Making the instantiated TorConfigFiles used in the `topl-service` module publicly available for Lib users
 - Moves the lock objects from OnionProxyContext to TorConfigFiles to be publicly available to acquire
 - Adds acquisition of appropriate file locks to uses from from the `topl-service` module.

Additionally, it:
 - Cleans up the ServiceActionProcessor and associated classes
 - Cleans up code/tests