### PR TITLE
Add exception to the GNUv3 License

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,42 +6,66 @@ https://topl-android.matthewnelson.io
 
 TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of  
 work from the Tor_Onion_Proxy_Library project that started at commit  
-hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after  
+hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after  
 said commit hash are:  
 
 Copyright (C) 2020 Matthew Nelson  
 
-This program is free software: you can redistribute it and/or modify  
-it under the terms of the GNU General Public License as published by  
-the Free Software Foundation, either version 3 of the License, or  
-(at your option) any later version.  
+This program is free software: you can redistribute it and/or modify it  
+under the terms of the GNU General Public License as published by the  
+Free Software Foundation, either version 3 of the License, or (at your  
+option) any later version.  
 
-This program is distributed in the hope that it will be useful,  
-but WITHOUT ANY WARRANTY; without even the implied warranty of  
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the  
-GNU General Public License for more details.  
+This program is distributed in the hope that it will be useful, but  
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  
+or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License  
+for more details.  
 
 You should have received a copy of the GNU General Public License  
-along with this program.  If not, see <a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank">here</a>.  
+along with this program. If not, see 
+<a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank">here</a>.  
 
 `===========================================================================`  
 `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`  
 `===========================================================================`  
 
-The original code, prior to commit hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86,  
-was:  
+The following exception is an additional permission under section 7 of the  
+GNU General Public License, version 3 (“GPLv3”).  
 
-Copyright (c) Microsoft Open Technologies, Inc.  
-All Rights Reserved  
+"The Interfaces" is henceforth defined as Application Programming Interfaces  
+that are publicly available classes/functions/etc (ie: do not contain the  
+visibility modifiers `internal`, `private`, `protected`, or are within  
+classes/functions/etc that contain the aforementioned visibility modifiers)  
+to TorOnionProxyLibrary-Android users that are needed to implement  
+TorOnionProxyLibrary-Android and reside in ONLY the following modules:  
 
-Licensed under the Apache License, Version 2.0 (the "License");  
-you may not use this file except in compliance with the License.  
-You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0  
+ - topl-core-base  
+ - topl-service  
 
-THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR  
-CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING  
-WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE,  
-FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.  
+The following are excluded from "The Interfaces":  
 
-See the Apache 2 License for the specific language governing permissions and  
-limitations under the License.  
+  - All other code  
+
+Linking TorOnionProxyLibrary-Android statically or dynamically with other  
+modules is making a combined work based on TorOnionProxyLibrary-Android.  
+Thus, the terms and conditions of the GNU General Public License cover the  
+whole combination.  
+
+As a special exception, the copyright holder of TorOnionProxyLibrary-Android  
+gives you permission to combine TorOnionProxyLibrary-Android program with free  
+software programs or libraries that are released under the GNU LGPL and with  
+independent modules that communicate with TorOnionProxyLibrary-Android solely  
+through "The Interfaces". You may copy and distribute such a system following  
+the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of  
+the other code concerned, provided that you include the source code of that  
+other code when and as the GNU GPL requires distribution of source code and  
+provided that you do not modify "The Interfaces".  
+
+Note that people who make modified versions of TorOnionProxyLibrary-Android  
+are not obligated to grant this special exception for their modified versions;  
+it is their choice whether to do so. The GNU General Public License gives  
+permission to release a modified version without this exception; this exception  
+also makes it possible to release a modified version which carries forward this  
+exception. If you modify "The Interfaces", this exception does not apply to your  
+modified version of TorOnionProxyLibrary-Android, and you must remove this  
+exception when you distribute your modified version.  

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,42 +37,66 @@ application, and customizing the notification to meet your liking.
 
 TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of  
 work from the Tor_Onion_Proxy_Library project that started at commit  
-hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after  
+hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after  
 said commit hash are:  
 
 Copyright (C) 2020 Matthew Nelson  
 
