### PR TITLE
Disable ability to select BackgroundManager Policy keep alive

### DIFF
--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -122,9 +122,6 @@ class App: Application() {
     private fun generateBackgroundManagerPolicy(): BackgroundManager.Builder.Policy {
 //  private fun generateBackgroundManagerPolicy(): BackgroundManager.Builder.Policy {
         return BackgroundManager.Builder()
-
-              // Can only choose 1 option, but this is the other unselected one.
-//            .keepAliveWhileInBackground(secondsFrom20To40 = 30)
             .respectResourcesWhileInBackground(secondsFrom5To45 = 20)
 
 //  }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/lifecycle/BackgroundManager.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/lifecycle/BackgroundManager.kt
@@ -151,24 +151,24 @@ class BackgroundManager internal constructor(
         //  performing it's normal lifecycle after user swipes it away such that it's not going
         //  through Application.onCreate, but is holding onto references. (same problem when
         //  starting the service using Context.startForegroundService), which is bullshit.
-        /**
-         * While your application is in the background (the Recent App's tray or lock screen),
-         * this [Policy] periodically switches [TorService] to the foreground then immediately
-         * back the background. Doing do prevents your application from going idle and being
-         * killed by the OS. It is much more resource intensive than choosing
-         * [respectResourcesWhileInBackground].
-         *
-         * @param [secondsFrom20To40]? Seconds between the events of cycling from background to
-         * foreground to background. Sending null will use the default (30s)
-         * @return [BackgroundManager.Builder.Policy] To use when initializing
-         *   [io.matthewnelson.topl_service.TorServiceController.Builder]
-         * */
-        fun keepAliveWhileInBackground(secondsFrom20To40: Int? = null): Policy {
-            chosenPolicy = BackgroundPolicy.KEEP_ALIVE
-            if (secondsFrom20To40 != null && secondsFrom20To40 in 20..40)
-                executionDelay = (secondsFrom20To40 * 1000).toLong()
-            return Policy(this)
-        }
+//        /**
+//         * While your application is in the background (the Recent App's tray or lock screen),
+//         * this [Policy] periodically switches [TorService] to the foreground then immediately
+//         * back the background. Doing do prevents your application from going idle and being
+//         * killed by the OS. It is much more resource intensive than choosing
+//         * [respectResourcesWhileInBackground].
+//         *
+//         * @param [secondsFrom20To40]? Seconds between the events of cycling from background to
+//         * foreground to background. Sending null will use the default (30s)
+//         * @return [BackgroundManager.Builder.Policy] To use when initializing
+//         *   [io.matthewnelson.topl_service.TorServiceController.Builder]
+//         * */
+//        fun keepAliveWhileInBackground(secondsFrom20To40: Int? = null): Policy {
+//            chosenPolicy = BackgroundPolicy.KEEP_ALIVE
+//            if (secondsFrom20To40 != null && secondsFrom20To40 in 20..40)
+//                executionDelay = (secondsFrom20To40 * 1000).toLong()
+//            return Policy(this)
+//        }
 
         /**
          * Stops [TorService] after being in the background for the declared [secondsFrom5To45].


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR temporarily disables the `BackgroundManager.Builder` option to keep the service alive while the application is in the background. It needs more work/testing before enabling it as an option.