### PR TITLE
Refactors lastServiceAction tracking

### DIFF
--- a/topl-service/src/main/java/io/matthewnelson/topl_service/lifecycle/BackgroundManager.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/lifecycle/BackgroundManager.kt
@@ -72,6 +72,7 @@ import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
 import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.service.TorService
+import io.matthewnelson.topl_service.service.components.actions.ServiceActionProcessor
 import io.matthewnelson.topl_service.service.components.binding.BaseServiceConnection
 import io.matthewnelson.topl_service.util.ServiceConsts
 
@@ -255,15 +256,20 @@ class BackgroundManager internal constructor(
     private fun applicationMovedToForeground() {
         // if the last _accepted_ ServiceAction to be issued by the Application was not to STOP
         // the service, then we want to put it back in the state it was in
-        if (!BaseService.wasLastAcceptedServiceActionStop()) {
+        if (!ServiceActionProcessor.wasLastAcceptedServiceActionStop()) {
             BaseServiceConnection.serviceBinder?.cancelExecuteBackgroundPolicyJob()
-            BaseService.startService(BaseService.getAppContext(), serviceClass, serviceConnection)
+            BaseService.startService(
+                BaseService.getAppContext(),
+                serviceClass,
+                serviceConnection,
+                includeIntentActionStart = false
+            )
         }
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     private fun applicationMovedToBackground() {
-        if (!BaseService.wasLastAcceptedServiceActionStop())
+        if (!ServiceActionProcessor.wasLastAcceptedServiceActionStop())
             BaseServiceConnection.serviceBinder?.executeBackgroundPolicyJob(policy, executionDelay)
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -262,7 +262,7 @@ internal class TorService: BaseService() {
         super.onTaskRemoved(rootIntent)
         broadcastLogger.debug("Task has been removed")
 
-        // Shutdown Tor and stop the Service
-        processServiceAction(ServiceActions.Stop())
+        // Shutdown Tor and stop the Service.
+        processServiceAction(ServiceActions.Stop(updateLastServiceAction = false))
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
@@ -181,7 +181,7 @@ internal class ServiceActionProcessor(private val torService: BaseService): Serv
         processQueueJob = torService.getScopeIO().launch {
             broadcastDebugMsgWithObjectDetails("Processing Queue: ", this)
 
-            while (actionQueue.isNotEmpty()) {
+            while (actionQueue.isNotEmpty() && isActive) {
                 val serviceAction = actionQueue.elementAtOrNull(0)
                 if (serviceAction == null) {
                     return@launch

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActions.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActions.kt
@@ -115,6 +115,16 @@ internal sealed class ServiceActions {
                 delayLengthQueue.removeAt(0)
             else
                 0L
+
+        /**
+         * Boolean value for providing [ServiceAction]'s the capability of being issued to
+         * the [ServiceActionProcessor] and notifying that the submitter of the [ServiceAction]
+         * wants [ServiceActionProcessor.lastServiceAction] to be updated.
+         *
+         * @see [Start]
+         * @see [Stop]
+         * */
+        open val updateLastAction: Boolean = true
     }
 
     class NewId: ServiceAction() {
@@ -143,7 +153,7 @@ internal sealed class ServiceActions {
         override val delayLengthQueue = mutableListOf(ServiceActionProcessor.restartTorDelayTime)
     }
 
-    class Start: ServiceAction() {
+    class Start(private val updateLastServiceAction: Boolean = true): ServiceAction() {
 
         @ServiceActionName
         override val name: String = ServiceActionName.START
@@ -152,9 +162,12 @@ internal sealed class ServiceActions {
             get() = arrayOf(
                 ServiceActionCommand.START_TOR
             )
+
+        override val updateLastAction: Boolean
+            get() = updateLastServiceAction
     }
 
-    class Stop: ServiceAction() {
+    class Stop(private val updateLastServiceAction: Boolean = true): ServiceAction() {
 
         @ServiceActionName
         override val name: String = ServiceActionName.STOP
@@ -167,5 +180,8 @@ internal sealed class ServiceActions {
             )
 
         override val delayLengthQueue = mutableListOf(ServiceActionProcessor.stopServiceDelayTime)
+
+        override val updateLastAction: Boolean
+            get() = updateLastServiceAction
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/TorServiceBinder.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/TorServiceBinder.kt
@@ -83,14 +83,9 @@ internal class TorServiceBinder(private val torService: BaseService): Binder() {
     /**
      * Accepts all [ServiceActions] except [ServiceActions.Start], which gets issued via
      * [io.matthewnelson.topl_service.service.TorService.onStartCommand].
-     *
-     * To be used **only** by interactions coming from the User or Application so
-     * [BaseService.lastAcceptedServiceAction] stays in sync.
      * */
     fun submitServiceAction(serviceAction: ServiceAction) {
         if (serviceAction is ServiceActions.Start) return
-
-        BaseService.updateLastAcceptedServiceAction(serviceAction.name)
         torService.processServiceAction(serviceAction)
     }
 
@@ -127,7 +122,9 @@ internal class TorServiceBinder(private val torService: BaseService): Binder() {
                 BackgroundPolicy.RESPECT_RESOURCES -> {
                     delay(executionDelay)
                     bgMgrBroadcastLogger.debug("Executing background management policy")
-                    torService.processServiceAction(ServiceActions.Stop())
+                    torService.processServiceAction(
+                        ServiceActions.Stop(updateLastServiceAction = false)
+                    )
                 }
             }
         }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
@@ -128,19 +128,13 @@ internal class TorServiceReceiver(private val torService: BaseService): Broadcas
 
             when (val serviceAction = intent.getStringExtra(SERVICE_INTENT_FILTER)) {
                 ServiceActionName.NEW_ID -> {
-                    BaseServiceConnection.serviceBinder?.submitServiceAction(
-                        ServiceActions.NewId()
-                    )
+                    torService.processServiceAction(ServiceActions.NewId())
                 }
                 ServiceActionName.RESTART_TOR -> {
-                    BaseServiceConnection.serviceBinder?.submitServiceAction(
-                        ServiceActions.RestartTor()
-                    )
+                    torService.processServiceAction(ServiceActions.RestartTor())
                 }
                 ServiceActionName.STOP -> {
-                    BaseServiceConnection.serviceBinder?.submitServiceAction(
-                        ServiceActions.Stop()
-                    )
+                    torService.processServiceAction(ServiceActions.Stop())
                 }
                 else -> {
                     broadcastLogger.warn(

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
@@ -216,6 +216,6 @@ internal class TestTorService(
         super.onTaskRemoved(rootIntent)
 
         // Shutdown Tor and stop the Service
-        processServiceAction(ServiceActions.Stop())
+        processServiceAction(ServiceActions.Stop(updateLastServiceAction = false))
     }
 }


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR refactors updating of the `lastServiceAction` variable so that it is done in one central place, the `ServiceActionProcessor`. It moves the declaration of wanting it updated to the `ServiceActions` classes, so that differentiation of what interactions are coming from the Application (either via user, or how the Library is implemented), and those that are coming from the Library (`BackgroundManager`, `onTaskRemoved`, etc).