-This program is free software: you can redistribute it and/or modify  
-it under the terms of the GNU General Public License as published by  
-the Free Software Foundation, either version 3 of the License, or  
-(at your option) any later version.  
+This program is free software: you can redistribute it and/or modify it  
+under the terms of the GNU General Public License as published by the  
+Free Software Foundation, either version 3 of the License, or (at your  
+option) any later version.  
 
-This program is distributed in the hope that it will be useful,  
-but WITHOUT ANY WARRANTY; without even the implied warranty of  
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the  
-GNU General Public License for more details.  
+This program is distributed in the hope that it will be useful, but  
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  
+or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License  
+for more details.  
 
 You should have received a copy of the GNU General Public License  
-along with this program.  If not, see <a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank">here</a>.  
+along with this program. If not, see 
+<a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank">here</a>.  
 
 `===========================================================================`  
 `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`  
 `===========================================================================`  
 
-The original code, prior to commit hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86,  
-was:  
+The following exception is an additional permission under section 7 of the  
+GNU General Public License, version 3 (“GPLv3”).  
 
-Copyright (c) Microsoft Open Technologies, Inc.  
-All Rights Reserved  
+"The Interfaces" is henceforth defined as Application Programming Interfaces  
+that are publicly available classes/functions/etc (ie: do not contain the  
+visibility modifiers `internal`, `private`, `protected`, or are within  
+classes/functions/etc that contain the aforementioned visibility modifiers)  
+to TorOnionProxyLibrary-Android users that are needed to implement  
+TorOnionProxyLibrary-Android and reside in ONLY the following modules:  
 
-Licensed under the Apache License, Version 2.0 (the "License");  
-you may not use this file except in compliance with the License.  
-You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0  
+ - topl-core-base  
+ - topl-service  
 
-THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR  
-CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING  
-WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE,  
-FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.  
+The following are excluded from "The Interfaces":  
 
-See the Apache 2 License for the specific language governing permissions and  
-limitations under the License.  
+  - All other code  
+
+Linking TorOnionProxyLibrary-Android statically or dynamically with other  
+modules is making a combined work based on TorOnionProxyLibrary-Android.  
+Thus, the terms and conditions of the GNU General Public License cover the  
+whole combination.  
+
+As a special exception, the copyright holder of TorOnionProxyLibrary-Android  
+gives you permission to combine TorOnionProxyLibrary-Android program with free  
+software programs or libraries that are released under the GNU LGPL and with  
+independent modules that communicate with TorOnionProxyLibrary-Android solely  
+through "The Interfaces". You may copy and distribute such a system following  
+the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of  
+the other code concerned, provided that you include the source code of that  
+other code when and as the GNU GPL requires distribution of source code and  
+provided that you do not modify "The Interfaces".  
+
+Note that people who make modified versions of TorOnionProxyLibrary-Android  
+are not obligated to grant this special exception for their modified versions;  
+it is their choice whether to do so. The GNU General Public License gives  
+permission to release a modified version without this exception; this exception  
+also makes it possible to release a modified version which carries forward this  
+exception. If you modify "The Interfaces", this exception does not apply to your  
+modified version of TorOnionProxyLibrary-Android, and you must remove this  
+exception when you distribute your modified version.  

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.sampleapp
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/LogMessageAdapter.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/LogMessageAdapter.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.sampleapp
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/MainActivity.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/MainActivity.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.sampleapp
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/MyEventBroadcaster.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/MyEventBroadcaster.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.sampleapp
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/MyTorSettings.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/MyTorSettings.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.sampleapp
 

--- a/sampleapp/src/main/res/layout/activity_main.xml
+++ b/sampleapp/src/main/res/layout/activity_main.xml
@@ -1,20 +1,70 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 -->
 

--- a/sampleapp/src/main/res/layout/log_message.xml
+++ b/sampleapp/src/main/res/layout/log_message.xml
@@ -1,3 +1,71 @@
+<!--
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/scripts/fix_dokka_doc_external_links.sh
+++ b/scripts/fix_dokka_doc_external_links.sh
@@ -1,19 +1,69 @@
 #!/usr/bin/env bash
 # /*
