### PR TITLE
Improves ease of use for java projects

### DIFF
--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorConfigFiles.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorConfigFiles.kt
@@ -157,6 +157,8 @@ class TorConfigFiles private constructor(
          * @param [configDir] context.getDir("dir_name_here", Context.MODE_PRIVATE)
          * @param [dataDir] if you wish it in a different location than lib/tor
          * */
+        @JvmOverloads
+        @JvmStatic
         fun createConfig(context: Context, configDir: File, dataDir: File? = null): TorConfigFiles {
             val installDir = File(context.applicationInfo.nativeLibraryDir)
             val builder = Builder(installDir, configDir)
@@ -171,6 +173,7 @@ class TorConfigFiles private constructor(
          *
          * @param context Context
          * */
+        @JvmStatic
         fun createConfig(context: Context): TorConfigFiles =
             createConfig(context, context.getDir("torservice", Context.MODE_PRIVATE))
     }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyManager.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyManager.kt
@@ -131,7 +131,6 @@ import java.util.concurrent.TimeUnit
  * @param [buildConfigDebug] Send [BuildConfig.DEBUG] which will show Logcat messages for this
  *   module on Debug builds of your Application. If `null`, all the messages will still be
  *   broadcast to the provided [EventBroadcaster] and you can handle them there how you'd like.
- * @sample [io.matthewnelson.topl_service.service.TorService.initTOPLCore]
  * */
 class OnionProxyManager(
     context: Context,

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/FileUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/FileUtilities.kt
@@ -144,6 +144,7 @@ object FileUtilities {
 
     // TODO: search commit history to see why this method name does not
     //  properly represent what it is doing.
+    @JvmStatic
     fun setToReadOnlyPermissions(file: File): Boolean {
         return file.setReadable(false, false) &&
                 file.setWritable(false, false) &&
@@ -158,6 +159,7 @@ object FileUtilities {
      *
      * @param file the file to set the permissions on
      */
+    @JvmStatic
     fun setPerms(file: File) {
         file.setReadable(true)
         file.setExecutable(true)
@@ -171,6 +173,7 @@ object FileUtilities {
      * @param out Stream to write to
      * @throws java.io.IOException - If close on input or output fails
      */
+    @JvmStatic
     @Throws(IOException::class)
     fun copy(`in`: InputStream, out: OutputStream) {
         `in`.use { inputStream ->
@@ -184,6 +187,7 @@ object FileUtilities {
      * @param out Will be closed
      * @throws java.io.IOException If close on output fails
      */
+    @JvmStatic
     @Throws(IOException::class)
     fun copyDoNotCloseInput(`in`: InputStream, out: OutputStream) {
         out.use { outputStream ->
@@ -196,6 +200,7 @@ object FileUtilities {
         }
     }
 
+    @JvmStatic
     @Throws(SecurityException::class)
     fun listFilesToLog(f: File) {
         if (f.isDirectory) {
@@ -212,6 +217,7 @@ object FileUtilities {
      *
      * @throws java.io.IOException - If any of the file operations fail
      */
+    @JvmStatic
     @Throws(IOException::class, SecurityException::class)
     fun cleanInstallOneFile(readFrom: InputStream, fileToWriteTo: File) {
         if (fileToWriteTo.exists() && !fileToWriteTo.delete())
@@ -221,6 +227,7 @@ object FileUtilities {
         copy(readFrom, out)
     }
 
+    @JvmStatic
     @Throws(SecurityException::class)
     fun recursiveFileDelete(fileOrDirectory: File) {
         if (fileOrDirectory.isDirectory) {
@@ -239,6 +246,7 @@ object FileUtilities {
      * @param zipFileInputStream Stream to unzip
      * @throws java.io.IOException - If there are any file errors
      */
+    @JvmStatic
     @Throws(IOException::class, RuntimeException::class)
     fun extractContentFromZip(destinationDirectory: File, zipFileInputStream: InputStream) {
         val zipInputStream: ZipInputStream

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/Utilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/Utilities.kt
@@ -112,6 +112,7 @@ object Utilities {
      * destination host.
      * @throws IOException Networking issues
      */
+    @JvmStatic
     @Throws(IOException::class)
     fun socks4aSocketConnection(
         networkHost: String,

--- a/topl-service/build.gradle
+++ b/topl-service/build.gradle
@@ -33,6 +33,10 @@ android {
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8
+        freeCompilerArgs += [
+                '-Xopt-in=kotlin.time.ExperimentalTime',
+                '-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi',
+        ]
     }
 }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -303,6 +303,8 @@ class TorServiceController private constructor(): ServiceConsts() {
      * Where everything needed to interact with [TorService] resides.
      * */
     companion object {
+
+        @JvmStatic
         var appEventBroadcaster: TorServiceEventBroadcaster? = null
             private set
 
@@ -312,6 +314,7 @@ class TorServiceController private constructor(): ServiceConsts() {
          * @return Instance of [TorConfigFiles] that are being used throughout TOPL-Android
          * @throws [RuntimeException] if called before [Builder.build]
          * */
+        @JvmStatic
         @Throws(RuntimeException::class)
         fun getTorConfigFiles(): TorConfigFiles {
             BaseService.getAppContext()
@@ -325,6 +328,7 @@ class TorServiceController private constructor(): ServiceConsts() {
          * @return Instance of [TorSettings] that are being used throughout TOPL-Android
          * @throws [RuntimeException] if called before [Builder.build]
          * */
+        @JvmStatic
         @Throws(RuntimeException::class)
         fun getTorSettings(): TorSettings {
             BaseService.getAppContext()
@@ -337,6 +341,7 @@ class TorServiceController private constructor(): ServiceConsts() {
          *
          * @throws [RuntimeException] if called before [Builder.build]
          * */
+        @JvmStatic
         @Throws(RuntimeException::class)
         fun startTor() {
             BaseService.startService(BaseService.getAppContext(), TorService::class.java)
@@ -345,6 +350,7 @@ class TorServiceController private constructor(): ServiceConsts() {
         /**
          * Stops [TorService].
          * */
+        @JvmStatic
         fun stopTor() {
             TorServiceConnection.serviceBinder?.submitServiceAction(ServiceActions.Stop())
         }
@@ -352,6 +358,7 @@ class TorServiceController private constructor(): ServiceConsts() {
         /**
          * Restarts Tor.
          * */
+        @JvmStatic
         fun restartTor() {
             TorServiceConnection.serviceBinder?.submitServiceAction(ServiceActions.RestartTor())
         }
@@ -359,6 +366,7 @@ class TorServiceController private constructor(): ServiceConsts() {
         /**
          * Changes identities.
          * */
+        @JvmStatic
         fun newIdentity() {
             TorServiceConnection.serviceBinder?.submitServiceAction(ServiceActions.NewId())
         }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/lifecycle/BackgroundManager.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/lifecycle/BackgroundManager.kt
@@ -192,6 +192,7 @@ class BackgroundManager internal constructor(
          * @return [BackgroundManager.Builder.Policy] To use when initializing
          *   [io.matthewnelson.topl_service.TorServiceController.Builder]
          * */
+        @JvmOverloads
         fun respectResourcesWhileInBackground(secondsFrom5To45: Int? = null): Policy {
             chosenPolicy = BackgroundPolicy.RESPECT_RESOURCES
             if (secondsFrom5To45 != null && secondsFrom5To45 in 5..45)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -290,6 +290,7 @@ class ServiceNotification internal constructor(
          *   for implementor to query SharedPreferences for user's settings (if desired)
          * @return [Builder] To continue customizing
          * */
+        @JvmOverloads
         fun enableTorRestartButton(enable: Boolean = true): Builder {
             serviceNotification.enableRestartButton = enable
             return this
@@ -306,6 +307,7 @@ class ServiceNotification internal constructor(
          *   for implementor to query SharedPreferences for user's settings (if desired)
          * @return [Builder] To continue customizing
          * */
+        @JvmOverloads
         fun enableTorStopButton(enable: Boolean = true): Builder {
             serviceNotification.enableStopButton = enable
             return this
@@ -325,6 +327,7 @@ class ServiceNotification internal constructor(
          *   implementor to query SharedPreferences for user's settings (if desired)
          * @return [Builder] To continue customizing
          * */
+        @JvmOverloads
         fun showNotification(show: Boolean = false): Builder {
             serviceNotification.showNotification = show
             return this

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
@@ -132,14 +132,11 @@ internal class TestTorService(
     /// Coroutines ///
     //////////////////
     val supervisorJob = SupervisorJob()
-    @ExperimentalCoroutinesApi
     val testCoroutineScope = TestCoroutineScope(dispatcher + supervisorJob)
 
-    @ExperimentalCoroutinesApi
     override fun getScopeIO(): CoroutineScope {
         return testCoroutineScope
     }
-    @ExperimentalCoroutinesApi
     override fun getScopeMain(): CoroutineScope {
         return testCoroutineScope
     }
@@ -157,7 +154,6 @@ internal class TestTorService(
      * is simulated properly in that it will stop processing the queue and the Coroutine
      * Job will move to `complete`.
      * */
-    @ExperimentalCoroutinesApi
     override fun stopService() {
         stopSelfCalled = true
         getScopeMain().launch { onDestroy() }
@@ -240,7 +236,6 @@ internal class TestTorService(
     val bandwidth0 = "0"
 
     // Add 6_000ms delay at start of each test to account for startup time.
-    @ExperimentalCoroutinesApi
     private fun simulateStart() = getScopeIO().launch {
         try {
             onionProxyManager.setup()
@@ -263,13 +258,11 @@ internal class TestTorService(
             broadcastLogger.exception(e)
         }
     }
-    @ExperimentalCoroutinesApi
     @WorkerThread
     override fun stopTor() {
         simulateStopTor()
     }
 
-    @ExperimentalCoroutinesApi
     private fun simulateStopTor() = getScopeIO().launch {
         serviceEventBroadcaster.broadcastTorState(TorState.STOPPING, TorNetworkState.ENABLED)
         delay(1000)

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
@@ -105,6 +105,7 @@ internal class TorServiceControllerUnitTest {
             "Test Channel Description",
             615615
         )
+            .showNotification(false)
     }
     private val torSettings: TestTorSettings by lazy { TestTorSettings() }
     private lateinit var installDir: File

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/service/TorServiceUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/service/TorServiceUnitTest.kt
@@ -108,7 +108,6 @@ import java.io.File
 /**
  * Tests the components that make [TorService] work.
  * */
-@InternalCoroutinesApi
 @Config(minSdk = 16, maxSdk = 28)
 @RunWith(RobolectricTestRunner::class)
 internal class TorServiceUnitTest {
@@ -128,10 +127,8 @@ internal class TorServiceUnitTest {
     private val serviceNotification: ServiceNotification
         get() = ServiceNotification.serviceNotification
 
-    @ExperimentalCoroutinesApi
     private val testDispatcher = TestCoroutineDispatcher()
 
-    @ExperimentalCoroutinesApi
     @Before
     fun setup() {
         testDirectory.create()
@@ -212,7 +209,6 @@ internal class TorServiceUnitTest {
             .useCustomTorConfigFiles(torConfigFiles)
     }
 
-    @ExperimentalCoroutinesApi
     @After
     fun tearDown() {
         testDirectory.delete()
@@ -220,7 +216,6 @@ internal class TorServiceUnitTest {
         testDispatcher.cleanupTestCoroutines()
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `validate startup state`() = runBlockingTest(testDispatcher) {
         // Check EventBroadcasters are working and notification is being updated
@@ -285,7 +280,6 @@ internal class TorServiceUnitTest {
         testTorService.refreshBroadcastLoggerWasCalled = false
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `calling stopTor cleans up`() = runBlockingTest(testDispatcher){
         delay(6000) // testTorService.simulateStart() takes 6000ms


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR adds JVM annotations (JvmStatic, JvmOverload, etc.) to public APIs such that Java projects using the Library.
It also cleans up the testing coroutine use by opting out via build.gradle instead of annotating methods as experimental.