### PR TITLE
Refactors BackgroundManager class

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,6 +17,7 @@ ext.deps = [
         lifecycle: [
             commonJava8: "androidx.lifecycle:lifecycle-common-java8:${versions.lifecycle}",
             liveData: "androidx.lifecycle:lifecycle-livedata-ktx:${versions.lifecycle}",
+            processLifecycleOwner: "androidx.lifecycle:lifecycle-process:${versions.lifecycle}",
             reactiveStreams: "androidx.lifecycle:lifecycle-reactivestreams-ktx:${versions.lifecycle}",
             runtime: "androidx.lifecycle:lifecycle-runtime-ktx:${versions.lifecycle}",
             service: "androidx.lifecycle:lifecycle-service:${versions.lifecycle}",

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -73,6 +73,7 @@ import androidx.core.app.NotificationCompat
 import io.matthewnelson.topl_core_base.TorConfigFiles
 import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.notification.ServiceNotification
+import io.matthewnelson.topl_service.service.components.BackgroundManager
 import java.io.File
 
 /**
@@ -117,11 +118,19 @@ class App: Application() {
 //  }
     }
 
+    private fun generateBackgroundManagerPolicy(): BackgroundManager.Builder.Policy {
+//  private fun generateBackgroundManagerPolicy(): BackgroundManager.Builder.Policy {
+        return BackgroundManager.Builder()
+            .stopServiceThenStartIfBroughtBackIntoForeground(secondsFrom15To45 = 30)
+//  }
+    }
+
     private fun setupTorServices(application: Application, torConfigFiles: TorConfigFiles) {
 //  private fun setupTorServices(application: Application, torConfigFiles: TorConfigFiles ) {
         TorServiceController.Builder(
             application = application,
             torServiceNotificationBuilder = generateTorServiceNotificationBuilder(),
+            backgroundManagerPolicy = generateBackgroundManagerPolicy(),
             buildConfigVersionCode = BuildConfig.VERSION_CODE,
 
             // Can instantiate directly here then access it from

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -122,7 +122,11 @@ class App: Application() {
     private fun generateBackgroundManagerPolicy(): BackgroundManager.Builder.Policy {
 //  private fun generateBackgroundManagerPolicy(): BackgroundManager.Builder.Policy {
         return BackgroundManager.Builder()
-            .stopServiceThenStartIfBroughtBackIntoForeground(secondsFrom5To45 = 5)
+
+              // Can only choose 1 option, but this is the other unselected one.
+//            .keepAliveWhileInBackground(secondsFrom20To40 = 30)
+            .respectResourcesWhileInBackground(secondsFrom5To45 = 20)
+
 //  }
     }
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -89,6 +89,7 @@ class App: Application() {
                 "SampleApp|Application|Process ID: ${Process.myPid()}"
             )
         }
+        TorServiceController.startTor()
     }
 
     private fun generateTorServiceNotificationBuilder(): ServiceNotification.Builder {
@@ -121,7 +122,7 @@ class App: Application() {
     private fun generateBackgroundManagerPolicy(): BackgroundManager.Builder.Policy {
 //  private fun generateBackgroundManagerPolicy(): BackgroundManager.Builder.Policy {
         return BackgroundManager.Builder()
-            .stopServiceThenStartIfBroughtBackIntoForeground(secondsFrom15To45 = 30)
+            .stopServiceThenStartIfBroughtBackIntoForeground(secondsFrom5To45 = 5)
 //  }
     }
 
@@ -146,7 +147,6 @@ class App: Application() {
         )
             .addTimeToRestartTorDelay(milliseconds = 100L)
             .addTimeToStopServiceDelay(milliseconds = 100L)
-            .setBackgroundHeartbeatTime(milliseconds = 30_000L)
             .setBuildConfigDebug(buildConfigDebug = BuildConfig.DEBUG)
 
             // Can instantiate directly here then access it from

--- a/topl-service/build.gradle
+++ b/topl-service/build.gradle
@@ -72,6 +72,8 @@ dependencies {
     implementation project(':topl-core')
     implementation project(':topl-core-base')
     implementation deps.androidx.core
+    implementation deps.androidx.lifecycle.runtime
+    implementation deps.androidx.lifecycle.processLifecycleOwner
     implementation deps.jtorctl
     implementation deps.kotlin.coroutinesAndroid
     implementation deps.kotlin.coroutinesCore

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -75,7 +75,7 @@ import io.matthewnelson.topl_core_base.TorConfigFiles
 import io.matthewnelson.topl_core_base.TorSettings
 import io.matthewnelson.topl_service.receiver.TorServiceReceiver
 import io.matthewnelson.topl_service.service.BaseService
-import io.matthewnelson.topl_service.service.components.BackgroundKeepAlive
+import io.matthewnelson.topl_service.service.components.BackgroundManager
 import io.matthewnelson.topl_service.service.components.ServiceActionProcessor
 import io.matthewnelson.topl_service.service.components.TorServiceConnection
 import io.matthewnelson.topl_service.util.ServiceConsts
@@ -130,7 +130,7 @@ class TorServiceController private constructor(): ServiceConsts() {
     ) {
 
         private var appEventBroadcaster: EventBroadcaster? = Companion.appEventBroadcaster
-        private var backgroundHeartbeatTime = BackgroundKeepAlive.backgroundHeartbeatTime
+        private var heartbeatTime = BackgroundManager.heartbeatTime
         private var restartTorDelayTime = ServiceActionProcessor.restartTorDelayTime
         private var stopServiceDelayTime = ServiceActionProcessor.stopServiceDelayTime
         private var torConfigFiles: TorConfigFiles? = null
@@ -189,7 +189,7 @@ class TorServiceController private constructor(): ServiceConsts() {
          * Default is set to 30_000ms
          *
          * When the user sends your application to the background (recent app's tray),
-         * [io.matthewnelson.topl_service.service.components.BackgroundKeepAlive] begins
+         * [io.matthewnelson.topl_service.service.components.BackgroundManager] begins
          * a heartbeat for Tor, as well as cycling [TorService] between foreground and
          * background as to keep the OS from killing things due to being idle for too long.
          *
@@ -203,7 +203,7 @@ class TorServiceController private constructor(): ServiceConsts() {
          * */
         fun setBackgroundHeartbeatTime(milliseconds: Long): Builder {
             if (milliseconds in 15_000L..45_000L)
-                backgroundHeartbeatTime = milliseconds
+                heartbeatTime = milliseconds
             return this
         }
 
@@ -282,7 +282,7 @@ class TorServiceController private constructor(): ServiceConsts() {
                 torConfigFiles ?: TorConfigFiles.createConfig(application.applicationContext),
                 torSettings
             )
-            BackgroundKeepAlive.initialize(backgroundHeartbeatTime)
+            BackgroundManager.initialize(heartbeatTime)
             ServiceActionProcessor.initialize(restartTorDelayTime, stopServiceDelayTime)
 
             Companion.appEventBroadcaster = this.appEventBroadcaster

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -109,6 +109,8 @@ class TorServiceController private constructor(): ServiceConsts() {
      * @param [application] [Application], for obtaining context
      * @param [torServiceNotificationBuilder] The [ServiceNotification.Builder] for
      *   customizing [TorService]'s notification
+     * @param [backgroundManagerPolicy] The [BackgroundManager.Builder.Policy] to be executed
+     *   while your application is in the background (the Recent App's tray).
      * @param [buildConfigVersionCode] send [BuildConfig.VERSION_CODE]. Mitigates copying of geoip
      *   files to app updates only
      * @param [torSettings] [TorSettings] used to create your torrc file on start of Tor
@@ -118,11 +120,13 @@ class TorServiceController private constructor(): ServiceConsts() {
      *   assets/common directory, send this variable "common/geoip6")
      *
      * @sample [io.matthewnelson.sampleapp.App.generateTorServiceNotificationBuilder]
+     * @sample [io.matthewnelson.sampleapp.App.generateBackgroundManagerPolicy]
      * @sample [io.matthewnelson.sampleapp.App.setupTorServices]
      * */
     class Builder(
         private val application: Application,
         private val torServiceNotificationBuilder: ServiceNotification.Builder,
+        private val backgroundManagerPolicy: BackgroundManager.Builder.Policy,
         private val buildConfigVersionCode: Int,
         private val torSettings: TorSettings,
         private val geoipAssetPath: String,
@@ -289,6 +293,8 @@ class TorServiceController private constructor(): ServiceConsts() {
 
             torServiceNotificationBuilder.build()
             ServiceNotification.get().setupNotificationChannel(application.applicationContext)
+
+            backgroundManagerPolicy.build(application)
         }
     }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -81,6 +81,7 @@ import io.matthewnelson.topl_service.service.components.BaseServiceConnection
 import io.matthewnelson.topl_service.service.components.ServiceActionProcessor
 import io.matthewnelson.topl_service.service.components.TorServiceConnection
 import io.matthewnelson.topl_service.util.ServiceConsts
+import kotlinx.coroutines.Dispatchers
 
 class TorServiceController private constructor(): ServiceConsts() {
 
@@ -288,6 +289,7 @@ class TorServiceController private constructor(): ServiceConsts() {
                 torConfigFiles ?: TorConfigFiles.createConfig(application.applicationContext),
                 torSettings
             )
+
 //            BackgroundManager.initialize(heartbeatTime)
             ServiceActionProcessor.initialize(restartTorDelayTime, stopServiceDelayTime)
 
@@ -297,7 +299,6 @@ class TorServiceController private constructor(): ServiceConsts() {
             ServiceNotification.get().setupNotificationChannel(application.applicationContext)
 
             backgroundManagerPolicy.build(
-                application,
                 TorService::class.java,
                 TorServiceConnection.torServiceConnection
             )

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -352,36 +352,26 @@ class TorServiceController private constructor(): ServiceConsts() {
 
         /**
          * Stops [TorService].
-         *
-         * @throws [RuntimeException] if called before [Builder.build]
          * */
-        @Throws(RuntimeException::class)
         fun stopTor() =
-            sendBroadcast(ServiceAction.STOP)
-//            BaseServiceConnection.serviceBinder?.submitServiceActionIntent(Intent(ServiceAction.STOP))
+            BaseServiceConnection.serviceBinder?.submitServiceActionIntent(
+                Intent(ServiceAction.STOP)
+            )
 
         /**
          * Restarts Tor.
-         *
-         * @throws [RuntimeException] if called before [Builder.build]
          * */
-        @Throws(RuntimeException::class)
         fun restartTor() =
-            sendBroadcast(ServiceAction.RESTART_TOR)
-//            BaseServiceConnection.serviceBinder?.submitServiceActionIntent(Intent(ServiceAction.RESTART_TOR))
+            BaseServiceConnection.serviceBinder?.submitServiceActionIntent(
+                Intent(ServiceAction.RESTART_TOR)
+            )
 
         /**
          * Changes identities.
-         *
-         * @throws [RuntimeException] if called before [Builder.build]
          * */
-        @Throws(RuntimeException::class)
         fun newIdentity() =
-            sendBroadcast(ServiceAction.NEW_ID)
-//            BaseServiceConnection.serviceBinder?.submitServiceActionIntent(Intent(ServiceAction.NEW_ID))
-
-        @Throws(RuntimeException::class)
-        private fun sendBroadcast(@ServiceAction action: String) =
-            TorServiceReceiver.sendBroadcast(BaseService.getAppContext(), action, null)
+            BaseServiceConnection.serviceBinder?.submitServiceActionIntent(
+                Intent(ServiceAction.NEW_ID)
+            )
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -439,10 +439,10 @@ class ServiceNotification internal constructor(
     /// Foreground Service ///
     //////////////////////////
     @Volatile
-    var inForeground = false
+    internal var inForeground = false
         private set
     @Volatile
-    var notificationShowing = false
+    internal var notificationShowing = false
         private set
 
     @Synchronized
@@ -472,7 +472,7 @@ class ServiceNotification internal constructor(
     /// Actions ///
     ///////////////
     @Volatile
-    var actionsPresent = false
+    internal var actionsPresent = false
         private set
 
     @Synchronized
@@ -529,7 +529,7 @@ class ServiceNotification internal constructor(
     /// Content Text ///
     ////////////////////
     @Volatile
-    var currentContentText = "Waiting..."
+    internal var currentContentText = "Waiting..."
         private set
 
     @Synchronized
@@ -546,7 +546,7 @@ class ServiceNotification internal constructor(
     /// Content Title ///
     /////////////////////
     @Volatile
-    var currentContentTitle = TorState.OFF
+    internal var currentContentTitle = TorState.OFF
         private set
 
     @Synchronized
@@ -563,7 +563,7 @@ class ServiceNotification internal constructor(
     /// Icon ///
     ////////////
     @Volatile
-    var currentIcon = imageNetworkDisabled
+    internal var currentIcon = imageNetworkDisabled
         private set
 
     @Synchronized
@@ -602,7 +602,7 @@ class ServiceNotification internal constructor(
     /// Progress Bar ///
     ////////////////////
     @Volatile
-    var progressBarShown = false
+    internal var progressBarShown = false
         private set
 
     @Synchronized

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefsListener.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefsListener.kt
@@ -89,7 +89,7 @@ internal class TorServicePrefsListener(
 
     init {
         torServicePrefs.registerListener(this)
-        broadcastLogger.debug("Listener registered")
+        broadcastLogger.debug("Has been registered")
     }
 
     /**
@@ -97,7 +97,7 @@ internal class TorServicePrefsListener(
      * */
     fun unregister() {
         torServicePrefs.unregisterListener(this)
-        broadcastLogger.debug("Listener unregistered")
+        broadcastLogger.debug("Has been unregistered")
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/receiver/TorServiceReceiver.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/receiver/TorServiceReceiver.kt
@@ -76,6 +76,7 @@ import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.service.components.ServiceActionProcessor
 import io.matthewnelson.topl_service.service.TorService
 import io.matthewnelson.topl_service.service.components.BackgroundManager
+import io.matthewnelson.topl_service.service.components.BaseServiceConnection
 import io.matthewnelson.topl_service.util.ServiceConsts
 import io.matthewnelson.topl_service.util.ServiceConsts.ServiceAction
 import java.math.BigInteger
@@ -99,25 +100,6 @@ internal class TorServiceReceiver(private val torService: BaseService): Broadcas
         @Volatile
         var isRegistered = false
             private set
-
-        /**
-         * Adding a StringExtra to the Intent by passing a value for [extrasString] will
-         * always use the [action] as the key for retrieving it.
-         *
-         * @param [context] [Context]
-         * @param [action] A [ServiceConsts.ServiceAction] to be processed by [TorService]
-         * @param [extrasString] To be included in the intent.
-         * */
-        fun sendBroadcast(context: Context, @ServiceAction action: String, extrasString: String?) {
-            val broadcastIntent = Intent(SERVICE_INTENT_FILTER)
-            broadcastIntent.putExtra(SERVICE_INTENT_FILTER, action)
-            broadcastIntent.setPackage(context.applicationContext.packageName)
-
-            if (extrasString != null)
-                broadcastIntent.putExtra(action, extrasString)
-
-            context.applicationContext.sendBroadcast(broadcastIntent)
-        }
     }
 
     private val broadcastLogger = torService.getBroadcastLogger(TorServiceReceiver::class.java)
@@ -142,37 +124,20 @@ internal class TorServiceReceiver(private val torService: BaseService): Broadcas
         }
     }
 
-    // TODO: Funnel everything through the binder that is instantiated in order to handle
-    //  BackgroundManager execution stuff properly and in a single spot.
     override fun onReceive(context: Context?, intent: Intent?) {
         if (context != null && intent != null) {
             // Only accept Intents from this package.
             if (context.applicationInfo.dataDir != torService.context.applicationInfo.dataDir) return
 
             when (val serviceAction = intent.getStringExtra(SERVICE_INTENT_FILTER)) {
-
                 // Only accept these 3 ServiceActions.
                 ServiceAction.NEW_ID, ServiceAction.RESTART_TOR, ServiceAction.STOP -> {
-                    val newIntent = Intent(serviceAction)
-
-                    // To STOP, user either clicks notification Action STOP (if enabled),
-                    // or TorServiceController.StopTor was called (sending a broadcast here).
-                    // Either way we need to stop listening to the Activity LCEs so the return
-                    // to foreground doesn't go off.
-                    if (serviceAction == ServiceAction.STOP)
-                        torService.unregisterBackgroundManager(executeRestart = false)
-
-                    // If the broadcast intent has any string extras, their key will be the
-                    // ServiceAction that was included.
-                    intent.getStringExtra(serviceAction)?.let {
-                        newIntent.putExtra(serviceAction, it)
-                    }
-                    torService.processIntent(newIntent)
+                    BaseServiceConnection.serviceBinder?.submitServiceActionIntent(
+                        Intent(serviceAction)
+                    )
                 }
                 else -> {
-                    broadcastLogger.warn(
-                        "This class does not accept $serviceAction as an argument."
-                    )
+                    broadcastLogger.warn("This class does not accept $serviceAction as an argument.")
                 }
             }
         }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -78,7 +78,7 @@ import io.matthewnelson.topl_core_base.TorSettings
 import io.matthewnelson.topl_service.BuildConfig
 import io.matthewnelson.topl_service.notification.ServiceNotification
 import io.matthewnelson.topl_service.service.components.BaseServiceConnection
-import io.matthewnelson.topl_service.util.ServiceConsts
+import io.matthewnelson.topl_service.util.ServiceConsts.ServiceAction
 import io.matthewnelson.topl_service.util.ServiceConsts.NotificationImage
 import kotlinx.coroutines.CoroutineScope
 import java.io.File
@@ -132,12 +132,35 @@ internal abstract class BaseService: Service() {
         fun getLocalPrefs(context: Context): SharedPreferences =
             context.getSharedPreferences("TorServiceLocalPrefs", Context.MODE_PRIVATE)
 
+
+        ///////////////////////////////////
+        /// Last Accepted ServiceAction ///
+        ///////////////////////////////////
+        @Volatile
+        @ServiceAction var lastAcceptedServiceAction: String = ServiceAction.STOP
+            private set
+
+        /**
+         * Updates [lastAcceptedServiceAction] in several key places so that we can keep the
+         * Service's state in sync with the latest calls coming from the Application using
+         * the Library. It is used in [TorService.onStartCommand] and
+         * [io.matthewnelson.topl_service.service.components.TorServiceBinder.submitServiceActionIntent]
+         *
+         * @param [serviceAction] The [ServiceAction] to update [lastAcceptedServiceAction] to
+         * */
+        fun updateLastAcceptedServiceAction(@ServiceAction serviceAction: String) {
+            lastAcceptedServiceAction = serviceAction
+        }
+        fun wasLastAcceptedServiceActionStop(): Boolean =
+            lastAcceptedServiceAction == ServiceAction.STOP
+
         //////////////////////
         /// ServiceStartup ///
         //////////////////////
+
         fun startService(context: Context, clazz: Class<*>, serviceConn: BaseServiceConnection) {
             val startServiceIntent = Intent(context.applicationContext, clazz)
-            startServiceIntent.action = ServiceConsts.ServiceAction.START
+            startServiceIntent.action = ServiceAction.START
             context.applicationContext.startService(startServiceIntent)
             bindService(context.applicationContext, serviceConn, clazz)
         }
@@ -150,7 +173,7 @@ internal abstract class BaseService: Service() {
          * */
         private fun bindService(context: Context, serviceConn: BaseServiceConnection, clazz: Class<*>) {
             val bindingIntent = Intent(context.applicationContext, clazz)
-            bindingIntent.action = ServiceConsts.ServiceAction.START
+            bindingIntent.action = ServiceAction.START
 
             context.applicationContext.bindService(
                 bindingIntent,
@@ -179,13 +202,6 @@ internal abstract class BaseService: Service() {
     // swap it out without needing to start the Service and still get functionality for
     // the components that make TorService work.
     abstract val context: Context
-
-
-    ///////////////////////////
-    /// BackgroundKeepAlive ///
-    ///////////////////////////
-    abstract fun registerBackgroundManager()
-    abstract fun unregisterBackgroundManager(executeRestart: Boolean)
 
 
     ///////////////

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -185,7 +185,7 @@ internal abstract class BaseService: Service() {
     /// BackgroundKeepAlive ///
     ///////////////////////////
     abstract fun registerBackgroundManager()
-    abstract fun unregisterBackgroundManager()
+    abstract fun unregisterBackgroundManager(executeRestart: Boolean)
 
 
     ///////////////

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -184,8 +184,8 @@ internal abstract class BaseService: Service() {
     ///////////////////////////
     /// BackgroundKeepAlive ///
     ///////////////////////////
-    abstract fun registerBackgroundKeepAlive()
-    abstract fun unregisterBackgroundKeepAlive()
+    abstract fun registerBackgroundManager()
+    abstract fun unregisterBackgroundManager()
 
 
     ///////////////

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -100,16 +100,13 @@ internal class TorService: BaseService() {
     /////////////////////////
     /// BackgroundManager ///
     /////////////////////////
-    private var backgroundManager: BackgroundManager? = null
-
     override fun registerBackgroundManager() {
-        backgroundManager?.unregister()
-        backgroundManager = BackgroundManager(this)
+        BackgroundManager.registerActivityLCEs()
     }
-    override fun unregisterBackgroundManager() {
-        backgroundManager?.unregister()
-        backgroundManager = null
+    override fun unregisterBackgroundManager(executeRestart: Boolean) {
+        BackgroundManager.unregisterActivityLCEs(executeRestart)
     }
+
     override fun onTrimMemory(level: Int) {
         when (level) {
             ComponentCallbacks2.TRIM_MEMORY_COMPLETE -> {
@@ -327,7 +324,6 @@ internal class TorService: BaseService() {
 
     override fun onDestroy() {
         unregisterPrefsListener()
-        unregisterBackgroundManager()
         removeNotification()
         supervisorJob.cancel()
     }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -80,7 +80,7 @@ import io.matthewnelson.topl_service.onionproxy.ServiceTorInstaller
 import io.matthewnelson.topl_service.onionproxy.ServiceTorSettings
 import io.matthewnelson.topl_service.prefs.TorServicePrefsListener
 import io.matthewnelson.topl_service.receiver.TorServiceReceiver
-import io.matthewnelson.topl_service.service.components.BackgroundKeepAlive
+import io.matthewnelson.topl_service.service.components.BackgroundManager
 import io.matthewnelson.topl_service.service.components.ServiceActionProcessor
 import io.matthewnelson.topl_service.service.components.TorServiceBinder
 import io.matthewnelson.topl_service.service.components.TorServiceConnection
@@ -97,18 +97,18 @@ internal class TorService: BaseService() {
         get() = this
 
 
-    ///////////////////////////
-    /// BackgroundKeepAlive ///
-    ///////////////////////////
-    private var backgroundKeepAlive: BackgroundKeepAlive? = null
+    /////////////////////////
+    /// BackgroundManager ///
+    /////////////////////////
+    private var backgroundManager: BackgroundManager? = null
 
-    override fun registerBackgroundKeepAlive() {
-        backgroundKeepAlive?.unregister()
-        backgroundKeepAlive = BackgroundKeepAlive(this)
+    override fun registerBackgroundManager() {
+        backgroundManager?.unregister()
+        backgroundManager = BackgroundManager(this)
     }
-    override fun unregisterBackgroundKeepAlive() {
-        backgroundKeepAlive?.unregister()
-        backgroundKeepAlive = null
+    override fun unregisterBackgroundManager() {
+        backgroundManager?.unregister()
+        backgroundManager = null
     }
     override fun onTrimMemory(level: Int) {
         when (level) {
@@ -119,7 +119,7 @@ internal class TorService: BaseService() {
             }
             ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN -> {
                 broadcastLogger.debug("Application sent to background")
-                registerBackgroundKeepAlive()
+                registerBackgroundManager()
             }
             else -> {}
         }
@@ -327,7 +327,7 @@ internal class TorService: BaseService() {
 
     override fun onDestroy() {
         unregisterPrefsListener()
-        unregisterBackgroundKeepAlive()
+        unregisterBackgroundManager()
         removeNotification()
         supervisorJob.cancel()
     }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -97,32 +97,6 @@ internal class TorService: BaseService() {
         get() = this
 
 
-    /////////////////////////
-    /// BackgroundManager ///
-    /////////////////////////
-    override fun registerBackgroundManager() {
-        BackgroundManager.registerActivityLCEs()
-    }
-    override fun unregisterBackgroundManager(executeRestart: Boolean) {
-        BackgroundManager.unregisterActivityLCEs(executeRestart)
-    }
-
-    override fun onTrimMemory(level: Int) {
-        when (level) {
-            ComponentCallbacks2.TRIM_MEMORY_COMPLETE -> {
-            }
-            ComponentCallbacks2.TRIM_MEMORY_MODERATE -> {
-                startForegroundService().stopForeground(this)
-            }
-            ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN -> {
-                broadcastLogger.debug("Application sent to background")
-                registerBackgroundManager()
-            }
-            else -> {}
-        }
-    }
-
-
     ///////////////
     /// Binding ///
     ///////////////
@@ -316,6 +290,8 @@ internal class TorService: BaseService() {
     }
 
 
+
+
     override fun onCreate() {
         serviceNotification.buildNotification(this)
         broadcastLogger.notice("BuildConfig.DEBUG set to: $buildConfigDebug")
@@ -329,30 +305,39 @@ internal class TorService: BaseService() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        if (intent != null) {
+        intent?.action?.let {
+            if (it == ServiceAction.START) {
+                updateLastAcceptedServiceAction(it)
+                processIntent(intent)
+            } else {
+                broadcastLogger.warn(
+                    "$it was used with startService. Use only ${ServiceAction.START} to" +
+                            "ensure proper startup of Tor"
+                )
+                updateLastAcceptedServiceAction(ServiceAction.START)
+                processIntent(Intent(ServiceAction.START))
 
-                if (intent.action == ServiceAction.START) {
+                if (it.contains(ServiceAction.SERVICE_ACTION)) {
                     processIntent(intent)
-                } else {
-                    broadcastLogger.warn(
-                        "${intent.action} was used with startService. Use only " +
-                                "${ServiceAction.START} to ensure proper startup of Tor"
-                    )
-                    processIntent(Intent(ServiceAction.START))
-                    processIntent(intent)
+                    updateLastAcceptedServiceAction(it)
                 }
-
-        }/* else {
-            // If it's null, we're getting a re-start from the system via START_STICKY
-            // and need to relink everything.
-            TorServiceController.startTor()
-        }*/
-        return /*START_STICKY*/START_NOT_STICKY
+            }
+        }
+        return START_NOT_STICKY
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
+        // Move to the foreground so we can properly shutdown w/o interrupting the
+        // application's normal lifecycle (Context.startServiceForeground does... thus,
+        // the complexity)
         startForegroundService()
+
+        // Cancel the BackgroundManager's coroutine if it's active so it doesn't execute
+        torServiceBinder.cancelExecuteBackgroundPolicyJob(BackgroundManager.getPolicy())
+
         broadcastLogger.debug("Task has been removed")
+
+        // Shutdown Tor and stop the Service
         processIntent(Intent(ServiceAction.STOP))
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/BackgroundManager.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/BackgroundManager.kt
@@ -101,8 +101,9 @@ import io.matthewnelson.topl_service.util.ServiceConsts
  * This is where Services get sketchy (especially when trying to implement an always
  * running service for networking), and is the purpose of the [BackgroundManager] class.
  *
- * This class tracks the number of Activities started and stopped in order to tell when the
- * Application's UI is hidden (either by lock screen, or being sent to the recent apps tray).
+ * This class starts your chosen [BackgroundManager.Builder.Policy] as soon as your
+ * application is sent to the background, waits for the time you declared, and then executes.
+ * See the [Builder] for more detail.
  *
  * @param [policy] The chosen [ServiceConsts.BackgroundPolicy] to be executed.
  * @param [executionDelay] Length of time before the policy gets executed *after* the application

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/BaseServiceConnection.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/BaseServiceConnection.kt
@@ -4,9 +4,11 @@ import android.content.ServiceConnection
 
 internal abstract class BaseServiceConnection: ServiceConnection {
 
-    @Volatile
-    var serviceBinder: TorServiceBinder? = null
-        private set
+    companion object {
+        @Volatile
+        var serviceBinder: TorServiceBinder? = null
+            private set
+    }
 
     /**
      * Sets the reference to [TorServiceBinder] to `null` because

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/ServiceActionProcessor.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/ServiceActionProcessor.kt
@@ -112,6 +112,7 @@ internal class ServiceActionProcessor(private val torService: BaseService): Serv
     private fun processActionObject(serviceActionObject: ServiceActionObject) {
         when (serviceActionObject) {
             is ActionCommands.Stop -> {
+                torService.unbindService()
                 torService.unregisterReceiver()
                 clearActionQueue()
                 broadcastLogger.notice(serviceActionObject.serviceAction)
@@ -231,7 +232,6 @@ internal class ServiceActionProcessor(private val torService: BaseService): Serv
                 }
             }
             ActionCommand.STOP_SERVICE -> {
-                torService.unbindService()
                 broadcastDebugObjectDetailsMsg("Stopping: ", torService)
                 torService.stopService()
             }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/TorServiceBinder.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/TorServiceBinder.kt
@@ -69,15 +69,16 @@ package io.matthewnelson.topl_service.service.components
 import android.content.Intent
 import android.os.Binder
 import io.matthewnelson.topl_service.service.BaseService
+import io.matthewnelson.topl_service.util.ServiceConsts.BackgroundPolicy
 import io.matthewnelson.topl_service.util.ServiceConsts.ServiceAction
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
 
 internal class TorServiceBinder(private val torService: BaseService): Binder() {
 
-    private fun throwIllegalArgument(action: String?) {
-        throw IllegalArgumentException(
-            "$action is not an accepted argument for ${this.javaClass.simpleName}"
-        )
-    }
+    private val broadcastLogger = torService.getBroadcastLogger(TorServiceBinder::class.java)
 
     @Throws(IllegalArgumentException::class)
     fun submitServiceActionIntent(serviceActionIntent: Intent) {
@@ -92,14 +93,58 @@ internal class TorServiceBinder(private val torService: BaseService): Binder() {
                     // Do not accept the above ServiceActions through use of this method.
                     // NEW_ID, RESTART_TOR, STOP = via BroadcastReceiver
                     // START = to start TorService
-                    throwIllegalArgument(action)
+                    broadcastLogger.warn("$action is not an accepted intent action for this class")
                 }
                 else -> {
                     torService.processIntent(serviceActionIntent)
                 }
             }
-        } else {
-            throwIllegalArgument(action)
+        }
+    }
+
+
+    //////////////////////////////////////////
+    /// BackgroundManager Policy Execution ///
+    //////////////////////////////////////////
+
+    val bgMgrBroadcastLogger = torService.getBroadcastLogger(BackgroundManager::class.java)
+    private var backgroundPolicyExecutionJob: Job? = null
+
+    /**
+     * Execution of a [BackgroundPolicy] takes place here in order to stay within the lifecycle
+     * of [io.matthewnelson.topl_service.service.TorService] so that we prevent any potential
+     * leaks from occurring.
+     *
+     * @param [policy] The [BackgroundPolicy] to be executed
+     * @param [executionDelay] the time expressed in your [BackgroundManager.Builder.Policy]
+     * */
+    fun executeBackgroundPolicyJob(@BackgroundPolicy policy: String, executionDelay: Long) {
+        cancelExecuteBackgroundPolicyJob(policy)
+        backgroundPolicyExecutionJob = torService.getScopeMain().launch {
+            when (policy) {
+                BackgroundPolicy.FOREGROUND -> {
+
+                }
+                BackgroundPolicy.STOP_THEN_START -> {
+                    delay(executionDelay)
+                    bgMgrBroadcastLogger.debug("Executing $policy")
+                    torService.processIntent(Intent(ServiceAction.STOP))
+                }
+            }
+        }
+    }
+
+    /**
+     * Cancels the coroutine executing the [BackgroundPolicy] if it is active.
+     *
+     * @param [policy] the [BackgroundPolicy] being cancelled
+     * */
+    fun cancelExecuteBackgroundPolicyJob(@BackgroundPolicy policy: String) {
+        if (backgroundPolicyExecutionJob?.isActive == true) {
+            backgroundPolicyExecutionJob?.let {
+                it.cancel()
+                bgMgrBroadcastLogger.debug("Execution of $policy has been cancelled")
+            }
         }
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/TorServiceBinder.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/TorServiceBinder.kt
@@ -80,20 +80,20 @@ internal class TorServiceBinder(private val torService: BaseService): Binder() {
 
     private val broadcastLogger = torService.getBroadcastLogger(TorServiceBinder::class.java)
 
-    @Throws(IllegalArgumentException::class)
     fun submitServiceActionIntent(serviceActionIntent: Intent) {
         val action = serviceActionIntent.action
         if (action != null && action.contains(ServiceAction.SERVICE_ACTION)) {
 
             when (action) {
-                ServiceAction.NEW_ID,
-                ServiceAction.RESTART_TOR,
-                ServiceAction.START,
-                ServiceAction.STOP -> {
+                ServiceAction.START -> {
                     // Do not accept the above ServiceActions through use of this method.
                     // NEW_ID, RESTART_TOR, STOP = via BroadcastReceiver
                     // START = to start TorService
                     broadcastLogger.warn("$action is not an accepted intent action for this class")
+                }
+                ServiceAction.STOP -> {
+                    torService.unregisterBackgroundManager(executeRestart = false)
+                    torService.processIntent(serviceActionIntent)
                 }
                 else -> {
                     torService.processIntent(serviceActionIntent)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
@@ -217,7 +217,7 @@ abstract class ServiceConsts: BaseConsts() {
         ServiceAction.START,
         ServiceAction.STOP
     )
-    @kotlin.annotation.Retention(AnnotationRetention.SOURCE)
+    @Retention(AnnotationRetention.SOURCE)
     internal annotation class ServiceAction {
         companion object {
             const val SERVICE_ACTION = "ServiceAction_"
@@ -240,7 +240,7 @@ abstract class ServiceConsts: BaseConsts() {
         ActionCommand.STOP_SERVICE,
         ActionCommand.STOP_TOR
     )
-    @kotlin.annotation.Retention(AnnotationRetention.SOURCE)
+    @Retention(AnnotationRetention.SOURCE)
     internal annotation class ActionCommand {
         companion object {
             private const val ACTION_COMMAND = "ActionCommand_"
@@ -253,4 +253,19 @@ abstract class ServiceConsts: BaseConsts() {
     }
 
 
+    ///////////////////////////////
+    /// BackgroundManagerPolicy ///
+    ///////////////////////////////
+    @StringDef(
+        BackgroundPolicy.FOREGROUND,
+        BackgroundPolicy.STOP_THEN_START
+    )
+    @Retention(AnnotationRetention.SOURCE)
+    internal annotation class BackgroundPolicy {
+        companion object {
+            const val BACKGROUND_POLICY = "BackgroundPolicy_"
+            const val FOREGROUND = "${BACKGROUND_POLICY}FOREGROUND"
+            const val STOP_THEN_START = "${BACKGROUND_POLICY}STOP_THEN_START"
+        }
+    }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
@@ -210,7 +210,9 @@ abstract class ServiceConsts: BaseConsts() {
     //////////////////////
     /// ServiceActions ///
     //////////////////////
-    @Target(AnnotationTarget.CLASS, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.TYPE)
+    @Target(AnnotationTarget.CLASS, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.TYPE,
+        AnnotationTarget.PROPERTY
+    )
     @StringDef(
         ServiceAction.NEW_ID,
         ServiceAction.RESTART_TOR,
@@ -256,16 +258,22 @@ abstract class ServiceConsts: BaseConsts() {
     ///////////////////////////////
     /// BackgroundManagerPolicy ///
     ///////////////////////////////
+    @Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.PROPERTY,
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.TYPE
+    )
     @StringDef(
-        BackgroundPolicy.FOREGROUND,
-        BackgroundPolicy.STOP_THEN_START
+        BackgroundPolicy.KEEP_ALIVE,
+        BackgroundPolicy.RESPECT_RESOURCES
     )
     @Retention(AnnotationRetention.SOURCE)
     internal annotation class BackgroundPolicy {
         companion object {
-            const val BACKGROUND_POLICY = "BackgroundPolicy_"
-            const val FOREGROUND = "${BACKGROUND_POLICY}FOREGROUND"
-            const val STOP_THEN_START = "${BACKGROUND_POLICY}STOP_THEN_START"
+            private const val BACKGROUND_POLICY = "BackgroundPolicy_"
+            const val KEEP_ALIVE = "${BACKGROUND_POLICY}KEEP_ALIVE"
+            const val RESPECT_RESOURCES = "${BACKGROUND_POLICY}RESPECT_RESOURCES"
         }
     }
 }

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
@@ -38,10 +38,10 @@ internal class TestTorService(
     ///////////////////////////
     /// BackgroundKeepAlive ///
     ///////////////////////////
-    override fun registerBackgroundKeepAlive() {
+    override fun registerBackgroundManager() {
 
     }
-    override fun unregisterBackgroundKeepAlive() {
+    override fun unregisterBackgroundManager() {
 
     }
 

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
@@ -35,17 +35,6 @@ internal class TestTorService(
 ): BaseService() {
 
 
-    ///////////////////////////
-    /// BackgroundKeepAlive ///
-    ///////////////////////////
-    override fun registerBackgroundManager() {
-
-    }
-    override fun unregisterBackgroundManager() {
-
-    }
-
-
     ///////////////
     /// Binding ///
     ///////////////

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
@@ -73,6 +73,7 @@ import io.matthewnelson.test_helpers.application_provided_classes.TestTorSetting
 import io.matthewnelson.topl_core_base.TorConfigFiles
 import io.matthewnelson.topl_service.notification.ServiceNotification
 import io.matthewnelson.topl_service.service.BaseService
+import io.matthewnelson.topl_service.service.components.BackgroundManager
 import io.matthewnelson.topl_service.service.components.ServiceActionProcessor
 import org.junit.*
 import org.junit.Assert.assertEquals
@@ -131,13 +132,6 @@ internal class TorServiceControllerUnitTest {
     }
 
     @Test(expected = RuntimeException::class)
-    fun `_throw errors if sendBroadcast called before build`() {
-        // sendBroadcast method used in newIdentity, restartTor, and stopTor
-        // which is what will throw the RuntimeException.
-        TorServiceController.newIdentity()
-    }
-
-    @Test(expected = RuntimeException::class)
     fun `_throw errors if getTorSettings called before build`() {
         TorServiceController.getTorSettings()
     }
@@ -160,7 +154,7 @@ internal class TorServiceControllerUnitTest {
         getNewControllerBuilder()
             .addTimeToRestartTorDelay(timeToAdd)
             .addTimeToStopServiceDelay(timeToAdd)
-            .setBackgroundHeartbeatTime(40_000)
+//            .setBackgroundHeartbeatTime(40_000)
             .setBuildConfigDebug(!BuildConfig.DEBUG)
             .setEventBroadcaster(TestEventBroadcaster())
             .build()
@@ -202,6 +196,7 @@ internal class TorServiceControllerUnitTest {
         return TorServiceController.Builder(
             app,
             notificationBuilder,
+            BackgroundManager.Builder().respectResourcesWhileInBackground(30),
             BuildConfig.VERSION_CODE,
             torSettings,
             "common/geoip",

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/service/TorServiceUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/service/TorServiceUnitTest.kt
@@ -15,6 +15,8 @@ import io.matthewnelson.topl_service.notification.ServiceNotification
 import io.matthewnelson.topl_service.onionproxy.ServiceEventBroadcaster
 import io.matthewnelson.topl_service.prefs.TorServicePrefs
 import io.matthewnelson.topl_service.receiver.TorServiceReceiver
+import io.matthewnelson.topl_service.service.components.BackgroundManager
+import io.matthewnelson.topl_service.service.components.TorServiceConnection
 import io.matthewnelson.topl_service.util.ServiceConsts.PrefKeyBoolean
 import io.matthewnelson.topl_service.util.ServiceConsts.ServiceAction
 import io.matthewnelson.topl_service.util.ServiceUtilities
@@ -100,9 +102,20 @@ internal class TorServiceUnitTest {
     private fun getNewControllerBuilder(
         notificationBuilder: ServiceNotification.Builder
     ): TorServiceController.Builder {
+        val backgroundPolicyBuilder = BackgroundManager.Builder()
+            .respectResourcesWhileInBackground(5)
+
+        // Build it prior to initializing TorServiceController with the builder
+        // so we get our test classes initialized which won't be overwritten.
+        backgroundPolicyBuilder.build(
+            TestTorService::class.java,
+            TorServiceConnection.torServiceConnection
+        )
+
         return TorServiceController.Builder(
             app,
             notificationBuilder,
+            backgroundPolicyBuilder,
             BuildConfig.VERSION_CODE,
             torSettings,
             "common/geoip",


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR refactors the BackgroundManager class by:
 - Implementing a builder for Library users to choose options (currently only 2) for how they would like `TorService` to perform while their application is in the background.
 - Funnels all calls to `TorService` except for START through `TorServiceBinder` to better control the flow of command actions, especially while a `BackgroundManager.Builder.Policy` is being executed.
 - Implements the androidx lifecycle-process library for executing the Library user's `BackgroundManager.Builder` selection.

Published SNAPSHOT on Sonatype is version `1.0.0-alpha02b-SNAPSHOT`