-# * Copyright (C) 2020 Matthew Nelson
+# * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+# * work from the Tor_Onion_Proxy_Library project that started at commit
+# * hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+# * said commit hash are:
 # *
-# * This program is free software: you can redistribute it and/or modify
-# * it under the terms of the GNU General Public License as published by
-# * the Free Software Foundation, either version 3 of the License, or
-# * (at your option) any later version.
+# *     Copyright (C) 2020 Matthew Nelson
 # *
-# * This program is distributed in the hope that it will be useful,
-# * but WITHOUT ANY WARRANTY; without even the implied warranty of
-# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# * GNU General Public License for more details.
+# *     This program is free software: you can redistribute it and/or modify it
+# *     under the terms of the GNU General Public License as published by the
+# *     Free Software Foundation, either version 3 of the License, or (at your
+# *     option) any later version.
 # *
-# * You should have received a copy of the GNU General Public License
-# * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# *     This program is distributed in the hope that it will be useful, but
+# *     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# *     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# *     for more details.
+# *
+# *     You should have received a copy of the GNU General Public License
+# *     along with this program. If not, see <https://www.gnu.org/licenses/>.
+# *
+# * `===========================================================================`
+# * `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+# * `===========================================================================`
+# *
+# * The following exception is an additional permission under section 7 of the
+# * GNU General Public License, version 3 (“GPLv3”).
+# *
+# *     "The Interfaces" is henceforth defined as Application Programming Interfaces
+# *     that are publicly available classes/functions/etc (ie: do not contain the
+# *     visibility modifiers `internal`, `private`, `protected`, or are within
+# *     classes/functions/etc that contain the aforementioned visibility modifiers)
+# *     to TorOnionProxyLibrary-Android users that are needed to implement
+# *     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+# *
+# *      - topl-core-base
+# *      - topl-service
+# *
+# *     The following are excluded from "The Interfaces":
+# *
+# *       - All other code
+# *
+# *     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+# *     modules is making a combined work based on TorOnionProxyLibrary-Android.
+# *     Thus, the terms and conditions of the GNU General Public License cover the
+# *     whole combination.
+# *
+# *     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+# *     gives you permission to combine TorOnionProxyLibrary-Android program with free
+# *     software programs or libraries that are released under the GNU LGPL and with
+# *     independent modules that communicate with TorOnionProxyLibrary-Android solely
+# *     through "The Interfaces". You may copy and distribute such a system following
+# *     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+# *     the other code concerned, provided that you include the source code of that
+# *     other code when and as the GNU GPL requires distribution of source code and
+# *     provided that you do not modify "The Interfaces".
+# *
+# *     Note that people who make modified versions of TorOnionProxyLibrary-Android
+# *     are not obligated to grant this special exception for their modified versions;
+# *     it is their choice whether to do so. The GNU General Public License gives
+# *     permission to release a modified version without this exception; this exception
+# *     also makes it possible to release a modified version which carries forward this
+# *     exception. If you modify "The Interfaces", this exception does not apply to your
+# *     modified version of TorOnionProxyLibrary-Android, and you must remove this
+# *     exception when you distribute your modified version.
 # * */
 
 # Get current directory where the script is located

--- a/scripts/pull_latest_transports.sh
+++ b/scripts/pull_latest_transports.sh
@@ -1,4 +1,70 @@
 #!/usr/bin/env bash
