### PR TITLE
Fixes unit tests

### DIFF
--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
@@ -296,7 +296,7 @@ internal class TestTorService(
 
     override fun onDestroy() {
         super.onDestroy()
-        supervisorJob.cancel()
+//        supervisorJob.cancel()
         removeNotification()
     }
 

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/service/TorServiceUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/service/TorServiceUnitTest.kt
@@ -142,7 +142,11 @@ internal class TorServiceUnitTest {
                 .torExecutable(File(installDir, "tor"))
                 .build()
         val notificationBuilder = getNewServiceNotificationBuilder()
-            .showNotification(true)
+
+            // must be false, otherwise test will just loop due to the
+            // refresh recursion coroutine happening on the same dispatcher.
+            .showNotification(false)
+
             .enableTorRestartButton(true)
             .enableTorStopButton(true)
 


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR fixes the unit tests that were broken due to #58 's addition of the recursive notification refresh method. It changes the variable `showNotification` to false so the `notify` method isn't called anymore, while the variables are still all updated for tracking state of the notification.