### PR TITLE
Adds broadcasting of Tor's port information to the application

### DIFF
--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/MyEventBroadcaster.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/MyEventBroadcaster.kt
@@ -74,6 +74,8 @@ import io.matthewnelson.topl_service.util.ServiceUtilities
 
 /**
  * @suppress
+ * @see [TorServiceEventBroadcaster]
+ * @see [io.matthewnelson.topl_core_base.EventBroadcaster]
  * */
 class MyEventBroadcaster: TorServiceEventBroadcaster() {
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/MyEventBroadcaster.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/MyEventBroadcaster.kt
@@ -68,13 +68,59 @@ package io.matthewnelson.sampleapp
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import io.matthewnelson.topl_core_base.EventBroadcaster
+import io.matthewnelson.topl_core_base.BaseConsts
+import io.matthewnelson.topl_service.service.components.onionproxy.TorServiceEventBroadcaster
 import io.matthewnelson.topl_service.util.ServiceUtilities
 
 /**
  * @suppress
  * */
-class MyEventBroadcaster: EventBroadcaster() {
+class MyEventBroadcaster: TorServiceEventBroadcaster() {
+
+
+    //////////////////////////
+    /// ControlPortAddress ///
+    //////////////////////////
+
+    // Make Volatile so that if referencing on a different thread, we get
+    // the update immediately
+    @Volatile
+    var controlPortAddress: String? = null
+        private set
+
+    override fun broadcastControlPortAddress(controlPortAddress: String?) {
+        this.controlPortAddress = controlPortAddress
+    }
+
+
+    ////////////////////////
+    /// SocksPortAddress ///
+    ////////////////////////
+
+    // Make Volatile so that if referencing on a different thread, we get
+    // the update immediately
+    @Volatile
+    var socksPortAddress: String? = null
+        private set
+
+    override fun broadcastSocksPortAddress(socksPortAddress: String?) {
+        this.socksPortAddress = socksPortAddress
+    }
+
+
+    ///////////////////////
+    /// HttpPortAddress ///
+    ///////////////////////
+
+    // Make Volatile so that if referencing on a different thread, we get
+    // the update immediately
+    @Volatile
+    var httpPortAddress: String? = null
+        private set
+
+    override fun broadcastHttpPortAddress(httpPortAddress: String?) {
+        this.httpPortAddress = httpPortAddress
+    }
 
 
     /////////////////
@@ -137,15 +183,15 @@ class MyEventBroadcaster: EventBroadcaster() {
     ///////////////////
     inner class TorStateData(val state: String, val networkState: String)
 
-    private var lastState = TorState.OFF
-    private var lastNetworkState = TorNetworkState.DISABLED
+    private var lastState = BaseConsts.TorState.OFF
+    private var lastNetworkState = BaseConsts.TorNetworkState.DISABLED
 
     private val _liveTorState = MutableLiveData<TorStateData>(
         TorStateData(lastState, lastNetworkState)
     )
     val liveTorState: LiveData<TorStateData> = _liveTorState
 
-    override fun broadcastTorState(@TorState state: String, @TorNetworkState networkState: String) {
+    override fun broadcastTorState(@BaseConsts.TorState state: String, @BaseConsts.TorNetworkState networkState: String) {
         if (state == lastState && networkState == lastNetworkState) return
 
         lastState = state

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/MyTorSettings.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/MyTorSettings.kt
@@ -93,7 +93,7 @@ class MyTorSettings: TorSettings() {
         get() = DEFAULT__EXIT_NODES
 
     override val httpTunnelPort: String
-        get() = DEFAULT__HTTP_TUNNEL_PORT
+        get() = "auto"
 
     override val listOfSupportedBridges: List<@SupportedBridges String>
         get() = arrayListOf(SupportedBridges.MEEK, SupportedBridges.OBFS4)
@@ -129,7 +129,7 @@ class MyTorSettings: TorSettings() {
         get() = null
 
     override val socksPort: String
-        get() = "9051"
+        get() = "auto"
 
     override val virtualAddressNetwork: String?
         get() = "10.192.0.2/10"

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/MyTorSettings.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/MyTorSettings.kt
@@ -69,8 +69,8 @@ package io.matthewnelson.sampleapp
 import io.matthewnelson.topl_core_base.TorSettings
 
 /**
- * See [TorSettings] for comments on what is what.
  * @suppress
+ * @see [TorSettings]
  * */
 class MyTorSettings: TorSettings() {
 

--- a/topl-core-base/build.gradle
+++ b/topl-core-base/build.gradle
@@ -42,7 +42,8 @@ dokka {
         includeNonPublic = false
         skipEmptyPackages = true
         samples = [
-                "$rootDir/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt".toString()
+                "$rootDir/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt".toString(),
+                "$rootDir/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt".toString()
         ]
         sourceLink {
             url = "https://github.com/05nelsonm/TorOnionProxyLibrary-Android/blob/master/"

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/EventBroadcaster.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/EventBroadcaster.kt
@@ -96,6 +96,7 @@ package io.matthewnelson.topl_core_base
  * allows for easier separation of messages based on the type, process or class.
  *
  * See [BaseConsts.BroadcastType]s
+ * @sample [io.matthewnelson.topl_service.service.components.onionproxy.ServiceEventBroadcaster]
  */
 abstract class EventBroadcaster: BaseConsts() {
 

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorSettings.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorSettings.kt
@@ -176,12 +176,14 @@ abstract class TorSettings: BaseConsts() {
     abstract val exitNodes: String?
 
     /**
+     * Could be "auto" or a specific port, such as "8288".
+     *
      * TorBrowser and Orbot use "8218" by default. It may be wise to pick something
      * that won't conflict if you're using this setting.
      *
      * Docs: https://2019.www.torproject.org/docs/tor-manual.html.en#HTTPTunnelPort
      *
-     * See [DEFAULT__HTTP_TUNNEL_PORT]
+     * See [DEFAULT__HTTP_TUNNEL_PORT] ("0", to disable it)
      *
      * TODO: Change to List<String> and update TorSettingsBuilder method for
      *  multi-port support.
@@ -262,7 +264,7 @@ abstract class TorSettings: BaseConsts() {
     abstract val relayPort: Int?
 
     /**
-     * Could be "auto" or a specified port, such as "9051".
+     * Could be "auto" or a specific port, such as "9051".
      *
      * TorBrowser uses "9150", and Orbot uses "9050" by default. It may be wise
      * to pick something that won't conflict.

--- a/topl-service/build.gradle
+++ b/topl-service/build.gradle
@@ -44,7 +44,8 @@ dokka {
         includeNonPublic = false
         skipEmptyPackages = true
         samples = [
-                "$rootDir/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt".toString()
+                "$rootDir/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt".toString(),
+                "$rootDir/sampleapp/src/main/java/io/matthewnelson/sampleapp/MyEventBroadcaster.kt".toString()
         ]
         sourceLink {
             url = "https://github.com/05nelsonm/TorOnionProxyLibrary-Android/blob/master/"

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -79,6 +79,7 @@ import io.matthewnelson.topl_service.service.components.binding.BaseServiceConne
 import io.matthewnelson.topl_service.service.components.actions.ServiceActionProcessor
 import io.matthewnelson.topl_service.service.components.actions.ServiceActions
 import io.matthewnelson.topl_service.service.components.binding.TorServiceConnection
+import io.matthewnelson.topl_service.service.components.onionproxy.TorServiceEventBroadcaster
 import io.matthewnelson.topl_service.util.ServiceConsts
 
 class TorServiceController private constructor(): ServiceConsts() {
@@ -134,7 +135,7 @@ class TorServiceController private constructor(): ServiceConsts() {
         private val geoip6AssetPath: String
     ) {
 
-        private var appEventBroadcaster: EventBroadcaster? = Companion.appEventBroadcaster
+        private var appEventBroadcaster: TorServiceEventBroadcaster? = Companion.appEventBroadcaster
 //        private var heartbeatTime = BackgroundManager.heartbeatTime
         private var restartTorDelayTime = ServiceActionProcessor.restartTorDelayTime
         private var stopServiceDelayTime = ServiceActionProcessor.stopServiceDelayTime
@@ -240,7 +241,7 @@ class TorServiceController private constructor(): ServiceConsts() {
          * NOTE: You will, ofc, have to cast [Companion.appEventBroadcaster] as whatever your
          * class actually is.
          * */
-        fun setEventBroadcaster(eventBroadcaster: EventBroadcaster): Builder {
+        fun setEventBroadcaster(eventBroadcaster: TorServiceEventBroadcaster): Builder {
             this.appEventBroadcaster = eventBroadcaster
             return this
         }
@@ -306,7 +307,7 @@ class TorServiceController private constructor(): ServiceConsts() {
      * Where everything needed to interact with [TorService] resides.
      * */
     companion object {
-        var appEventBroadcaster: EventBroadcaster? = null
+        var appEventBroadcaster: TorServiceEventBroadcaster? = null
             private set
 
         /**

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/TorServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/TorServiceEventBroadcaster.kt
@@ -1,0 +1,118 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
+package io.matthewnelson.topl_service.service.components.onionproxy
+
+import io.matthewnelson.topl_core_base.EventBroadcaster
+
+/**
+ * Adds broadcasting methods to the [EventBroadcaster] to update you with information about
+ * what addresses Tor is operating on. Very helpful when choosing "auto" in your
+ * [io.matthewnelson.topl_core_base.TorSettings] to easily identifying what addresses to
+ * use for making network calls, as well as being notified when Tor is ready to be used.
+ *
+ * The addresses will be broadcast to you after Tor has been fully Bootstrapped. If Tor is
+ * stopped (ie. it's [io.matthewnelson.topl_core_base.BaseConsts.TorState] changes from **ON**
+ * to **OFF**), `null` will be broadcast.
+ *
+ * All broadcasts to your implementation to this class will occur on the Main thread.
+ *
+ * @sample [io.matthewnelson.sampleapp.MyEventBroadcaster]
+ * */
+abstract class TorServiceEventBroadcaster: EventBroadcaster() {
+
+    /**
+     * Override this method to implement receiving of the control port address that Tor
+     * is operating on.
+     *
+     * Example of what will be broadcast:
+     *
+     *   - "127.0.0.1:33432"
+     * */
+    abstract fun broadcastControlPortAddress(controlPortAddress: String?)
+
+    /**
+     * Override this method to implement receiving of the Socks port address that Tor
+     * is operating on (if you've specified a
+     * [io.matthewnelson.topl_core_base.TorSettings.socksPort]).
+     *
+     * Example of what will be broadcast:
+     *
+     *   - "127.0.0.1:9051"
+     * */
+    abstract fun broadcastSocksPortAddress(socksPortAddress: String?)
+
+    /**
+     * Override this method to implement receiving of the http port address that Tor
+     * is operating on (if you've specified a
+     * [io.matthewnelson.topl_core_base.TorSettings.httpTunnelPort]).
+     *
+     * Example of what will be broadcast:
+     *
+     *   - "127.0.0.1:33432"
+     * */
+    abstract fun broadcastHttpPortAddress(httpPortAddress: String?)
+}


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR adds broadcasting of what ports Tor is operating to the application. It creates a new abstraction of the `EventBroadcaster` to add the methods for receiving information pertaining to the:
 - Control Port
 - Http Port
 - Socks Port

The `TorServiceController.Builder.setEventBroadcaster` method was updated to accept this new class, and is an API breaking change.