+# /*
+# * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+# * work from the Tor_Onion_Proxy_Library project that started at commit
+# * hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+# * said commit hash are:
+# *
+# *     Copyright (C) 2020 Matthew Nelson
+# *
+# *     This program is free software: you can redistribute it and/or modify it
+# *     under the terms of the GNU General Public License as published by the
+# *     Free Software Foundation, either version 3 of the License, or (at your
+# *     option) any later version.
+# *
+# *     This program is distributed in the hope that it will be useful, but
+# *     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# *     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# *     for more details.
+# *
+# *     You should have received a copy of the GNU General Public License
+# *     along with this program. If not, see <https://www.gnu.org/licenses/>.
+# *
+# * `===========================================================================`
+# * `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+# * `===========================================================================`
+# *
+# * The following exception is an additional permission under section 7 of the
+# * GNU General Public License, version 3 (“GPLv3”).
+# *
+# *     "The Interfaces" is henceforth defined as Application Programming Interfaces
+# *     that are publicly available classes/functions/etc (ie: do not contain the
+# *     visibility modifiers `internal`, `private`, `protected`, or are within
+# *     classes/functions/etc that contain the aforementioned visibility modifiers)
+# *     to TorOnionProxyLibrary-Android users that are needed to implement
+# *     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+# *
+# *      - topl-core-base
+# *      - topl-service
+# *
+# *     The following are excluded from "The Interfaces":
+# *
+# *       - All other code
+# *
+# *     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+# *     modules is making a combined work based on TorOnionProxyLibrary-Android.
+# *     Thus, the terms and conditions of the GNU General Public License cover the
+# *     whole combination.
+# *
+# *     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+# *     gives you permission to combine TorOnionProxyLibrary-Android program with free
+# *     software programs or libraries that are released under the GNU LGPL and with
+# *     independent modules that communicate with TorOnionProxyLibrary-Android solely
+# *     through "The Interfaces". You may copy and distribute such a system following
+# *     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+# *     the other code concerned, provided that you include the source code of that
+# *     other code when and as the GNU GPL requires distribution of source code and
+# *     provided that you do not modify "The Interfaces".
+# *
+# *     Note that people who make modified versions of TorOnionProxyLibrary-Android
+# *     are not obligated to grant this special exception for their modified versions;
+# *     it is their choice whether to do so. The GNU General Public License gives
+# *     permission to release a modified version without this exception; this exception
+# *     also makes it possible to release a modified version which carries forward this
+# *     exception. If you modify "The Interfaces", this exception does not apply to your
+# *     modified version of TorOnionProxyLibrary-Android, and you must remove this
+# *     exception when you distribute your modified version.
+# * */
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 

--- a/scripts/sign_sampleapp_release_build.sh
+++ b/scripts/sign_sampleapp_release_build.sh
@@ -1,19 +1,69 @@
 #!/usr/bin/env bash
 # /*
-# * Copyright (C) 2020 Matthew Nelson
+# * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+# * work from the Tor_Onion_Proxy_Library project that started at commit
+# * hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+# * said commit hash are:
 # *
-# * This program is free software: you can redistribute it and/or modify
-# * it under the terms of the GNU General Public License as published by
-# * the Free Software Foundation, either version 3 of the License, or
-# * (at your option) any later version.
+# *     Copyright (C) 2020 Matthew Nelson
 # *
-# * This program is distributed in the hope that it will be useful,
-# * but WITHOUT ANY WARRANTY; without even the implied warranty of
-# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# * GNU General Public License for more details.
+# *     This program is free software: you can redistribute it and/or modify it
+# *     under the terms of the GNU General Public License as published by the
+# *     Free Software Foundation, either version 3 of the License, or (at your
+# *     option) any later version.
 # *
