### PR TITLE
Removes use of = operator from methods that do not return anything

### DIFF
--- a/topl-core/build.gradle
+++ b/topl-core/build.gradle
@@ -44,7 +44,7 @@ dokka {
         skipEmptyPackages = true
         samples = [
                 "$rootDir/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt".toString(),
-                "$rootDir/topl-service/src/main/java/io/matthewnelson/topl_service/onionproxy/ServiceTorInstaller.kt".toString()
+                "$rootDir/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorInstaller.kt".toString()
         ]
         sourceLink {
             url = "https://github.com/05nelsonm/TorOnionProxyLibrary-Android/blob/master/"

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
@@ -300,17 +300,18 @@ internal class OnionProxyContext(
      * @throws [SecurityException] Unauthorized access to file/directory.
      */
     @Throws(RuntimeException::class, SecurityException::class)
-    fun deleteDataDirExceptHiddenService() =
+    fun deleteDataDirExceptHiddenService() {
         synchronized(dataDirLock) {
             val listFiles = torConfigFiles.dataDir.listFiles() ?: return
             for (file in listFiles)
                 if (file.isDirectory)
                     if (file.absolutePath != torConfigFiles.hiddenServiceDir.absolutePath)
                         FileUtilities.recursiveFileDelete(file)
-                else
-                    if (!file.delete())
-                        throw RuntimeException("Could not delete file ${file.absolutePath}")
+                    else
+                        if (!file.delete())
+                            throw RuntimeException("Could not delete file ${file.absolutePath}")
         }
+    }
 
     ////////////////////
     /// HostnameFile ///

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyManager.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyManager.kt
@@ -164,8 +164,9 @@ class OnionProxyManager(
     /**
      * See [BroadcastLoggerHelper.refreshBroadcastLoggersHasDebugLogsVar]
      * */
-    fun refreshBroadcastLoggersHasDebugLogsVar() =
+    fun refreshBroadcastLoggersHasDebugLogsVar() {
         logHelper.refreshBroadcastLoggersHasDebugLogsVar()
+    }
 
     /**
      * See [BroadcastLoggerHelper.getBroadcastLogger]
@@ -204,7 +205,9 @@ class OnionProxyManager(
      * the system this does not need to be invoked.
      */
     @Throws(IOException::class)
-    fun setup() = torInstaller.setup()
+    fun setup() {
+        torInstaller.setup()
+    }
 
     fun getNewSettingsBuilder(): TorSettingsBuilder {
         broadcastLogger.debug("Generating a new SettingsBuilder")
@@ -214,8 +217,9 @@ class OnionProxyManager(
         )
     }
 
-    private fun warnControlConnectionNotResponding(methodCall: String) =
+    private fun warnControlConnectionNotResponding(methodCall: String) {
         broadcastLogger.warn("TorControlConnection is not responding properly to $methodCall")
+    }
 
     @Volatile
     private var networkStateReceiver: NetworkStateReceiver? = null
@@ -984,10 +988,14 @@ class OnionProxyManager(
     }
 
     @Throws(Exception::class)
-    fun restartTorProcess() = killTorProcess(-1)
+    fun restartTorProcess() {
+        killTorProcess(-1)
+    }
 
     @Throws(Exception::class)
-    fun killTorProcess() = killTorProcess(-9)
+    fun killTorProcess() {
+        killTorProcess(-9)
+    }
 
     @Throws(Exception::class)
     private fun killTorProcess(signal: Int) {

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/settings/TorSettingsBuilder.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/settings/TorSettingsBuilder.kt
@@ -154,10 +154,11 @@ class TorSettingsBuilder internal constructor(
      * TODO: Devise a more elegant solution using a diff to simply update it if
      *       need be.
      * */
-    fun finishAndWriteToTorrcFile() =
+    fun finishAndWriteToTorrcFile() {
         synchronized(torConfigFiles.torrcFileLock) {
             torConfigFiles.torrcFile.writeText(finishAndReturnString())
         }
+    }
 
     /**
      * Add a new line to the [buffer] if a setting here is not available.

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/FileUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/FileUtilities.kt
@@ -172,10 +172,11 @@ object FileUtilities {
      * @throws java.io.IOException - If close on input or output fails
      */
     @Throws(IOException::class)
-    fun copy(`in`: InputStream, out: OutputStream) =
+    fun copy(`in`: InputStream, out: OutputStream) {
         `in`.use { inputStream ->
             copyDoNotCloseInput(inputStream, out)
         }
+    }
 
     /**
      * Won't close the input stream when it's done, needed to handle ZipInputStreams
@@ -184,7 +185,7 @@ object FileUtilities {
      * @throws java.io.IOException If close on output fails
      */
     @Throws(IOException::class)
-    fun copyDoNotCloseInput(`in`: InputStream, out: OutputStream) =
+    fun copyDoNotCloseInput(`in`: InputStream, out: OutputStream) {
         out.use { outputStream ->
             val buf = ByteArray(4096)
             while (true) {
@@ -193,6 +194,7 @@ object FileUtilities {
                 outputStream.write(buf, 0, read)
             }
         }
+    }
 
     @Throws(SecurityException::class)
     fun listFilesToLog(f: File) {

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/TorInstaller.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/TorInstaller.kt
@@ -120,7 +120,7 @@ abstract class TorInstaller: CoreConsts() {
      * the system this does not need to be invoked.
      *
      * @return true if tor installation is successful, otherwise false.
-     * @sample [io.matthewnelson.topl_service.onionproxy.ServiceTorInstaller.setup]
+     * @sample [io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorInstaller.setup]
      */
     @Throws(IOException::class)
     abstract fun setup()
@@ -143,7 +143,7 @@ abstract class TorInstaller: CoreConsts() {
      *
      * The second form is used for custom bridges from the user.
      *
-     * @sample [io.matthewnelson.topl_service.onionproxy.ServiceTorInstaller.openBridgesStream]
+     * @sample [io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorInstaller.openBridgesStream]
      */
     @Throws(IOException::class)
     abstract fun openBridgesStream(): InputStream?

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/WriteObserver.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/WriteObserver.kt
@@ -115,8 +115,9 @@ class WriteObserver(file: File) : FileObserver(file.absolutePath, CLOSE_WRITE) {
     }
 
     @Throws(IllegalArgumentException::class, SecurityException::class)
-    private fun checkExists(file: File) =
+    private fun checkExists(file: File) {
         require(file.exists()) { "FileObserver doesn't work properly on files that don't already exist." }
+    }
 
     init {
         checkExists(file)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -338,25 +338,29 @@ class TorServiceController private constructor(): ServiceConsts() {
          * @throws [RuntimeException] if called before [Builder.build]
          * */
         @Throws(RuntimeException::class)
-        fun startTor() =
+        fun startTor() {
             BaseService.startService(BaseService.getAppContext(), TorService::class.java)
+        }
 
         /**
          * Stops [TorService].
          * */
-        fun stopTor() =
+        fun stopTor() {
             TorServiceConnection.serviceBinder?.submitServiceAction(ServiceActions.Stop())
+        }
 
         /**
          * Restarts Tor.
          * */
-        fun restartTor() =
+        fun restartTor() {
             TorServiceConnection.serviceBinder?.submitServiceAction(ServiceActions.RestartTor())
+        }
 
         /**
          * Changes identities.
          * */
-        fun newIdentity() =
+        fun newIdentity() {
             TorServiceConnection.serviceBinder?.submitServiceAction(ServiceActions.NewId())
+        }
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefs.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefs.kt
@@ -98,14 +98,17 @@ class TorServicePrefs(context: Context): ServiceConsts() {
      * Registers a [SharedPreferences.OnSharedPreferenceChangeListener] for the
      * associated SharedPreference
      * */
-    fun registerListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) =
+    fun registerListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
         prefs.registerOnSharedPreferenceChangeListener(listener)
+    }
+
     /**
      * Unregisters a [SharedPreferences.OnSharedPreferenceChangeListener] for the
      * associated SharedPreference
      * */
-    fun unregisterListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) =
+    fun unregisterListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
         prefs.unregisterOnSharedPreferenceChangeListener(listener)
+    }
 
 
     /////////////
@@ -135,9 +138,8 @@ class TorServicePrefs(context: Context): ServiceConsts() {
      *  associated with the [booleanKey].
      * @return The Boolean value associated with the [booleanKey], otherwise [defValue]
      * */
-    fun getBoolean(@PrefKeyBoolean booleanKey: String, defValue: Boolean): Boolean {
-        return prefs.getBoolean(booleanKey, defValue)
-    }
+    fun getBoolean(@PrefKeyBoolean booleanKey: String, defValue: Boolean): Boolean =
+        prefs.getBoolean(booleanKey, defValue)
 
     /**
      * Returns an Int value for the provided [ServiceConsts.PrefKeyInt]. If no

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
@@ -154,21 +154,23 @@ internal class ServiceActionProcessor(private val torService: BaseService): Serv
             }
         }
 
-    private fun removeActionFromQueue(serviceAction: ServiceAction) =
+    private fun removeActionFromQueue(serviceAction: ServiceAction) {
         synchronized(actionQueueLock) {
             if (actionQueue.remove(serviceAction))
                 broadcastDebugMsgWithObjectDetails(
                     "Removed from queue: ServiceAction.", serviceAction
                 )
         }
+    }
 
-    private fun clearActionQueue() =
+    private fun clearActionQueue() {
         synchronized(actionQueueLock) {
             if (!actionQueue.isNullOrEmpty()) {
                 actionQueue.clear()
                 broadcastLogger.debug("Queue cleared")
             }
         }
+    }
 
 
     ////////////////////////

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorInstaller.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorInstaller.kt
@@ -128,21 +128,23 @@ internal class ServiceTorInstaller(private val torService: BaseService): TorInst
         }
     }
 
-    private fun copyGeoIpAsset() =
+    private fun copyGeoIpAsset() {
         synchronized(torConfigFiles.geoIpFileLock) {
             torService.copyAsset(BaseService.geoipAssetPath, torConfigFiles.geoIpFile)
             broadcastLogger?.debug(
                 "Asset copied from ${BaseService.geoipAssetPath} -> ${torConfigFiles.geoIpFile}"
             )
         }
+    }
 
-    private fun copyGeoIpv6Asset() =
+    private fun copyGeoIpv6Asset() {
         synchronized(torConfigFiles.geoIpv6FileLock) {
             torService.copyAsset(BaseService.geoip6AssetPath, torConfigFiles.geoIpv6File)
             broadcastLogger?.debug(
                 "Asset copied from ${BaseService.geoip6AssetPath} -> ${torConfigFiles.geoIpv6File}"
             )
         }
+    }
 
     @Throws(IOException::class, TimeoutException::class)
     override fun updateTorConfigCustom(content: String?) {


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR removes the use of Kotlin's equal operator in all methods that do not specify a return type.
Resolves #55 