### PR TITLE
Mn/feature/builder functionality

### DIFF
--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -191,6 +191,13 @@ class TorServiceController private constructor(): ServiceConsts() {
          * */
         fun build() {
 
+            // If TorSettings has been initialized already, return as to not
+            // overwrite things.
+            try {
+                getTorSettings()
+                return
+            } catch (e: RuntimeException) {}
+
             torServiceNotificationBuilder.build()
 
             Companion.torSettings = torSettings

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -128,6 +128,7 @@ class TorServiceController private constructor(): ServiceConsts() {
     ) {
 
         private lateinit var torConfigFiles: TorConfigFiles
+        private lateinit var appEventBroadcaster: EventBroadcaster
 
         // On published releases of this Library, this value will **always** be `false`.
         private var buildConfigDebug = BuildConfig.DEBUG
@@ -161,7 +162,7 @@ class TorServiceController private constructor(): ServiceConsts() {
          * class actually is.
          * */
         fun setEventBroadcaster(eventBroadcaster: EventBroadcaster): Builder {
-            appEventBroadcaster = eventBroadcaster
+            this.appEventBroadcaster = eventBroadcaster
             return this
         }
 
@@ -191,6 +192,8 @@ class TorServiceController private constructor(): ServiceConsts() {
          * */
         fun build() {
 
+            appContext = application.applicationContext
+
             // If TorSettings has been initialized already, return as to not
             // overwrite things.
             try {
@@ -199,6 +202,9 @@ class TorServiceController private constructor(): ServiceConsts() {
             } catch (e: RuntimeException) {}
 
             torServiceNotificationBuilder.build()
+
+            if (::appEventBroadcaster.isInitialized)
+                Companion.appEventBroadcaster = this.appEventBroadcaster
 
             Companion.torSettings = torSettings
             Companion.torConfigFiles =
@@ -215,8 +221,6 @@ class TorServiceController private constructor(): ServiceConsts() {
             )
 
             ServiceNotification.get().setupNotificationChannel(application.applicationContext)
-
-            appContext = application.applicationContext
         }
     }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -104,12 +104,10 @@ internal class TorService: Service() {
             geoipAssetPath: String,
             geoip6AssetPath: String
         ) {
-            if (Companion::geoipAssetPath.isInitialized) return
             this.buildConfigVersionCode = buildConfigVersionCode
             this.buildConfigDebug = buildConfigDebug
             this.geoipAssetPath = geoipAssetPath
             this.geoip6AssetPath = geoip6AssetPath
-
         }
 
         // For things that can't be saved to TorServicePrefs, such as BuildConfig.VERSION_CODE

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/TestEventBroadcaster.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/TestEventBroadcaster.kt
@@ -1,0 +1,30 @@
+package io.matthewnelson.test_helpers
+
+import io.matthewnelson.topl_core_base.EventBroadcaster
+
+class TestEventBroadcaster: EventBroadcaster() {
+
+    override fun broadcastBandwidth(bytesRead: String, bytesWritten: String) {
+
+    }
+
+    override fun broadcastDebug(msg: String) {
+
+    }
+
+    override fun broadcastException(msg: String?, e: Exception) {
+
+    }
+
+    override fun broadcastLogMessage(logMessage: String?) {
+
+    }
+
+    override fun broadcastNotice(msg: String) {
+
+    }
+
+    override fun broadcastTorState(state: String, networkState: String) {
+
+    }
+}

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/TestTorSettings.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/TestTorSettings.kt
@@ -1,0 +1,117 @@
+package io.matthewnelson.test_helpers
+
+import io.matthewnelson.topl_core_base.TorSettings
+
+internal class TestTorSettings: TorSettings() {
+
+    override val disableNetwork: Boolean
+        get() = DEFAULT__DISABLE_NETWORK
+
+    override val dnsPort: String
+        get() = DEFAULT__DNS_PORT
+
+    override val customTorrc: String?
+        get() = null
+
+    override val entryNodes: String?
+        get() = DEFAULT__ENTRY_NODES
+
+    override val excludeNodes: String?
+        get() = DEFAULT__EXCLUDED_NODES
+
+    override val exitNodes: String?
+        get() = DEFAULT__EXIT_NODES
+
+    override val httpTunnelPort: String
+        get() = DEFAULT__HTTP_TUNNEL_PORT
+
+    override val listOfSupportedBridges: List<@SupportedBridges String>
+        get() = arrayListOf(SupportedBridges.MEEK, SupportedBridges.OBFS4)
+
+    override val proxyHost: String?
+        get() = DEFAULT__PROXY_HOST
+
+    override val proxyPassword: String?
+        get() = DEFAULT__PROXY_PASSWORD
+
+    override val proxyPort: Int?
+        get() = null
+
+    override val proxySocks5Host: String?
+        get() = DEFAULT__PROXY_SOCKS5_HOST
+
+    override val proxySocks5ServerPort: Int?
+        get() = null
+
+    override val proxyType: String?
+        get() = DEFAULT__PROXY_TYPE
+
+    override val proxyUser: String?
+        get() = DEFAULT__PROXY_USER
+
+    override val reachableAddressPorts: String
+        get() = DEFAULT__REACHABLE_ADDRESS_PORTS
+
+    override val relayNickname: String?
+        get() = DEFAULT__RELAY_NICKNAME
+
+    override val relayPort: Int?
+        get() = null
+
+    override val socksPort: String
+        get() = "9051"
+
+    override val virtualAddressNetwork: String?
+        get() = "10.192.0.2/10"
+
+    override val hasBridges: Boolean
+        get() = DEFAULT__HAS_BRIDGES
+
+    override val connectionPadding: @ConnectionPadding String
+        get() = DEFAULT__HAS_CONNECTION_PADDING
+
+    override val hasCookieAuthentication: Boolean
+        get() = DEFAULT__HAS_COOKIE_AUTHENTICATION
+
+    override val hasDebugLogs: Boolean
+        get() = DEFAULT__HAS_DEBUG_LOGS
+
+    override val hasDormantCanceledByStartup: Boolean
+        get() = DEFAULT__HAS_DORMANT_CANCELED_BY_STARTUP
+
+    override val hasIsolationAddressFlagForTunnel: Boolean
+        get() = DEFAULT__HAS_ISOLATION_ADDRESS_FLAG_FOR_TUNNEL
+
+    override val hasOpenProxyOnAllInterfaces: Boolean
+        get() = DEFAULT__HAS_OPEN_PROXY_ON_ALL_INTERFACES
+
+    override val hasReachableAddress: Boolean
+        get() = DEFAULT__HAS_REACHABLE_ADDRESS
+
+    override val hasReducedConnectionPadding: Boolean
+        get() = DEFAULT__HAS_REDUCED_CONNECTION_PADDING
+
+    override val hasSafeSocks: Boolean
+        get() = DEFAULT__HAS_SAFE_SOCKS
+
+    override val hasStrictNodes: Boolean
+        get() = DEFAULT__HAS_STRICT_NODES
+
+    override val hasTestSocks: Boolean
+        get() = DEFAULT__HAS_TEST_SOCKS
+
+    override val isAutoMapHostsOnResolve: Boolean
+        get() = DEFAULT__IS_AUTO_MAP_HOSTS_ON_RESOLVE
+
+    override val isRelay: Boolean
+        get() = DEFAULT__IS_RELAY
+
+    override val runAsDaemon: Boolean
+        get() = DEFAULT__RUN_AS_DAEMON
+
+    override val transPort: String
+        get() = DEFAULT__TRANS_PORT
+
+    override val useSocks5: Boolean
+        get() = DEFAULT__USE_SOCKS5
+}

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
@@ -29,8 +29,8 @@ internal class TorServiceControllerUnitTest {
         )
     }
     private val torConfigFiles: TorConfigFiles by lazy {
-        TorConfigFiles.Builder(File("installDir"), File("configDir"))
-            .build()
+        // Cannot use factory methods used by default b/c not running on a device.
+        TorConfigFiles.Builder(File("installDir"), File("configDir")).build()
     }
     private lateinit var builder: TorServiceController.Builder
     private lateinit var torSettings: TestTorSettings
@@ -50,8 +50,25 @@ internal class TorServiceControllerUnitTest {
     }
 
     @Test(expected = RuntimeException::class)
-    fun `throw errors if called before build`() {
+    fun `throw errors if startTor called before build`() {
         TorServiceController.startTor()
+    }
+
+    @Test(expected = RuntimeException::class)
+    fun `throw errors if sendBroadcast called before build`() {
+        // sendBroadcast method used in newIdentity, restartTor, and stopTor
+        // which is what will throw the RuntimeException.
+        TorServiceController.newIdentity()
+    }
+
+    @Test(expected = RuntimeException::class)
+    fun `throw errors if getTorSettings called before build`() {
+        TorServiceController.getTorSettings()
+    }
+
+    @Test(expected = RuntimeException::class)
+    fun `throw errors if getTorConfigFiles called before build`() {
+        TorServiceController.getTorConfigFiles()
     }
 
     @Test
@@ -59,6 +76,7 @@ internal class TorServiceControllerUnitTest {
         builder.build()
         val initialHashCode = TorServiceController.getTorSettings().hashCode()
 
+        // Instantiate new TorSettings and try to overwrite things via the builder
         torSettings = TestTorSettings()
         builder = TorServiceController.Builder(
             app,

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
@@ -111,4 +111,14 @@ internal class TorServiceControllerUnitTest {
 
         assertEquals(initialHashCode, hashCodeAfterSecondBuildCall)
     }
+
+    @Test
+    fun `ensure setEventBroadcaster is properly initialized`() {
+        // Hasn't been initialized yet
+        assertNull(TorServiceController.appEventBroadcaster)
+
+        builder.setEventBroadcaster(TestEventBroadcaster()).build()
+
+        assertNotNull(TorServiceController.appEventBroadcaster)
+    }
 }

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
@@ -1,0 +1,79 @@
+package io.matthewnelson.topl_service
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import io.matthewnelson.test_helpers.TestTorSettings
+import io.matthewnelson.topl_core_base.TorConfigFiles
+import io.matthewnelson.topl_service.notification.ServiceNotification
+import org.junit.Before
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+@Config(minSdk = 16, maxSdk = 28)
+@RunWith(RobolectricTestRunner::class)
+internal class TorServiceControllerUnitTest {
+
+    private val app: Application by lazy {
+        ApplicationProvider.getApplicationContext() as Application
+    }
+    private val notificationBuilder: ServiceNotification.Builder by lazy {
+        ServiceNotification.Builder(
+            "Test Channel Name",
+            "Test Channel ID",
+            "Test Channel Description",
+            615615
+        )
+    }
+    private val torConfigFiles: TorConfigFiles by lazy {
+        TorConfigFiles.Builder(File("installDir"), File("configDir"))
+            .build()
+    }
+    private lateinit var builder: TorServiceController.Builder
+    private lateinit var torSettings: TestTorSettings
+
+    @Before
+    fun setup() {
+        torSettings = TestTorSettings()
+        builder = TorServiceController.Builder(
+            app,
+            notificationBuilder,
+            BuildConfig.VERSION_CODE,
+            torSettings,
+            "common/geoip",
+            "common/geoip6"
+        )
+            .useCustomTorConfigFiles(torConfigFiles)
+    }
+
+    @Test(expected = RuntimeException::class)
+    fun `throw errors if called before build`() {
+        TorServiceController.startTor()
+    }
+
+    @Test
+    fun `ensure one-time initialization`() {
+        builder.build()
+        val initialHashCode = TorServiceController.getTorSettings().hashCode()
+
+        torSettings = TestTorSettings()
+        builder = TorServiceController.Builder(
+            app,
+            notificationBuilder,
+            BuildConfig.VERSION_CODE,
+            torSettings,
+            "common/geoip",
+            "common/geoip6"
+        )
+            .useCustomTorConfigFiles(torConfigFiles)
+
+        builder.build()
+
+        val hashCodeAfterSecondBuildCall = TorServiceController.getTorSettings().hashCode()
+
+        assertEquals(initialHashCode, hashCodeAfterSecondBuildCall)
+    }
+}

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
@@ -2,17 +2,24 @@ package io.matthewnelson.topl_service
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import io.matthewnelson.test_helpers.TestEventBroadcaster
 import io.matthewnelson.test_helpers.TestTorSettings
 import io.matthewnelson.topl_core_base.TorConfigFiles
 import io.matthewnelson.topl_service.notification.ServiceNotification
+import io.matthewnelson.topl_service.service.TorService
 import org.junit.Before
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.junit.runners.MethodSorters
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.io.File
 
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @Config(minSdk = 16, maxSdk = 28)
 @RunWith(RobolectricTestRunner::class)
 internal class TorServiceControllerUnitTest {
@@ -50,29 +57,39 @@ internal class TorServiceControllerUnitTest {
     }
 
     @Test(expected = RuntimeException::class)
-    fun `throw errors if startTor called before build`() {
+    fun `_throw errors if startTor called before build`() {
         TorServiceController.startTor()
     }
 
     @Test(expected = RuntimeException::class)
-    fun `throw errors if sendBroadcast called before build`() {
+    fun `_throw errors if sendBroadcast called before build`() {
         // sendBroadcast method used in newIdentity, restartTor, and stopTor
         // which is what will throw the RuntimeException.
         TorServiceController.newIdentity()
     }
 
     @Test(expected = RuntimeException::class)
-    fun `throw errors if getTorSettings called before build`() {
+    fun `_throw errors if getTorSettings called before build`() {
         TorServiceController.getTorSettings()
     }
 
     @Test(expected = RuntimeException::class)
-    fun `throw errors if getTorConfigFiles called before build`() {
+    fun `_throw errors if getTorConfigFiles called before build`() {
         TorServiceController.getTorConfigFiles()
     }
 
     @Test
-    fun `ensure one-time initialization`() {
+    fun `_z_ensure setBuildConfigDebug is properly initialized`() {
+        // Hasn't been initialized yet
+        assertNull(TorService.buildConfigDebug)
+
+        builder.setBuildConfigDebug(BuildConfig.DEBUG).build()
+
+        assertEquals(TorService.buildConfigDebug, BuildConfig.DEBUG)
+    }
+
+    @Test
+    fun `ensure one-time initialization if build called more than once`() {
         builder.build()
         val initialHashCode = TorServiceController.getTorSettings().hashCode()
 

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/prefs/TorServicePrefsUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/prefs/TorServicePrefsUnitTest.kt
@@ -64,10 +64,10 @@
 *     modified version of TorOnionProxyLibrary-Android, and you must remove this
 *     exception when you distribute your modified version.
  */
-package io.matthewnelson.topl_service.util
+package io.matthewnelson.topl_service.prefs
 
 import androidx.test.core.app.ApplicationProvider
-import io.matthewnelson.topl_service.prefs.TorServicePrefs
+import io.matthewnelson.topl_service.util.ServiceConsts
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR adds tests for the `TorServiceController.Builder` to ensure proper initialization by the implementing application when `build` is called. It also fixes:

- Multiple calls to `build` were overwriting already initialized variables that `TorService` was using.
- `appEventBroadcaster` was being overwritten with multiple calls.