-# * You should have received a copy of the GNU General Public License
-# * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# *     This program is distributed in the hope that it will be useful, but
+# *     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# *     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# *     for more details.
+# *
+# *     You should have received a copy of the GNU General Public License
+# *     along with this program. If not, see <https://www.gnu.org/licenses/>.
+# *
+# * `===========================================================================`
+# * `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+# * `===========================================================================`
+# *
+# * The following exception is an additional permission under section 7 of the
+# * GNU General Public License, version 3 (“GPLv3”).
+# *
+# *     "The Interfaces" is henceforth defined as Application Programming Interfaces
+# *     that are publicly available classes/functions/etc (ie: do not contain the
+# *     visibility modifiers `internal`, `private`, `protected`, or are within
+# *     classes/functions/etc that contain the aforementioned visibility modifiers)
+# *     to TorOnionProxyLibrary-Android users that are needed to implement
+# *     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+# *
+# *      - topl-core-base
+# *      - topl-service
+# *
+# *     The following are excluded from "The Interfaces":
+# *
+# *       - All other code
+# *
+# *     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+# *     modules is making a combined work based on TorOnionProxyLibrary-Android.
+# *     Thus, the terms and conditions of the GNU General Public License cover the
+# *     whole combination.
+# *
+# *     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+# *     gives you permission to combine TorOnionProxyLibrary-Android program with free
+# *     software programs or libraries that are released under the GNU LGPL and with
+# *     independent modules that communicate with TorOnionProxyLibrary-Android solely
+# *     through "The Interfaces". You may copy and distribute such a system following
+# *     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+# *     the other code concerned, provided that you include the source code of that
+# *     other code when and as the GNU GPL requires distribution of source code and
+# *     provided that you do not modify "The Interfaces".
+# *
+# *     Note that people who make modified versions of TorOnionProxyLibrary-Android
+# *     are not obligated to grant this special exception for their modified versions;
+# *     it is their choice whether to do so. The GNU General Public License gives
+# *     permission to release a modified version without this exception; this exception
+# *     also makes it possible to release a modified version which carries forward this
+# *     exception. If you modify "The Interfaces", this exception does not apply to your
+# *     modified version of TorOnionProxyLibrary-Android, and you must remove this
+# *     exception when you distribute your modified version.
 # * */
 
 if [ "$ANDROID_SDK" == "" ]; then

--- a/topl-core-base/src/androidTest/java/io/matthewnelson/topl_core_base/TorConfigFilesAndroidTest.kt
+++ b/topl-core-base/src/androidTest/java/io/matthewnelson/topl_core_base/TorConfigFilesAndroidTest.kt
@@ -1,27 +1,72 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
 *
-* ================================================================================
-* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-* ================================================================================
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
 *
 * The original code, prior to commit hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86,
 * was:

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/BaseConsts.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/BaseConsts.kt
@@ -1,23 +1,68 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_core_base
 

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/EventBroadcaster.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/EventBroadcaster.kt
@@ -1,27 +1,72 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
 *
-* ================================================================================
-* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-* ================================================================================
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
 *
 * The original code, prior to commit hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86,
 * was:

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/FileExtensions.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/FileExtensions.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+ */
 package io.matthewnelson.topl_core_base
 
 import java.io.EOFException

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorConfigFiles.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorConfigFiles.kt
@@ -1,27 +1,72 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
 *
-* ================================================================================
-* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-* ================================================================================
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
 *
 * The original code, prior to commit hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86,
 * was:

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorSettings.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorSettings.kt
@@ -1,27 +1,72 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
 *
-* ================================================================================
-* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-* ================================================================================
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
 *
 * The original code, prior to commit hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86,
 * was:

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
@@ -1,27 +1,72 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
 *
-* ================================================================================
-* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-* ================================================================================
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
 *
 * The original code, prior to commit hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86,
 * was:

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyManager.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyManager.kt
@@ -1,27 +1,72 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
 *
-* ================================================================================
-* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-* ================================================================================
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
 *
 * The original code, prior to commit hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86,
 * was:

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/BroadcastLogger.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/BroadcastLogger.kt
@@ -1,23 +1,68 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_core.broadcaster
 

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/BroadcastLoggerHelper.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/BroadcastLoggerHelper.kt
@@ -1,23 +1,68 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_core.broadcaster
 

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/TorStateMachine.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/TorStateMachine.kt
@@ -1,27 +1,72 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
 *
-* ================================================================================
-* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-* ================================================================================
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
 *
 * The original code, prior to commit hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86,
 * was:

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/listener/BaseEventListener.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/listener/BaseEventListener.kt
@@ -1,23 +1,68 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_core.listener
 

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/receiver/NetworkStateReceiver.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/receiver/NetworkStateReceiver.kt
@@ -1,23 +1,68 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_core.receiver
 

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/settings/SettingsConfig.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/settings/SettingsConfig.kt
@@ -1,27 +1,72 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
 *
