### PR TITLE
Adds Builder option to disable stopping of service onTaskRemoved

### DIFF
--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -123,8 +123,8 @@ class App: Application() {
         return BackgroundManager.Builder()
 
             // All available options present. Only 1 is able to be chosen.
-            //.respectResourcesWhileInBackground(secondsFrom5To45 = 20)
-            .runServiceInForeground(killAppIfTaskIsRemoved = true)
+            .respectResourcesWhileInBackground(secondsFrom5To45 = 20)
+            //.runServiceInForeground(killAppIfTaskIsRemoved = true)
 //  }
     }
 
@@ -149,6 +149,7 @@ class App: Application() {
         )
             .addTimeToRestartTorDelay(milliseconds = 100L)
             .addTimeToStopServiceDelay(milliseconds = 100L)
+            .disableStopServiceOnTaskRemoved(disable = false)
             .setBuildConfigDebug(buildConfigDebug = BuildConfig.DEBUG)
 
             // Can instantiate directly here then access it from

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/lifecycle/BackgroundManager.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/lifecycle/BackgroundManager.kt
@@ -151,9 +151,9 @@ class BackgroundManager internal constructor(
     class Builder {
 
         @BackgroundPolicy
-        private lateinit var chosenPolicy: String
+        internal lateinit var chosenPolicy: String
         private var executionDelay: Long = 30_000L
-        private var killAppIfTaskIsRemoved = false
+        internal var killAppIfTaskIsRemoved = false
 
         /**
          * Stops [TorService] after being in the background for the declared [secondsFrom5To45].
@@ -221,7 +221,7 @@ class BackgroundManager internal constructor(
          *
          * @param [policyBuilder] The [BackgroundManager.Builder] to be built during initialization
          * */
-        class Policy(private val policyBuilder: Builder) {
+        class Policy(internal val policyBuilder: Builder) {
 
             /**
              * Only available internally, so this is where we intercept for integration testing.

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -496,7 +496,9 @@ class ServiceNotification internal constructor(
         if (inForeground) {
             torService.stopForeground(!showNotification)
             inForeground = false
-            launchRefreshNotificationJob(torService)
+            notificationBuilder?.let {
+                notify(torService, it)
+            }
         }
         return serviceNotification
     }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -108,6 +108,8 @@ internal abstract class BaseService: Service() {
             private set
         lateinit var torConfigFiles: TorConfigFiles
         lateinit var torSettings: TorSettings
+        var stopServiceOnTaskRemoved: Boolean = true
+            private set
 
         fun initialize(
             application: Application,
@@ -116,7 +118,8 @@ internal abstract class BaseService: Service() {
             geoipAssetPath: String,
             geoip6AssetPath: String,
             torConfigFiles: TorConfigFiles,
-            torSettings: TorSettings
+            torSettings: TorSettings,
+            stopServiceOnTaskRemoved: Boolean
         ) {
             this.application = application
             this.buildConfigVersionCode = buildConfigVersionCode
@@ -125,6 +128,7 @@ internal abstract class BaseService: Service() {
             this.geoip6AssetPath = geoip6AssetPath
             this.torConfigFiles = torConfigFiles
             this.torSettings = torSettings
+            this.stopServiceOnTaskRemoved = stopServiceOnTaskRemoved
         }
 
         @Throws(RuntimeException::class)
@@ -385,6 +389,7 @@ internal abstract class BaseService: Service() {
         startForegroundService()
 
         // Shutdown Tor and stop the Service.
-        processServiceAction(ServiceActions.Stop(updateLastServiceAction = false))
+        if (stopServiceOnTaskRemoved)
+            processServiceAction(ServiceActions.Stop(updateLastServiceAction = false))
     }
 }


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR adds to the `TorServiceController.Builder` an option for disabling the functionality of stopping the service when the `onTaskRemoved` callback is had.