### PR TITLE
Adds automatic cancellation of notification if not refreshed

### DIFF
--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -110,7 +110,6 @@ class App: Application() {
             .setImageTorNetworkingDisabled(drawableRes = R.drawable.tor_stat_network_disabled)
             .setImageTorDataTransfer(drawableRes = R.drawable.tor_stat_network_dataxfer)
             .setImageTorErrors(drawableRes = R.drawable.tor_stat_notifyerr)
-            .setCustomColor(colorRes = R.color.tor_service_white)
             .setVisibility(visibility = NotificationCompat.VISIBILITY_PRIVATE)
             .setCustomColor(colorRes = R.color.primaryColor)
             .enableTorRestartButton(enable = true)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -438,14 +438,8 @@ class ServiceNotification internal constructor(
     }
 
     @Synchronized
-    internal fun remove(torService: BaseService) {
-        val nm: NotificationManager? = torService.context.applicationContext
-            .getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager?
-
-        nm?.let {
-            it.cancel(notificationID)
-            notificationShowing = false
-        }
+    internal fun remove() {
+        notificationManager?.cancel(notificationID)
     }
 
     /**
@@ -478,9 +472,6 @@ class ServiceNotification internal constructor(
     @Volatile
     internal var inForeground = false
         private set
-    @Volatile
-    internal var notificationShowing = false
-        private set
 
     @Synchronized
     internal fun startForeground(torService: BaseService): ServiceNotification {
@@ -488,18 +479,16 @@ class ServiceNotification internal constructor(
             notificationBuilder?.let {
                 torService.startForeground(notificationID, it.build())
                 inForeground = true
-                notificationShowing = true
             }
         }
         return serviceNotification
     }
 
     @Synchronized
-    internal fun stopForeground(torService: BaseService, removeNotification: Boolean = false): ServiceNotification {
+    internal fun stopForeground(torService: BaseService): ServiceNotification {
         if (inForeground) {
-            torService.stopForeground(if (removeNotification) true else !showNotification)
+            torService.stopForeground(!showNotification)
             inForeground = false
-            notificationShowing = if (removeNotification) true else showNotification
         }
         return serviceNotification
     }
@@ -566,7 +555,7 @@ class ServiceNotification internal constructor(
     /// Content Text ///
     ////////////////////
     @Volatile
-    internal var currentContentText = "Waiting..."
+    internal var currentContentText = "Starting Tor..."
         private set
 
     @Synchronized

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -259,6 +259,9 @@ internal abstract class BaseService: Service() {
     fun addNotificationActions() {
         serviceNotification.addActions(this)
     }
+    fun removeNotification() {
+        serviceNotification.remove()
+    }
     fun removeNotificationActions() {
         serviceNotification.removeActions(this)
     }
@@ -328,7 +331,6 @@ internal abstract class BaseService: Service() {
 
     override fun onDestroy() {
         unregisterPrefsListener()
-        serviceNotification.remove()
     }
 
     /**

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -270,7 +270,7 @@ internal abstract class BaseService: Service() {
         serviceNotification.addActions(this)
     }
     fun removeNotification() {
-        serviceNotification.remove(this)
+        serviceNotification.remove()
     }
     fun removeNotificationActions() {
         serviceNotification.removeActions(this)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -257,9 +257,6 @@ internal class TorService: BaseService() {
     override fun onDestroy() {
         super.onDestroy()
         supervisorJob.cancel()
-
-        // Use _after_ cancelling supervisor job to inhibit any potential broadcasts
-        // that may update the notification after shutting down.
         removeNotification()
     }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -257,6 +257,10 @@ internal class TorService: BaseService() {
     override fun onDestroy() {
         super.onDestroy()
         supervisorJob.cancel()
+
+        // Use _after_ cancelling supervisor job to inhibit any potential broadcasts
+        // that may update the notification after shutting down.
+        removeNotification()
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
@@ -326,6 +326,15 @@ internal class ServiceEventBroadcaster(private val torService: BaseService): Eve
                 ServiceActionName.RESTART_TOR -> {
                     "Restarting Tor..."
                 }
+                ServiceActionName.START -> {
+                    // Need to check here if Tor is already on, as startTor can be called
+                    // anytime which would overwrite the contentText already showing and
+                    // then stay there until something else updates it.
+                    if (torState != TorState.ON)
+                        "Starting Tor..."
+                    else
+                        null
+                }
                 ServiceActionName.STOP -> {
                     "Stopping Service..."
                 }

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
@@ -263,11 +263,13 @@ internal class TestTorService(
             broadcastLogger.exception(e)
         }
     }
+    @ExperimentalCoroutinesApi
     @WorkerThread
     override fun stopTor() {
         simulateStopTor()
     }
 
+    @ExperimentalCoroutinesApi
     private fun simulateStopTor() = getScopeIO().launch {
         serviceEventBroadcaster.broadcastTorState(TorState.STOPPING, TorNetworkState.ENABLED)
         delay(1000)
@@ -295,9 +297,6 @@ internal class TestTorService(
     override fun onDestroy() {
         super.onDestroy()
         supervisorJob.cancel()
-
-        // Use _after_ cancelling supervisor job to inhibit any potential broadcasts
-        // that may update the notification after shutting down.
         removeNotification()
     }
 

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
@@ -292,6 +292,15 @@ internal class TestTorService(
             .finishAndWriteToTorrcFile()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        supervisorJob.cancel()
+
+        // Use _after_ cancelling supervisor job to inhibit any potential broadcasts
+        // that may update the notification after shutting down.
+        removeNotification()
+    }
+
     override fun onTaskRemoved(rootIntent: Intent?) {
         // Cancel the BackgroundManager's coroutine if it's active so it doesn't execute
         testTorServiceBinder.cancelExecuteBackgroundPolicyJob()


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR adds to the notification builder the `setTimeoutAfter` such that the notification times out on it's own after a set number of seconds. In addition, to keep the notification from being cancelled while Tor is active, a coroutine + recursion is used to continuously refresh the active notification. When the supervisor scope is cancelled, or service killed, that coroutine is no longer present and the notification is allowed to cancel itself.

This was the only seeable way to achieve the notification being removed, whilst keeping the service out of the foreground which would inhibit the application from going through its normal lifecycle process (as `startForeground` is an *awful* API, as well as returning `START_STICKY` from `onStartCommand` which is shoddy AF).

Fixes #57 