-* ================================================================================
-* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-* ================================================================================
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
 *
 * The original code, prior to commit hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86,
 * was:

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/settings/TorSettingsBuilder.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/settings/TorSettingsBuilder.kt
@@ -1,27 +1,72 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
 *
-* ================================================================================
-* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-* ================================================================================
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
 *
 * The original code, prior to commit hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86,
 * was:

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/CoreConsts.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/CoreConsts.kt
@@ -1,23 +1,68 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_core.util
 

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/FileUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/FileUtilities.kt
@@ -1,23 +1,68 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 *
 * ================================================================================
 * ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -42,9 +87,9 @@
 *     See the Apache 2 License for the specific language governing permissions and
 *     limitations under the License.
 *
-* ================================================================================
-* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-* ================================================================================
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
 *
 * This code took the Socks4a logic from SocksProxyClientConnOperator in NetCipher
 * which was then modified to meet our needs. That original code was licensed as:

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/TorInstaller.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/TorInstaller.kt
@@ -1,27 +1,72 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
 *
-* ================================================================================
-* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-* ================================================================================
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
 *
 * The original code, prior to commit hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86,
 * was:

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/Utilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/Utilities.kt
@@ -1,27 +1,72 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
 *
-* ================================================================================
-* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-* ================================================================================
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
 *
 * The original code, prior to commit hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86,
 * was:

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/WriteObserver.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/WriteObserver.kt
@@ -1,27 +1,72 @@
 /*
 * TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
 * work from the Tor_Onion_Proxy_Library project that started at commit
-* hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86. Contributions made after
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
 * said commit hash are:
 *
 *     Copyright (C) 2020 Matthew Nelson
 *
-*     This program is free software: you can redistribute it and/or modify
-*     it under the terms of the GNU General Public License as published by
-*     the Free Software Foundation, either version 3 of the License, or
-*     (at your option) any later version.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-*     This program is distributed in the hope that it will be useful,
-*     but WITHOUT ANY WARRANTY; without even the implied warranty of
-*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*     GNU General Public License for more details.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
 *
 *     You should have received a copy of the GNU General Public License
-*     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
 *
-* ================================================================================
-* ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-* ================================================================================
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
 *
 * The original code, prior to commit hash 74407114cbfa8ea6f2ac51417dda8be98d8aba86,
 * was:

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service.notification
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceEventBroadcaster.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service.onionproxy
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceEventListener.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceEventListener.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service.onionproxy
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceTorInstaller.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceTorInstaller.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service.onionproxy
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceTorSettings.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceTorSettings.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service.onionproxy
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefs.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefs.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service.prefs
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefsListener.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefsListener.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service.prefs
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/receiver/TorServiceReceiver.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/receiver/TorServiceReceiver.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service.receiver
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/ActionCommands.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/ActionCommands.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service.service
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/ServiceActionProcessor.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/ServiceActionProcessor.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service.service
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service.service
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorServiceConnection.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorServiceConnection.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service.service
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service.util
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceUtilities.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceUtilities.kt
@@ -1,18 +1,68 @@
 /*
-* Copyright (C) 2020 Matthew Nelson
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
 *
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+*     Copyright (C) 2020 Matthew Nelson
 *
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
 *
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
 * */
 package io.matthewnelson.topl_service.util
 

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/util/TorServicePrefsUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/util/TorServicePrefsUnitTest.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+ */
 package io.matthewnelson.topl_service.util
 
 import androidx.test.core.app.ApplicationProvider


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR adds an exception to the GNUv3 License to allow implementing TorOnionProxyLibrary-Android in Android Applications that may have conflicting licenses which would not allow them to do so.

The intention here is that:
- Code able to be instantiated, called, or interacted with which is publicly accessible from the `topl-service` and `topl-core-base` modules are fair game under the exception (ie: things **not** marked as internal/private/protected, and are exposed for the purposes of implementing TorOnionProxyLibrary-Android).