### PR TITLE
Add option to BackgroundManager to run service in the Foreground

### DIFF
--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -124,7 +124,7 @@ class App: Application() {
 
             // All available options present. Only 1 is able to be chosen.
             //.respectResourcesWhileInBackground(secondsFrom5To45 = 20)
-            .runServiceInForeground(secondsFrom0To45 = 0)
+            .runServiceInForeground(killAppIfTaskIsRemoved = true)
 //  }
     }
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -121,8 +121,10 @@ class App: Application() {
     private fun generateBackgroundManagerPolicy(): BackgroundManager.Builder.Policy {
 //  private fun generateBackgroundManagerPolicy(): BackgroundManager.Builder.Policy {
         return BackgroundManager.Builder()
-            .respectResourcesWhileInBackground(secondsFrom5To45 = 20)
 
+            // All available options present. Only 1 is able to be chosen.
+            //.respectResourcesWhileInBackground(secondsFrom5To45 = 20)
+            .runUntilKilled()
 //  }
     }
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -124,7 +124,7 @@ class App: Application() {
 
             // All available options present. Only 1 is able to be chosen.
             //.respectResourcesWhileInBackground(secondsFrom5To45 = 20)
-            .runUntilKilled()
+            .runServiceInForeground(secondsFrom0To45 = 0)
 //  }
     }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/lifecycle/BackgroundManager.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/lifecycle/BackgroundManager.kt
@@ -103,8 +103,9 @@ import io.matthewnelson.topl_service.util.ServiceConsts
  *
  * When the user sends your application to the Recent App's tray though, to recoup resources
  * the OS will kill your app after being idle for a period of time (random AF... typically
- * 0.75m to 1.25m). This is not an issue if the user removes the task before the OS
- * kills the app, as Tor will be able to shutdown properly and the service will stop.
+ * 0.75m to 1.25m if the device's memory is being used heavily). This is not an issue if
+ * the user removes the task before the OS kills the app, as Tor will be able to shutdown
+ * properly and the service will stop.
  *
  * This is where Services get sketchy (especially when trying to implement an always
  * running service for networking), and is the purpose of the [BackgroundManager] class.
@@ -197,6 +198,19 @@ class BackgroundManager internal constructor(
             chosenPolicy = BackgroundPolicy.RESPECT_RESOURCES
             if (secondsFrom5To45 != null && secondsFrom5To45 in 5..45)
                 executionDelay = (secondsFrom5To45 * 1000).toLong()
+            return Policy(this)
+        }
+
+        /**
+         * Electing this option will simply run [TorService] while your application is
+         * in the background, until the OS kills it along with your application. As long
+         * as your application has not been killed, the service will keep running. Upon
+         * being killed, the notification (if enabled) will simply timeout and cancel itself.
+         * All processes and threads will stop, and a cold start called on your application
+         * the next time the user opens it.
+         * */
+        fun runUntilKilled(): Policy {
+            chosenPolicy = BackgroundPolicy.RUN_UNTIL_KILLED
             return Policy(this)
         }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -480,6 +480,7 @@ class ServiceNotification internal constructor(
     internal fun startForeground(torService: BaseService): ServiceNotification {
         if (!inForeground) {
             notificationBuilder?.let {
+                launchRefreshNotificationJob(torService)
                 torService.startForeground(notificationID, it.build())
                 inForeground = true
             }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -432,7 +432,7 @@ class ServiceNotification internal constructor(
         if (notificationRefreshJob?.isActive == true)
             notificationRefreshJob?.cancel()
 
-        notificationRefreshJob = torService.getScopeMain().launch {
+        notificationRefreshJob = torService.getScopeIO().launch {
             delay(timeoutLength - 250L)
             notificationBuilder?.let {
                 notify(torService, it)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -432,11 +432,15 @@ class ServiceNotification internal constructor(
         if (notificationRefreshJob?.isActive == true)
             notificationRefreshJob?.cancel()
 
+        if (inForeground)
+            return
+
         notificationRefreshJob = torService.getScopeIO().launch {
             delay(timeoutLength - 250L)
-            notificationBuilder?.let {
-                notify(torService, it)
-            }
+            if (!inForeground)
+                notificationBuilder?.let {
+                    notify(torService, it)
+                }
         }
     }
 
@@ -480,7 +484,6 @@ class ServiceNotification internal constructor(
     internal fun startForeground(torService: BaseService): ServiceNotification {
         if (!inForeground) {
             notificationBuilder?.let {
-                launchRefreshNotificationJob(torService)
                 torService.startForeground(notificationID, it.build())
                 inForeground = true
             }
@@ -493,6 +496,7 @@ class ServiceNotification internal constructor(
         if (inForeground) {
             torService.stopForeground(!showNotification)
             inForeground = false
+            launchRefreshNotificationJob(torService)
         }
         return serviceNotification
     }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -194,16 +194,33 @@ internal abstract class BaseService: Service() {
             // the system via START_STICKY
             return try {
                 context.applicationContext.startService(intent)
-                context.applicationContext.bindService(
-                    intent,
-                    TorServiceConnection.torServiceConnection,
-                    bindServiceFlag
-                )
+                bindService(context, serviceClass, bindServiceFlag)
                 true
             } catch (e: RuntimeException) {
                 false
             }
         }
+
+        /**
+         * Binds the Service.
+         *
+         * @param [context]
+         * @param [serviceClass] The Service's class wanting to be started
+         * @param [bindServiceFlag] The flag to use when binding to [TorService]
+         * @return true if startService didn't throw an exception, false if it did.
+         * */
+        fun bindService(
+            context: Context,
+            serviceClass: Class<*>,
+            bindServiceFlag: Int = Context.BIND_AUTO_CREATE
+        ) {
+            context.applicationContext.bindService(
+                Intent(context.applicationContext, serviceClass),
+                TorServiceConnection.torServiceConnection,
+                bindServiceFlag
+            )
+        }
+
 
         /**
          * Unbinds [TorService] from the Application and clears the reference to

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -76,6 +76,7 @@ import io.matthewnelson.topl_core.broadcaster.BroadcastLogger
 import io.matthewnelson.topl_core_base.TorConfigFiles
 import io.matthewnelson.topl_core_base.TorSettings
 import io.matthewnelson.topl_service.BuildConfig
+import io.matthewnelson.topl_service.lifecycle.BackgroundManager
 import io.matthewnelson.topl_service.notification.ServiceNotification
 import io.matthewnelson.topl_service.prefs.TorServicePrefsListener
 import io.matthewnelson.topl_service.service.components.actions.ServiceActionProcessor
@@ -377,6 +378,7 @@ internal abstract class BaseService: Service() {
 
 
     override fun onTaskRemoved(rootIntent: Intent?) {
+        BackgroundManager.taskIsRemovedFromRecentApps(true)
         // Move to the foreground so we can properly shutdown w/o interrupting the
         // application's normal lifecycle (Context.startServiceForeground does... thus,
         // the complexity)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -73,6 +73,7 @@ import io.matthewnelson.topl_core.OnionProxyManager
 import io.matthewnelson.topl_core.broadcaster.BroadcastLogger
 import io.matthewnelson.topl_core.util.FileUtilities
 import io.matthewnelson.topl_service.TorServiceController
+import io.matthewnelson.topl_service.lifecycle.BackgroundManager
 import io.matthewnelson.topl_service.service.components.binding.TorServiceBinder
 import io.matthewnelson.topl_service.service.components.binding.TorServiceConnection
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceEventBroadcaster
@@ -258,6 +259,7 @@ internal class TorService: BaseService() {
         super.onDestroy()
         supervisorJob.cancel()
         removeNotification()
+        BackgroundManager.killAppProcess()
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/BaseServiceBinder.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/BaseServiceBinder.kt
@@ -118,8 +118,6 @@ internal abstract class BaseServiceBinder(private val torService: BaseService): 
         backgroundPolicyExecutionJob = torService.getScopeMain().launch {
             when (policy) {
                 BackgroundPolicy.RUN_IN_FOREGROUND -> {
-                    if (executionDelay > 0)
-                        delay(executionDelay)
                     bgMgrBroadcastLogger.debug("Executing background management policy")
                     torService.startForegroundService()
                 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/BaseServiceBinder.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/BaseServiceBinder.kt
@@ -66,7 +66,10 @@
 * */
 package io.matthewnelson.topl_service.service.components.binding
 
+import android.app.Activity
+import android.app.Application
 import android.os.Binder
+import android.os.Bundle
 import io.matthewnelson.topl_core.broadcaster.BroadcastLogger
 import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.lifecycle.BackgroundManager
@@ -77,6 +80,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import net.freehaven.tor.control.TorControlCommands
 
 
 internal abstract class BaseServiceBinder(private val torService: BaseService): Binder() {
@@ -113,8 +117,11 @@ internal abstract class BaseServiceBinder(private val torService: BaseService): 
         cancelExecuteBackgroundPolicyJob()
         backgroundPolicyExecutionJob = torService.getScopeMain().launch {
             when (policy) {
-                BackgroundPolicy.RUN_UNTIL_KILLED -> {
-                    // Do nothing...
+                BackgroundPolicy.RUN_IN_FOREGROUND -> {
+                    if (executionDelay > 0)
+                        delay(executionDelay)
+                    bgMgrBroadcastLogger.debug("Executing background management policy")
+                    torService.startForegroundService()
                 }
                 BackgroundPolicy.RESPECT_RESOURCES -> {
                     delay(executionDelay)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/BaseServiceBinder.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/BaseServiceBinder.kt
@@ -113,16 +113,8 @@ internal abstract class BaseServiceBinder(private val torService: BaseService): 
         cancelExecuteBackgroundPolicyJob()
         backgroundPolicyExecutionJob = torService.getScopeMain().launch {
             when (policy) {
-                BackgroundPolicy.KEEP_ALIVE -> {
-                    while (isActive && TorServiceConnection.serviceBinder != null) {
-                        delay(executionDelay)
-                        if (isActive && TorServiceConnection.serviceBinder != null) {
-                            bgMgrBroadcastLogger.debug("Executing background management policy")
-                            torService.stopForegroundService()
-                            torService.startForegroundService()
-                            torService.stopForegroundService()
-                        }
-                    }
+                BackgroundPolicy.RUN_UNTIL_KILLED -> {
+                    // Do nothing...
                 }
                 BackgroundPolicy.RESPECT_RESOURCES -> {
                     delay(executionDelay)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
@@ -84,14 +84,14 @@ abstract class ServiceConsts: BaseConsts() {
     )
     @StringDef(
         BackgroundPolicy.RESPECT_RESOURCES,
-        BackgroundPolicy.RUN_UNTIL_KILLED
+        BackgroundPolicy.RUN_IN_FOREGROUND
     )
     @Retention(AnnotationRetention.SOURCE)
     internal annotation class BackgroundPolicy {
         companion object {
             private const val BACKGROUND_POLICY = "BackgroundPolicy_"
             const val RESPECT_RESOURCES = "${BACKGROUND_POLICY}RESPECT_RESOURCES"
-            const val RUN_UNTIL_KILLED = "${BACKGROUND_POLICY}RUN_UNTIL_KILLED"
+            const val RUN_IN_FOREGROUND = "${BACKGROUND_POLICY}RUN_IN_FOREGROUND"
         }
     }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
@@ -83,15 +83,15 @@ abstract class ServiceConsts: BaseConsts() {
         AnnotationTarget.TYPE
     )
     @StringDef(
-        BackgroundPolicy.KEEP_ALIVE,
-        BackgroundPolicy.RESPECT_RESOURCES
+        BackgroundPolicy.RESPECT_RESOURCES,
+        BackgroundPolicy.RUN_UNTIL_KILLED
     )
     @Retention(AnnotationRetention.SOURCE)
     internal annotation class BackgroundPolicy {
         companion object {
             private const val BACKGROUND_POLICY = "BackgroundPolicy_"
-            const val KEEP_ALIVE = "${BACKGROUND_POLICY}KEEP_ALIVE"
             const val RESPECT_RESOURCES = "${BACKGROUND_POLICY}RESPECT_RESOURCES"
+            const val RUN_UNTIL_KILLED = "${BACKGROUND_POLICY}RUN_UNTIL_KILLED"
         }
     }
 


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR adds to `BackgroundManager`:
 - An option to choose from within the `Builder` to run the service in the Foreground, if the application is sent to the background.
- Static variables present in `BackgroundManager`'s companion object for Library users to query for determining the background state of their application.
- Tweaks `ServiceNotification`'s recursive coroutine call as to not start it if the service is in the foreground.