### PR TITLE
Makes ServiceNotification smarter

### DIFF
--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -357,8 +357,12 @@ class ServiceNotification internal constructor(
     private var notificationBuilder: NotificationCompat.Builder? = null
     private var notificationManager: NotificationManager? = null
     private val timeoutLength = 3_000L
+    private var startTime: Long? = null
 
-    internal fun buildNotification(torService: BaseService): NotificationCompat.Builder {
+    internal fun buildNotification(
+        torService: BaseService,
+        setStartTime: Boolean = false
+    ): NotificationCompat.Builder {
         val builder = NotificationCompat.Builder(torService.context.applicationContext, channelID)
             .setCategory(NotificationCompat.CATEGORY_PROGRESS)
             .setContentText(currentContentText)
@@ -373,17 +377,23 @@ class ServiceNotification internal constructor(
             .setTimeoutAfter(timeoutLength)
             .setVisibility(visibility)
 
+        if (startTime == null || setStartTime)
+            startTime = System.currentTimeMillis()
+
+        startTime?.let {
+            builder.setWhen(it)
+        }
+
         currentColor?.let {
             builder.color = it
         }
 
         if (progressBarShown) {
             val progress = progressValue
-            if (progress != null) {
+            if (progress != null)
                 builder.setProgress(100, progress, false)
-            } else {
+            else
                 builder.setProgress(100, 0, true)
-            }
         }
 
         if (activityWhenTapped != null)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -514,26 +514,27 @@ class ServiceNotification internal constructor(
     @Synchronized
     internal fun addActions(torService: BaseService) {
         val builder = notificationBuilder ?: return
+        actionsPresent = true
+
         builder.addAction(
             imageNetworkEnabled,
             "New Identity",
             getActionPendingIntent(torService, ServiceActionName.NEW_ID, 1)
         )
 
-        if (enableRestartButton)
+        if (enableRestartButton && TorServiceReceiver.deviceIsLocked != true)
             builder.addAction(
                 imageNetworkEnabled,
                 "Restart Tor",
                 getActionPendingIntent(torService, ServiceActionName.RESTART_TOR, 2)
             )
 
-        if (enableStopButton)
+        if (enableStopButton && TorServiceReceiver.deviceIsLocked != true)
             builder.addAction(
                 imageNetworkEnabled,
                 "Stop Tor",
                 getActionPendingIntent(torService, ServiceActionName.STOP, 3)
             )
-        actionsPresent = true
         notify(torService, builder)
     }
 
@@ -552,6 +553,13 @@ class ServiceNotification internal constructor(
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT
         )
+    }
+
+    @Synchronized
+    internal fun refreshActions(torService: BaseService) {
+        if (!actionsPresent) return
+        removeActions(torService)
+        addActions(torService)
     }
 
     @Synchronized

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -490,20 +490,29 @@ class ServiceNotification internal constructor(
     internal var inForeground = false
         private set
 
+    /**
+     * Sends [TorService] to the Foreground.
+     *
+     * @return `true` if sent to Foreground, `false` if no action taken
+     * */
     @Synchronized
     internal fun startForeground(torService: BaseService): Boolean {
         return if (!inForeground) {
             notificationBuilder?.let {
                 torService.startForeground(notificationID, it.build())
                 inForeground = true
-                return true
             }
-            false
+            inForeground
         } else {
             false
         }
     }
 
+    /**
+     * Sends [TorService] to the Background.
+     *
+     * @return `true` if sent to Background, `false` if no action taken
+     * */
     @Synchronized
     internal fun stopForeground(torService: BaseService): Boolean {
         return if (inForeground) {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -491,26 +491,31 @@ class ServiceNotification internal constructor(
         private set
 
     @Synchronized
-    internal fun startForeground(torService: BaseService): ServiceNotification {
-        if (!inForeground) {
+    internal fun startForeground(torService: BaseService): Boolean {
+        return if (!inForeground) {
             notificationBuilder?.let {
                 torService.startForeground(notificationID, it.build())
                 inForeground = true
+                return true
             }
+            false
+        } else {
+            false
         }
-        return serviceNotification
     }
 
     @Synchronized
-    internal fun stopForeground(torService: BaseService): ServiceNotification {
-        if (inForeground) {
+    internal fun stopForeground(torService: BaseService): Boolean {
+        return if (inForeground) {
             torService.stopForeground(!showNotification)
             inForeground = false
             notificationBuilder?.let {
                 notify(torService, it)
             }
+            true
+        } else {
+            false
         }
-        return serviceNotification
     }
 
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -501,8 +501,9 @@ class ServiceNotification internal constructor(
             notificationBuilder?.let {
                 torService.startForeground(notificationID, it.build())
                 inForeground = true
+                return true
             }
-            inForeground
+            false
         } else {
             false
         }
@@ -579,11 +580,22 @@ class ServiceNotification internal constructor(
         )
     }
 
+    /**
+     * Refreshes the notification Actions.
+     *
+     * @return `true` if actions were present to be refreshed, `false` if actions weren't
+     *   present, thus not needing a refresh
+     * @see [TorServiceReceiver.deviceIsLocked]
+     * */
     @Synchronized
-    internal fun refreshActions(torService: BaseService) {
-        if (!actionsPresent) return
-        removeActions(torService)
-        addActions(torService)
+    internal fun refreshActions(torService: BaseService): Boolean {
+        return if (actionsPresent) {
+            removeActions(torService)
+            addActions(torService)
+            true
+        } else {
+            false
+        }
     }
 
     @Synchronized

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -72,6 +72,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import androidx.annotation.WorkerThread
+import androidx.core.app.NotificationCompat
 import io.matthewnelson.topl_core.broadcaster.BroadcastLogger
 import io.matthewnelson.topl_core_base.TorConfigFiles
 import io.matthewnelson.topl_core_base.TorSettings
@@ -257,6 +258,7 @@ internal abstract class BaseService: Service() {
     /// BroadcastReceiver ///
     /////////////////////////
     abstract fun registerReceiver()
+    abstract fun setIsDeviceLocked()
     abstract fun unregisterReceiver()
 
 
@@ -290,6 +292,22 @@ internal abstract class BaseService: Service() {
 
     fun addNotificationActions() {
         serviceNotification.addActions(this)
+    }
+    fun doesReceiverNeedToListenForLockScreen(): Boolean {
+        return when {
+            serviceNotification.visibility == NotificationCompat.VISIBILITY_SECRET -> {
+                false
+            }
+            serviceNotification.enableRestartButton || serviceNotification.enableStopButton -> {
+                true
+            }
+            else -> {
+                false
+            }
+        }
+    }
+    fun refreshNotificationActions() {
+        serviceNotification.refreshActions(this)
     }
     fun removeNotification() {
         serviceNotification.remove()
@@ -359,6 +377,7 @@ internal abstract class BaseService: Service() {
     override fun onCreate() {
         serviceNotification.buildNotification(this)
         registerPrefsListener()
+        setIsDeviceLocked()
     }
 
     override fun onDestroy() {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -315,10 +315,10 @@ internal abstract class BaseService: Service() {
     fun removeNotificationActions() {
         serviceNotification.removeActions(this)
     }
-    fun startForegroundService(): ServiceNotification {
+    open fun startForegroundService(): Boolean {
         return serviceNotification.startForeground(this)
     }
-    fun stopForegroundService(): ServiceNotification {
+    open fun stopForegroundService(): Boolean {
         return serviceNotification.stopForeground(this)
     }
     fun updateNotificationContentText(string: String) {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -375,7 +375,7 @@ internal abstract class BaseService: Service() {
 
 
     override fun onCreate() {
-        serviceNotification.buildNotification(this)
+        serviceNotification.buildNotification(this, setStartTime = true)
         registerPrefsListener()
         setIsDeviceLocked()
     }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -306,8 +306,8 @@ internal abstract class BaseService: Service() {
             }
         }
     }
-    fun refreshNotificationActions() {
-        serviceNotification.refreshActions(this)
+    open fun refreshNotificationActions(): Boolean {
+        return serviceNotification.refreshActions(this)
     }
     fun removeNotification() {
         serviceNotification.remove()

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -161,6 +161,17 @@ internal class TorService: BaseService() {
 
     // See BaseService
 
+    override fun refreshNotificationActions(): Boolean {
+        val wasRefreshed = super.refreshNotificationActions()
+        if (wasRefreshed) {
+            val debugMsg = if (TorServiceReceiver.deviceIsLocked == true)
+                "Removed Notification Actions"
+            else
+                "Added Notification Actions"
+            broadcastLogger.debug(debugMsg)
+        }
+        return wasRefreshed
+    }
     override fun startForegroundService(): Boolean {
         val wasStarted = super.startForegroundService()
         if (wasStarted)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -125,6 +125,9 @@ internal class TorService: BaseService() {
     override fun registerReceiver() {
         torServiceReceiver.register()
     }
+    override fun setIsDeviceLocked() {
+        torServiceReceiver.setDeviceIsLocked()
+    }
     override fun unregisterReceiver() {
         torServiceReceiver.unregister()
     }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -161,6 +161,19 @@ internal class TorService: BaseService() {
 
     // See BaseService
 
+    override fun startForegroundService(): Boolean {
+        val wasStarted = super.startForegroundService()
+        if (wasStarted)
+            broadcastLogger.debug("Service sent to Foreground")
+        return wasStarted
+    }
+    override fun stopForegroundService(): Boolean {
+        val wasStopped = super.stopForegroundService()
+        if (wasStopped)
+            broadcastLogger.debug("Service sent to Background")
+        return wasStopped
+    }
+
 
     /////////////////
     /// TOPL-Core ///

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
@@ -66,6 +66,7 @@
 * */
 package io.matthewnelson.topl_service.service.components.receiver
 
+import android.app.KeyguardManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -94,17 +95,33 @@ internal class TorServiceReceiver(private val torService: BaseService): Broadcas
         @Volatile
         var isRegistered = false
             private set
+
+        @Volatile
+        var deviceIsLocked: Boolean? = null
+            private set
     }
 
     private val broadcastLogger = torService.getBroadcastLogger(TorServiceReceiver::class.java)
 
     fun register() {
-        torService.context.applicationContext.registerReceiver(
-            this, IntentFilter(SERVICE_INTENT_FILTER)
-        )
+        val filter = IntentFilter(SERVICE_INTENT_FILTER)
+        if (torService.doesReceiverNeedToListenForLockScreen()) {
+            filter.addAction(Intent.ACTION_SCREEN_OFF)
+            filter.addAction(Intent.ACTION_SCREEN_ON)
+            filter.addAction(Intent.ACTION_USER_PRESENT)
+        }
+        torService.context.applicationContext.registerReceiver(this, filter)
         if (!isRegistered)
             broadcastLogger.debug("Has been registered")
         isRegistered = true
+    }
+
+    /**
+     * Sets [deviceIsLocked] to the value sent. If [value] is null, it will check
+     * KeyguardManager.
+     * */
+    fun setDeviceIsLocked(value: Boolean? = null) {
+        deviceIsLocked = value ?: checkIfDeviceIsLocked()
     }
 
     fun unregister() {
@@ -112,6 +129,7 @@ internal class TorServiceReceiver(private val torService: BaseService): Broadcas
             try {
                 torService.context.applicationContext.unregisterReceiver(this)
                 isRegistered = false
+                setDeviceIsLocked()
                 broadcastLogger.debug("Has been unregistered")
             } catch (e: IllegalArgumentException) {
                 broadcastLogger.exception(e)
@@ -119,11 +137,14 @@ internal class TorServiceReceiver(private val torService: BaseService): Broadcas
         }
     }
 
+    private fun checkIfDeviceIsLocked(): Boolean? {
+        val keyguardManager = torService.context.applicationContext
+            .getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager?
+        return keyguardManager?.isKeyguardLocked
+    }
+
     override fun onReceive(context: Context?, intent: Intent?) {
         if (context != null && intent != null) {
-            // Only accept Intents from this package.
-            if (context.applicationInfo.dataDir != torService.context.applicationInfo.dataDir) return
-
             when (val serviceAction = intent.getStringExtra(SERVICE_INTENT_FILTER)) {
                 ServiceActionName.NEW_ID -> {
                     torService.processServiceAction(ServiceActions.NewId())
@@ -135,9 +156,26 @@ internal class TorServiceReceiver(private val torService: BaseService): Broadcas
                     torService.processServiceAction(ServiceActions.Stop())
                 }
                 else -> {
-                    broadcastLogger.warn(
-                        "This class does not accept $serviceAction as an argument."
-                    )
+
+                    when (intent.action) {
+                        Intent.ACTION_SCREEN_OFF,
+                        Intent.ACTION_SCREEN_ON,
+                        Intent.ACTION_USER_PRESENT -> {
+                            val locked = checkIfDeviceIsLocked()
+                            if (locked != deviceIsLocked) {
+                                setDeviceIsLocked(locked)
+                                broadcastLogger.debug("Device is locked: $deviceIsLocked")
+                                broadcastLogger.debug("Refreshing Notification Actions")
+                                torService.refreshNotificationActions()
+                            }
+                        }
+                        else -> {
+                            broadcastLogger.warn(
+                                "This class does not accept $serviceAction as an argument."
+                            )
+                        }
+                    }
+
                 }
             }
         }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
@@ -165,7 +165,6 @@ internal class TorServiceReceiver(private val torService: BaseService): Broadcas
                             if (locked != deviceIsLocked) {
                                 setDeviceIsLocked(locked)
                                 broadcastLogger.debug("Device is locked: $deviceIsLocked")
-                                broadcastLogger.debug("Refreshing Notification Actions")
                                 torService.refreshNotificationActions()
                             }
                         }

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
@@ -123,6 +123,9 @@ internal class TestTorService(
     override fun registerReceiver() {
         torServiceReceiver.register()
     }
+    override fun setIsDeviceLocked() {
+        torServiceReceiver.setDeviceIsLocked()
+    }
     override fun unregisterReceiver() {
         torServiceReceiver.unregister()
     }


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR makes `ServiceNotification` smarter by:
 - Removing Notification Actions when the device is locked.
 - Re-adds Notification Actions when device is unlocked.
 - Sets the Notification start time when `TorService` is created and initially builds the notification to be used.
 - Broadcasts when `TorService` is sent to the Foreground/Background.