### PR TITLE
TorSettings upgrades and implementing the features in the Sample App

### DIFF
--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -74,7 +74,7 @@ import io.matthewnelson.sampleapp.topl_android.MyTorSettings
 import io.matthewnelson.sampleapp.ui.MainActivity
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
-import io.matthewnelson.sampleapp.ui.fragments.settings.library.LibraryPrefs
+import io.matthewnelson.sampleapp.ui.fragments.settings.library.components.LibraryPrefs
 import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.notification.ServiceNotification
 import io.matthewnelson.topl_service.lifecycle.BackgroundManager

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -78,6 +78,7 @@ import io.matthewnelson.sampleapp.ui.fragments.settings.library.LibraryPrefs
 import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.notification.ServiceNotification
 import io.matthewnelson.topl_service.lifecycle.BackgroundManager
+import io.matthewnelson.topl_service.util.ServiceConsts.BackgroundPolicy
 
 /**
  * @suppress
@@ -128,18 +129,18 @@ class App: Application() {
          * */
         fun generateBackgroundManagerPolicy(
             prefs: Prefs,
-            policy: String? = null,
+            @BackgroundPolicy policy: String? = null,
             killApp: Boolean? = null,
             executionDelay: Int? = null
         ): BackgroundManager.Builder.Policy {
             val builder = BackgroundManager.Builder()
             return when (policy ?: LibraryPrefs.getBackgroundManagerPolicySetting(prefs)) {
-                LibraryPrefs.BACKGROUND_MANAGER_POLICY_FOREGROUND -> {
+                BackgroundPolicy.RUN_IN_FOREGROUND -> {
                     builder.runServiceInForeground(
                         killApp ?: LibraryPrefs.getBackgroundManagerKillAppSetting(prefs)
                     )
                 }
-                LibraryPrefs.BACKGROUND_MANAGER_POLICY_RESPECT -> {
+                BackgroundPolicy.RESPECT_RESOURCES -> {
                     builder.respectResourcesWhileInBackground(
                         executionDelay ?: LibraryPrefs.getBackgroundManagerExecuteDelaySetting(prefs)
                     )

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyEventBroadcaster.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyEventBroadcaster.kt
@@ -69,6 +69,7 @@ package io.matthewnelson.sampleapp.topl_android
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import io.matthewnelson.sampleapp.ui.fragments.home.LogMessageAdapter
+import io.matthewnelson.topl_service.service.components.onionproxy.model.TorPortInfo
 import io.matthewnelson.topl_service.service.components.onionproxy.model.TorServiceEventBroadcaster
 import io.matthewnelson.topl_service.util.ServiceUtilities
 
@@ -80,36 +81,14 @@ import io.matthewnelson.topl_service.util.ServiceUtilities
 class MyEventBroadcaster: TorServiceEventBroadcaster() {
 
 
-    //////////////////////////
-    /// ControlPortAddress ///
-    //////////////////////////
-    private val _liveControlPortAddress = MutableLiveData<String?>(null)
-    val liveControlPortAddress: LiveData<String?> = _liveControlPortAddress
+    ///////////////////
+    /// TorPortInfo ///
+    ///////////////////
+    private val _liveTorPortInfo = MutableLiveData<TorPortInfo>(null)
+    val liveTorPortInfo: LiveData<TorPortInfo> = _liveTorPortInfo
 
-    override fun broadcastControlPortAddress(controlPortAddress: String?) {
-        _liveControlPortAddress.value = controlPortAddress
-    }
-
-
-    ////////////////////////
-    /// SocksPortAddress ///
-    ////////////////////////
-    private val _liveSocksPortAddress = MutableLiveData<String?>(null)
-    val liveSocksPortAddress: LiveData<String?> = _liveSocksPortAddress
-
-    override fun broadcastSocksPortAddress(socksPortAddress: String?) {
-        _liveSocksPortAddress.value = socksPortAddress
-    }
-
-
-    ///////////////////////
-    /// HttpPortAddress ///
-    ///////////////////////
-    private val _liveHttpPortAddress = MutableLiveData<String?>(null)
-    val liveHttpPortAddress: LiveData<String?> = _liveHttpPortAddress
-
-    override fun broadcastHttpPortAddress(httpPortAddress: String?) {
-        _liveHttpPortAddress.value = httpPortAddress
+    override fun broadcastPortInformation(torPortInfo: TorPortInfo) {
+        _liveTorPortInfo.value = torPortInfo
     }
 
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyEventBroadcaster.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyEventBroadcaster.kt
@@ -69,7 +69,7 @@ package io.matthewnelson.sampleapp.topl_android
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import io.matthewnelson.sampleapp.ui.fragments.home.LogMessageAdapter
-import io.matthewnelson.topl_service.service.components.onionproxy.TorServiceEventBroadcaster
+import io.matthewnelson.topl_service.service.components.onionproxy.model.TorServiceEventBroadcaster
 import io.matthewnelson.topl_service.util.ServiceUtilities
 
 /**

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyTorSettings.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyTorSettings.kt
@@ -78,7 +78,12 @@ class MyTorSettings: TorSettings() {
         get() = DEFAULT__DISABLE_NETWORK
 
     override val dnsPort: String
-        get() = DEFAULT__DNS_PORT
+        get() = PortOption.DISABLED
+
+    override val dnsPortIsolationFlags: List<@IsolationFlag String>?
+        get() = arrayListOf(
+            IsolationFlag.ISOLATE_CLIENT_PROTOCOL
+        )
 
     override val customTorrc: String?
         get() = null
@@ -93,10 +98,15 @@ class MyTorSettings: TorSettings() {
         get() = DEFAULT__EXIT_NODES
 
     override val httpTunnelPort: String
-        get() = "auto"
+        get() = PortOption.DISABLED
 
-    override val listOfSupportedBridges: List<@SupportedBridges String>
-        get() = arrayListOf(SupportedBridges.MEEK, SupportedBridges.OBFS4)
+    override val httpTunnelPortIsolationFlags: List<@IsolationFlag String>?
+        get() = arrayListOf(
+            IsolationFlag.ISOLATE_CLIENT_PROTOCOL
+        )
+
+    override val listOfSupportedBridges: List<@SupportedBridgeType String>
+        get() = arrayListOf(SupportedBridgeType.MEEK, SupportedBridgeType.OBFS4)
 
     override val proxyHost: String?
         get() = DEFAULT__PROXY_HOST
@@ -113,8 +123,8 @@ class MyTorSettings: TorSettings() {
     override val proxySocks5ServerPort: Int?
         get() = null
 
-    override val proxyType: String?
-        get() = DEFAULT__PROXY_TYPE
+    override val proxyType: @ProxyType String
+        get() = ProxyType.DISABLED
 
     override val proxyUser: String?
         get() = DEFAULT__PROXY_USER
@@ -125,11 +135,19 @@ class MyTorSettings: TorSettings() {
     override val relayNickname: String?
         get() = DEFAULT__RELAY_NICKNAME
 
-    override val relayPort: Int?
-        get() = null
+    override val relayPort: String
+        get() = DEFAULT__RELAY_PORT
 
     override val socksPort: String
-        get() = "auto"
+        get() = PortOption.AUTO
+
+    override val socksPortIsolationFlags: List<@IsolationFlag String>?
+        get() = arrayListOf(
+            IsolationFlag.KEEP_ALIVE_ISOLATE_SOCKS_AUTH,
+            IsolationFlag.IPV6_TRAFFIC,
+            IsolationFlag.PREFER_IPV6,
+            IsolationFlag.ISOLATE_CLIENT_PROTOCOL
+        )
 
     override val virtualAddressNetwork: String?
         get() = "10.192.0.2/10"
@@ -138,7 +156,7 @@ class MyTorSettings: TorSettings() {
         get() = DEFAULT__HAS_BRIDGES
 
     override val connectionPadding: @ConnectionPadding String
-        get() = DEFAULT__HAS_CONNECTION_PADDING
+        get() = ConnectionPadding.OFF
 
     override val hasCookieAuthentication: Boolean
         get() = DEFAULT__HAS_COOKIE_AUTHENTICATION
@@ -148,9 +166,6 @@ class MyTorSettings: TorSettings() {
 
     override val hasDormantCanceledByStartup: Boolean
         get() = DEFAULT__HAS_DORMANT_CANCELED_BY_STARTUP
-
-    override val hasIsolationAddressFlagForTunnel: Boolean
-        get() = DEFAULT__HAS_ISOLATION_ADDRESS_FLAG_FOR_TUNNEL
 
     override val hasOpenProxyOnAllInterfaces: Boolean
         get() = DEFAULT__HAS_OPEN_PROXY_ON_ALL_INTERFACES
@@ -180,7 +195,12 @@ class MyTorSettings: TorSettings() {
         get() = DEFAULT__RUN_AS_DAEMON
 
     override val transPort: String
-        get() = DEFAULT__TRANS_PORT
+        get() = PortOption.DISABLED
+
+    override val transPortIsolationFlags: List<@IsolationFlag String>?
+        get() = arrayListOf(
+            IsolationFlag.ISOLATE_CLIENT_PROTOCOL
+        )
 
     override val useSocks5: Boolean
         get() = DEFAULT__USE_SOCKS5

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyTorSettings.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyTorSettings.kt
@@ -136,7 +136,7 @@ class MyTorSettings: TorSettings() {
         get() = DEFAULT__RELAY_NICKNAME
 
     override val relayPort: String
-        get() = DEFAULT__RELAY_PORT
+        get() = PortOption.DISABLED
 
     override val socksPort: String
         get() = PortOption.AUTO

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashMessage.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashMessage.kt
@@ -1,11 +1,14 @@
 package io.matthewnelson.sampleapp.ui.fragments.dashboard
 
+import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
+import io.matthewnelson.sampleapp.R
 
 class DashMessage(
     val message: String,
     @DrawableRes val background: Int,
-    val showLength: Long
+    val showLength: Long,
+    @ColorRes val textColor: Int = R.color.tor_service_white
 ) {
     companion object {
         const val EXCEPTION = "~~~ EXCEPTION ~~~\n"

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashboardFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashboardFragment.kt
@@ -13,7 +13,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
-import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.*
@@ -146,7 +145,13 @@ class DashboardFragment : Fragment() {
             buttonAppRestart.isEnabled = false
             HomeFragment.appIsBeingKilled()
 
-            Toast.makeText(context, "Killing Application", Toast.LENGTH_LONG).show()
+            showMessage(
+                DashMessage(
+                    "Application is being killed",
+                    R.drawable.dash_message_color_red,
+                    10_000
+                )
+            )
 
             TorServiceController.appEventBroadcaster?.let {
                 (it as MyEventBroadcaster).liveTorState.observe(owner, Observer { data ->

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashboardFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashboardFragment.kt
@@ -50,9 +50,9 @@ class DashboardFragment : Fragment() {
     private lateinit var textViewState: TextView
 
     // Bottom row
-    private lateinit var textViewControlPort: TextView
-    private lateinit var textViewSocksPort: TextView
+    private lateinit var textViewDnsPort: TextView
     private lateinit var textViewHttpPort: TextView
+    private lateinit var textViewSocksPort: TextView
 
     // Messages
     private lateinit var textViewMessage: TextView
@@ -83,9 +83,9 @@ class DashboardFragment : Fragment() {
         textViewBandwidth = view.findViewById(R.id.dash_text_view_bandwidth)
         textViewNetworkState = view.findViewById(R.id.dash_text_view_tor_network_state)
         textViewState = view.findViewById(R.id.dash_text_view_tor_state)
-        textViewControlPort = view.findViewById(R.id.dash_text_view_port_control)
-        textViewSocksPort = view.findViewById(R.id.dash_text_view_port_socks)
+        textViewDnsPort = view.findViewById(R.id.dash_text_view_port_dns)
         textViewHttpPort = view.findViewById(R.id.dash_text_view_port_http)
+        textViewSocksPort = view.findViewById(R.id.dash_text_view_port_socks)
         textViewMessage = view.findViewById(R.id.dash_text_view_message)
         buttonAppRestart = view.findViewById(R.id.dash_button_app_restart)
     }
@@ -121,9 +121,9 @@ class DashboardFragment : Fragment() {
         }
         TorServiceController.appEventBroadcaster?.let {
             (it as MyEventBroadcaster).liveTorPortInfo.observe(owner, Observer { data ->
-                textViewControlPort.text = data?.controlPort ?: "-----"
-                textViewSocksPort.text = data?.socksPort ?: "-----"
+                textViewDnsPort.text = data?.dnsPort ?: "-----"
                 textViewHttpPort.text = data?.httpPort ?: "-----"
+                textViewSocksPort.text = data?.socksPort ?: "-----"
             })
         }
     }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashboardFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashboardFragment.kt
@@ -5,6 +5,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
 import androidx.fragment.app.Fragment
@@ -13,6 +14,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
+import androidx.annotation.ColorRes
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.*
@@ -98,6 +100,8 @@ class DashboardFragment : Fragment() {
         liveDashMessage.observe(owner, Observer {
             if (it != null) {
                 textViewMessage.text = it.message
+                val colorHex = colorResToHexString(textViewMessage.context, it.textColor)
+                textViewMessage.setTextColor(Color.parseColor(colorHex))
                 textViewMessage.background = ContextCompat.getDrawable(textViewMessage.context, it.background)
                 textViewMessage.visibility = View.VISIBLE
                 launchCleanUpMessageJob(it.showLength)
@@ -126,6 +130,9 @@ class DashboardFragment : Fragment() {
             })
         }
     }
+
+    private fun colorResToHexString(context: Context, @ColorRes colorRes: Int): String =
+        "#${Integer.toHexString(ContextCompat.getColor(context, colorRes))}"
 
     private var showMessageCleanUpJob: Job? = null
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashboardFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashboardFragment.kt
@@ -120,18 +120,10 @@ class DashboardFragment : Fragment() {
             })
         }
         TorServiceController.appEventBroadcaster?.let {
-            (it as MyEventBroadcaster).liveControlPortAddress.observe(owner, Observer { data ->
-                textViewControlPort.text = data ?: "None"
-            })
-        }
-        TorServiceController.appEventBroadcaster?.let {
-            (it as MyEventBroadcaster).liveSocksPortAddress.observe(owner, Observer { data ->
-                textViewSocksPort.text = data ?: "None"
-            })
-        }
-        TorServiceController.appEventBroadcaster?.let {
-            (it as MyEventBroadcaster).liveHttpPortAddress.observe(owner, Observer { data ->
-                textViewHttpPort.text = data ?: "None"
+            (it as MyEventBroadcaster).liveTorPortInfo.observe(owner, Observer { data ->
+                textViewControlPort.text = data?.controlPort ?: "-----"
+                textViewSocksPort.text = data?.socksPort ?: "-----"
+                textViewHttpPort.text = data?.httpPort ?: "-----"
             })
         }
     }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashboardFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashboardFragment.kt
@@ -143,7 +143,7 @@ class DashboardFragment : Fragment() {
 
     private fun initButtons(context: Context, owner: LifecycleOwner) {
         buttonAppRestart.setOnClickListener {
-            buttonAppRestart.visibility = View.GONE
+            buttonAppRestart.isEnabled = false
             HomeFragment.appIsBeingKilled()
 
             Toast.makeText(context, "Killing Application", Toast.LENGTH_LONG).show()

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/CloseKeyBoardNavListener.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/CloseKeyBoardNavListener.kt
@@ -8,6 +8,14 @@ import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 
 class CloseKeyBoardNavListener(private val view: View): NavController.OnDestinationChangedListener {
+
+    companion object {
+        fun closeKeyboard(view: View) {
+            val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
+            imm?.hideSoftInputFromWindow(view.windowToken, 0)
+        }
+    }
+
     private var startLock: Any? = null
 
     override fun onDestinationChanged(
@@ -20,12 +28,7 @@ class CloseKeyBoardNavListener(private val view: View): NavController.OnDestinat
             return
         }
 
-        closeKeyboard()
+        closeKeyboard(view)
         controller.removeOnDestinationChangedListener(this)
-    }
-
-    private fun closeKeyboard() {
-        val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
-        imm?.hideSoftInputFromWindow(view.windowToken, 0)
     }
 }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/CloseKeyBoardNavListener.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/CloseKeyBoardNavListener.kt
@@ -1,0 +1,31 @@
+package io.matthewnelson.sampleapp.ui.fragments.settings
+
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination
+
+class CloseKeyBoardNavListener(private val view: View): NavController.OnDestinationChangedListener {
+    private var startLock: Any? = null
+
+    override fun onDestinationChanged(
+        controller: NavController,
+        destination: NavDestination,
+        arguments: Bundle?
+    ) {
+        if (startLock == null) {
+            startLock = Any()
+            return
+        }
+
+        closeKeyboard()
+        controller.removeOnDestinationChangedListener(this)
+    }
+
+    private fun closeKeyboard() {
+        val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
+        imm?.hideSoftInputFromWindow(view.windowToken, 0)
+    }
+}

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/CloseKeyBoardNavListener.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/CloseKeyBoardNavListener.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.sampleapp.ui.fragments.settings
 
 import android.content.Context

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/app/SettingsAppFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/app/SettingsAppFragment.kt
@@ -71,7 +71,9 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.navigation.fragment.findNavController
 import io.matthewnelson.sampleapp.R
+import io.matthewnelson.sampleapp.ui.fragments.settings.CloseKeyBoardNavListener
 
 class SettingsAppFragment : Fragment() {
 
@@ -85,6 +87,8 @@ class SettingsAppFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        findNavController().addOnDestinationChangedListener(CloseKeyBoardNavListener(view))
     }
 
     override fun onDestroyView() {

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/BackgroundManagerOptions.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/BackgroundManagerOptions.kt
@@ -6,6 +6,8 @@ import android.view.View
 import android.widget.*
 import io.matthewnelson.encrypted_storage.Prefs
 import io.matthewnelson.sampleapp.R
+import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
+import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
 import io.matthewnelson.topl_service.util.ServiceConsts.BackgroundPolicy
 
 class BackgroundManagerOptions(view: View, prefs: Prefs) {
@@ -29,12 +31,12 @@ class BackgroundManagerOptions(view: View, prefs: Prefs) {
     var killApp: Boolean = initialKillApp
         private set
 
-    fun saveSettings(context: Context, prefs: Prefs): Boolean? {
+    fun saveSettings(prefs: Prefs): Boolean? {
         var somethingChanged = false
 
         when (policy) {
             BackgroundPolicy.RESPECT_RESOURCES -> {
-                val executionDelay = getExecutionDelay(context) ?: return null
+                val executionDelay = getExecutionDelay() ?: return null
                 if (executionDelay != initialExecutionDelay) {
                     prefs.write(LibraryPrefs.BACKGROUND_MANAGER_EXECUTE_DELAY, executionDelay)
                     initialExecutionDelay = executionDelay
@@ -59,7 +61,7 @@ class BackgroundManagerOptions(view: View, prefs: Prefs) {
         return somethingChanged
     }
 
-    fun getExecutionDelay(context: Context): Int? {
+    fun getExecutionDelay(): Int? {
         var executionDelay: Int? = null
         try {
             val value = editTextDelay.text.toString().toInt()
@@ -68,9 +70,13 @@ class BackgroundManagerOptions(view: View, prefs: Prefs) {
         } catch (e: Exception) {}
 
         if (executionDelay == null)
-            Toast.makeText(
-                context, "Execution Delay must be between 5 and 45 seconds", Toast.LENGTH_SHORT
-            ).show()
+            DashboardFragment.showMessage(
+                DashMessage(
+                    "${DashMessage.EXCEPTION}Execution Delay must be between 5 and 45 seconds",
+                    R.drawable.dash_message_color_red,
+                    5_000
+                )
+            )
 
         return executionDelay
     }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/BackgroundManagerOptions.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/BackgroundManagerOptions.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.widget.*
 import io.matthewnelson.encrypted_storage.Prefs
 import io.matthewnelson.sampleapp.R
+import io.matthewnelson.topl_service.util.ServiceConsts.BackgroundPolicy
 
 class BackgroundManagerOptions(view: View, prefs: Prefs) {
 
@@ -32,7 +33,7 @@ class BackgroundManagerOptions(view: View, prefs: Prefs) {
         var somethingChanged = false
 
         when (policy) {
-            LibraryPrefs.BACKGROUND_MANAGER_POLICY_RESPECT -> {
+            BackgroundPolicy.RESPECT_RESOURCES -> {
                 val executionDelay = getExecutionDelay(context) ?: return null
                 if (executionDelay != initialExecutionDelay) {
                     prefs.write(LibraryPrefs.BACKGROUND_MANAGER_EXECUTE_DELAY, executionDelay)
@@ -40,7 +41,7 @@ class BackgroundManagerOptions(view: View, prefs: Prefs) {
                     somethingChanged = true
                 }
             }
-            LibraryPrefs.BACKGROUND_MANAGER_POLICY_FOREGROUND -> {
+            BackgroundPolicy.RUN_IN_FOREGROUND -> {
                 if (killApp != initialKillApp) {
                     prefs.write(LibraryPrefs.BACKGROUND_MANAGER_KILL_APP, killApp)
                     initialKillApp = killApp
@@ -112,11 +113,11 @@ class BackgroundManagerOptions(view: View, prefs: Prefs) {
 
     private fun setBackgroundManagerPolicySpinnerValue() {
         when (initialPolicy) {
-            LibraryPrefs.BACKGROUND_MANAGER_POLICY_RESPECT -> {
+            BackgroundPolicy.RESPECT_RESOURCES -> {
                 executionDelayOptionVisibility(true)
                 spinnerPolicy.setSelection(0)
             }
-            LibraryPrefs.BACKGROUND_MANAGER_POLICY_FOREGROUND -> {
+            BackgroundPolicy.RUN_IN_FOREGROUND -> {
                 executionDelayOptionVisibility(false)
                 spinnerPolicy.setSelection(1)
             }
@@ -173,11 +174,11 @@ class BackgroundManagerOptions(view: View, prefs: Prefs) {
                     policy = when (item.toString()) {
                         RESPECT_RESOURCES -> {
                             executionDelayOptionVisibility(true)
-                            LibraryPrefs.BACKGROUND_MANAGER_POLICY_RESPECT
+                            BackgroundPolicy.RESPECT_RESOURCES
                         }
                         FOREGROUND -> {
                             executionDelayOptionVisibility(false)
-                            LibraryPrefs.BACKGROUND_MANAGER_POLICY_FOREGROUND
+                            BackgroundPolicy.RUN_IN_FOREGROUND
                         }
                         else -> {
                             return

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/LibraryPrefs.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/LibraryPrefs.kt
@@ -4,6 +4,7 @@ import androidx.core.app.NotificationCompat
 import io.matthewnelson.encrypted_storage.Prefs
 import io.matthewnelson.sampleapp.BuildConfig
 import io.matthewnelson.sampleapp.R
+import io.matthewnelson.topl_service.util.ServiceConsts.BackgroundPolicy
 
 object LibraryPrefs {
 
@@ -18,10 +19,6 @@ object LibraryPrefs {
     const val BACKGROUND_MANAGER_POLICY = "BACKGROUND_MANAGER_POLICY"
     const val BACKGROUND_MANAGER_EXECUTE_DELAY = "BACKGROUND_MANAGER_EXECUTE_DELAY"
     const val BACKGROUND_MANAGER_KILL_APP = "BACKGROUND_MANAGER_KILL_APP"
-
-    // values
-    const val BACKGROUND_MANAGER_POLICY_RESPECT = "BACKGROUND_MANAGER_POLICY_RESPECT"
-    const val BACKGROUND_MANAGER_POLICY_FOREGROUND = "BACKGROUND_MANAGER_POLICY_FOREGROUND"
 
     // Controller Keys
     const val CONTROLLER_BUILD_CONFIG_DEBUG = "CONTROLLER_BUILD_CONFIG_DEBUG"
@@ -47,7 +44,7 @@ object LibraryPrefs {
 
     // Background Manager Settings
     fun getBackgroundManagerPolicySetting(prefs: Prefs): String =
-        prefs.read(BACKGROUND_MANAGER_POLICY, BACKGROUND_MANAGER_POLICY_RESPECT) ?: BACKGROUND_MANAGER_POLICY_RESPECT
+        prefs.read(BACKGROUND_MANAGER_POLICY, BackgroundPolicy.RESPECT_RESOURCES) ?: BackgroundPolicy.RESPECT_RESOURCES
 
     fun getBackgroundManagerExecuteDelaySetting(prefs: Prefs): Int =
         prefs.read(BACKGROUND_MANAGER_EXECUTE_DELAY, 20)

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/SettingsLibraryFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/SettingsLibraryFragment.kt
@@ -177,6 +177,10 @@ class SettingsLibraryFragment : Fragment() {
             DashboardFragment.showMessage(
                 DashMessage("Settings Saved", R.drawable.dash_message_color_green, 3_000L)
             )
+        } else {
+            DashboardFragment.showMessage(
+                DashMessage("No Changes", R.drawable.dash_message_color_secondary_light, 2_000)
+            )
         }
     }
 }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/SettingsLibraryFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/SettingsLibraryFragment.kt
@@ -78,6 +78,9 @@ import io.matthewnelson.sampleapp.App
 import io.matthewnelson.sampleapp.R
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
+import io.matthewnelson.sampleapp.ui.fragments.settings.library.components.BackgroundManagerOptions
+import io.matthewnelson.sampleapp.ui.fragments.settings.library.components.ControllerOptions
+import io.matthewnelson.sampleapp.ui.fragments.settings.library.components.NotificationOptions
 import io.matthewnelson.topl_service.util.ServiceConsts.BackgroundPolicy
 
 class SettingsLibraryFragment : Fragment() {
@@ -98,9 +101,21 @@ class SettingsLibraryFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         prefs = Prefs.createUnencrypted(App.PREFS_NAME, view.context)
-        notificationOptions = NotificationOptions(view, prefs)
-        backgroundManagerOptions = BackgroundManagerOptions(view, prefs)
-        controllerOptions = ControllerOptions(view, prefs)
+        notificationOptions =
+            NotificationOptions(
+                view,
+                prefs
+            )
+        backgroundManagerOptions =
+            BackgroundManagerOptions(
+                view,
+                prefs
+            )
+        controllerOptions =
+            ControllerOptions(
+                view,
+                prefs
+            )
 
         view.findViewById<Button>(R.id.settings_library_button_save).setOnClickListener {
             saveSettings(view.context.applicationContext as Application)

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/SettingsLibraryFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/SettingsLibraryFragment.kt
@@ -179,7 +179,12 @@ class SettingsLibraryFragment : Fragment() {
             )
         } else {
             DashboardFragment.showMessage(
-                DashMessage("No Changes", R.drawable.dash_message_color_secondary_light, 2_000)
+                DashMessage(
+                    "No Changes",
+                    R.drawable.dash_message_color_secondary_light,
+                    2_000,
+                    R.color.black
+                )
             )
         }
     }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/SettingsLibraryFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/SettingsLibraryFragment.kt
@@ -73,11 +73,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import androidx.navigation.fragment.findNavController
 import io.matthewnelson.encrypted_storage.Prefs
 import io.matthewnelson.sampleapp.App
 import io.matthewnelson.sampleapp.R
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
+import io.matthewnelson.sampleapp.ui.fragments.settings.CloseKeyBoardNavListener
 import io.matthewnelson.sampleapp.ui.fragments.settings.library.components.BackgroundManagerOptions
 import io.matthewnelson.sampleapp.ui.fragments.settings.library.components.ControllerOptions
 import io.matthewnelson.sampleapp.ui.fragments.settings.library.components.NotificationOptions
@@ -101,21 +103,11 @@ class SettingsLibraryFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         prefs = Prefs.createUnencrypted(App.PREFS_NAME, view.context)
-        notificationOptions =
-            NotificationOptions(
-                view,
-                prefs
-            )
-        backgroundManagerOptions =
-            BackgroundManagerOptions(
-                view,
-                prefs
-            )
-        controllerOptions =
-            ControllerOptions(
-                view,
-                prefs
-            )
+        notificationOptions = NotificationOptions(view, prefs)
+        backgroundManagerOptions = BackgroundManagerOptions(view, prefs)
+        controllerOptions = ControllerOptions(view, prefs)
+
+        findNavController().addOnDestinationChangedListener(CloseKeyBoardNavListener(view))
 
         view.findViewById<Button>(R.id.settings_library_button_save).setOnClickListener {
             saveSettings(view.context.applicationContext as Application)
@@ -125,9 +117,6 @@ class SettingsLibraryFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
     }
-
-    private fun isBackgroundManagerPolicyRespectResources(): Boolean =
-        backgroundManagerOptions.policy == BackgroundPolicy.RESPECT_RESOURCES
 
     private fun saveSettings(application: Application) {
         val backgroundManagerPolicy = App.generateBackgroundManagerPolicy(

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/SettingsLibraryFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/SettingsLibraryFragment.kt
@@ -114,7 +114,7 @@ class SettingsLibraryFragment : Fragment() {
     }
 
     private fun isBackgroundManagerPolicyRespectResources(): Boolean =
-        backgroundManagerOptions.policy == LibraryPrefs.BACKGROUND_MANAGER_POLICY_RESPECT
+        backgroundManagerOptions.policy == BackgroundPolicy.RESPECT_RESOURCES
 
     private fun saveSettings(context: Context) {
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/SettingsLibraryFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/SettingsLibraryFragment.kt
@@ -110,7 +110,7 @@ class SettingsLibraryFragment : Fragment() {
         findNavController().addOnDestinationChangedListener(CloseKeyBoardNavListener(view))
 
         view.findViewById<Button>(R.id.settings_library_button_save).setOnClickListener {
-            saveSettings(view.context.applicationContext as Application)
+            saveSettings(view)
         }
     }
 
@@ -118,7 +118,9 @@ class SettingsLibraryFragment : Fragment() {
         super.onDestroyView()
     }
 
-    private fun saveSettings(application: Application) {
+    private fun saveSettings(view: View) {
+        CloseKeyBoardNavListener.closeKeyboard(view)
+
         val backgroundManagerPolicy = App.generateBackgroundManagerPolicy(
             prefs,
             backgroundManagerOptions.policy,
@@ -143,7 +145,7 @@ class SettingsLibraryFragment : Fragment() {
 
         try {
             App.setupTorServices(
-                application,
+                view.context.applicationContext as Application,
                 notificationBuilder,
                 backgroundManagerPolicy,
                 controllerOptions.getRestartDelayValue(),

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/SettingsLibraryFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/SettingsLibraryFragment.kt
@@ -154,11 +154,11 @@ class SettingsLibraryFragment : Fragment() {
         } catch (e: Exception) {
             e.message?.let {
                 val msg = if (it.contains(BackgroundPolicy.RUN_IN_FOREGROUND))
-                        "${DashMessage.EXCEPTION}Selected Controller option\n" +
-                                ">>> ${ControllerOptions.DO_NOT_STOP_SERVICE} <<<\n" +
-                                "requires BackgroundManager Policy of\n" +
-                                ">>> ${BackgroundManagerOptions.FOREGROUND} <<< and\n" +
-                                ">>> ${BackgroundManagerOptions.KILL_APP} <<<"
+                        "${DashMessage.EXCEPTION}Selected Controller option " +
+                                "'${ControllerOptions.DO_NOT_STOP_SERVICE}' " +
+                                "requires BackgroundManager Policy of " +
+                                "'${BackgroundManagerOptions.FOREGROUND}' and " +
+                                "'${BackgroundManagerOptions.KILL_APP}'"
                     else
                         it
                 DashboardFragment.showMessage(

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/BackgroundManagerOptions.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/BackgroundManagerOptions.kt
@@ -1,4 +1,4 @@
-package io.matthewnelson.sampleapp.ui.fragments.settings.library
+package io.matthewnelson.sampleapp.ui.fragments.settings.library.components
 
 import android.content.Context
 import android.text.InputFilter
@@ -21,13 +21,22 @@ class BackgroundManagerOptions(view: View, prefs: Prefs) {
         const val NO_KILL_APP = "Don't Kill Application"
     }
 
-    private var initialPolicy: String = LibraryPrefs.getBackgroundManagerPolicySetting(prefs)
+    private var initialPolicy: String =
+        LibraryPrefs.getBackgroundManagerPolicySetting(
+            prefs
+        )
     var policy: String = initialPolicy
         private set
 
-    private var initialExecutionDelay: Int = LibraryPrefs.getBackgroundManagerExecuteDelaySetting(prefs)
+    private var initialExecutionDelay: Int =
+        LibraryPrefs.getBackgroundManagerExecuteDelaySetting(
+            prefs
+        )
 
-    private var initialKillApp: Boolean = LibraryPrefs.getBackgroundManagerKillAppSetting(prefs)
+    private var initialKillApp: Boolean =
+        LibraryPrefs.getBackgroundManagerKillAppSetting(
+            prefs
+        )
     var killApp: Boolean = initialKillApp
         private set
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/BackgroundManagerOptions.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/BackgroundManagerOptions.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.sampleapp.ui.fragments.settings.library.components
 
 import android.content.Context

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/ControllerOptions.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/ControllerOptions.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.sampleapp.ui.fragments.settings.library.components
 
 import android.content.Context

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/ControllerOptions.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/ControllerOptions.kt
@@ -1,4 +1,4 @@
-package io.matthewnelson.sampleapp.ui.fragments.settings.library
+package io.matthewnelson.sampleapp.ui.fragments.settings.library.components
 
 import android.content.Context
 import android.text.InputFilter
@@ -21,15 +21,27 @@ class ControllerOptions(view: View, prefs: Prefs) {
         const val RELEASE = "Release"
     }
 
-    private var initialRestartDelayTime: Long = LibraryPrefs.getControllerRestartDelaySetting(prefs)
+    private var initialRestartDelayTime: Long =
+        LibraryPrefs.getControllerRestartDelaySetting(
+            prefs
+        )
 
-    private var initialStopDelayTime: Long = LibraryPrefs.getControllerStopDelaySetting(prefs)
+    private var initialStopDelayTime: Long =
+        LibraryPrefs.getControllerStopDelaySetting(
+            prefs
+        )
 
-    private var initialDisableStopServiceOnTaskRemoved: Boolean = LibraryPrefs.getControllerDisableStopServiceOnTaskRemovedSetting(prefs)
+    private var initialDisableStopServiceOnTaskRemoved: Boolean =
+        LibraryPrefs.getControllerDisableStopServiceOnTaskRemovedSetting(
+            prefs
+        )
     var disableStopServiceOnTaskRemoved: Boolean = initialDisableStopServiceOnTaskRemoved
         private set
 
-    private var initialBuildConfigDebug: Boolean = LibraryPrefs.getControllerBuildConfigDebugSetting(prefs)
+    private var initialBuildConfigDebug: Boolean =
+        LibraryPrefs.getControllerBuildConfigDebugSetting(
+            prefs
+        )
     var buildConfigDebug: Boolean = initialBuildConfigDebug
         private set
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/LibraryPrefs.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/LibraryPrefs.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.sampleapp.ui.fragments.settings.library.components
 
 import androidx.core.app.NotificationCompat

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/LibraryPrefs.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/LibraryPrefs.kt
@@ -1,4 +1,4 @@
-package io.matthewnelson.sampleapp.ui.fragments.settings.library
+package io.matthewnelson.sampleapp.ui.fragments.settings.library.components
 
 import androidx.core.app.NotificationCompat
 import io.matthewnelson.encrypted_storage.Prefs

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/NotificationOptions.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/NotificationOptions.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.sampleapp.ui.fragments.settings.library.components
 
 import android.content.Context

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/NotificationOptions.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/library/components/NotificationOptions.kt
@@ -1,4 +1,4 @@
-package io.matthewnelson.sampleapp.ui.fragments.settings.library
+package io.matthewnelson.sampleapp.ui.fragments.settings.library.components
 
 import android.content.Context
 import android.view.View

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/DnsPortOption.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/DnsPortOption.kt
@@ -1,0 +1,146 @@
+package io.matthewnelson.sampleapp.ui.fragments.settings.tor
+
+import android.content.Context
+import android.text.InputFilter
+import android.view.View
+import android.widget.*
+import io.matthewnelson.sampleapp.R
+import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
+import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
+import io.matthewnelson.topl_core_base.BaseConsts
+import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
+
+class DnsPortOption(view: View, private val serviceTorSettings: ServiceTorSettings) {
+
+    // Views
+    private lateinit var spinnerDnsPort: Spinner
+    private lateinit var adapterDnsPort: ArrayAdapter<String>
+    private lateinit var listenerDnsPort: DnsPortSelectionListener
+    private lateinit var textViewDnsPortCustom: TextView
+    private lateinit var editTextDnsPortCustom: EditText
+
+    private var initialDnsPort = serviceTorSettings.dnsPort
+
+    fun saveDnsPort(): Any? {
+        val dnsPort = when (adapterDnsPort.getItem(listenerDnsPort.position)) {
+            SettingsTorFragment.AUTO -> {
+                BaseConsts.PortOption.AUTO
+            }
+            SettingsTorFragment.DISABLED -> {
+                BaseConsts.PortOption.DISABLED
+            }
+            else -> {
+                editTextDnsPortCustom.text.toString()
+            }
+        }
+
+        try {
+            serviceTorSettings.dnsPortSave(dnsPort)
+            initialDnsPort = dnsPort
+        } catch (e: IllegalArgumentException) {
+            DashboardFragment.showMessage(
+                DashMessage("${DashMessage.EXCEPTION}${e.message}",
+                    R.drawable.dash_message_color_red,
+                    4_000
+                )
+            )
+            return null
+        }
+        return Any()
+    }
+
+    init {
+        findViews(view)
+        setViewParameters()
+        initSpinnerTorDnsPort(view.context)
+    }
+
+    private fun findViews(view: View) {
+        spinnerDnsPort = view.findViewById(R.id.settings_tor_spinner_dns_port)
+        textViewDnsPortCustom = view.findViewById(R.id.settings_tor_text_view_dns_port_custom)
+        editTextDnsPortCustom = view.findViewById(R.id.settings_tor_edit_text_dns_port_custom)
+    }
+
+    private fun setViewParameters() {
+        editTextDnsPortCustom.filters = arrayOf(InputFilter.LengthFilter(5))
+    }
+
+    private fun initSpinnerTorDnsPort(context: Context) {
+        val categorySocksPort = arrayOf(
+            SettingsTorFragment.AUTO,
+            SettingsTorFragment.CUSTOM,
+            SettingsTorFragment.DISABLED
+        )
+        adapterDnsPort = ArrayAdapter(context, R.layout.spinner_list_item, categorySocksPort)
+        adapterDnsPort.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        spinnerDnsPort.adapter = adapterDnsPort
+        setDnsPortSpinnerValue()
+        listenerDnsPort = DnsPortSelectionListener()
+        spinnerDnsPort.onItemSelectedListener = listenerDnsPort
+    }
+
+    private fun setDnsPortSpinnerValue() {
+        when (initialDnsPort) {
+            BaseConsts.PortOption.AUTO -> {
+                dnsPortCustomVisibility(false)
+                spinnerDnsPort.setSelection(0)
+            }
+            BaseConsts.PortOption.DISABLED -> {
+                dnsPortCustomVisibility(false)
+                spinnerDnsPort.setSelection(2)
+            }
+            else -> {
+                editTextDnsPortCustom.setText(initialDnsPort)
+                spinnerDnsPort.setSelection(1)
+                dnsPortCustomVisibility(true)
+            }
+        }
+    }
+
+    private fun dnsPortCustomVisibility(show: Boolean) {
+        textViewDnsPortCustom.visibility = if (show) View.VISIBLE else View.GONE
+        editTextDnsPortCustom.visibility = if (show) View.VISIBLE else View.GONE
+    }
+
+    private inner class DnsPortSelectionListener: AdapterView.OnItemSelectedListener {
+        var position = 0
+            private set
+        var count = 0
+            private set
+
+        override fun onNothingSelected(parent: AdapterView<*>?) {}
+
+        override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+            this.position = position
+
+            if (count == 0) {
+                count ++
+                return
+            }
+
+            when (parent?.getItemAtPosition(position).toString()) {
+                SettingsTorFragment.AUTO -> {
+                    dnsPortCustomVisibility(false)
+                }
+                SettingsTorFragment.CUSTOM -> {
+                    when (initialDnsPort) {
+                        BaseConsts.PortOption.AUTO,
+                        BaseConsts.PortOption.DISABLED -> {
+                            editTextDnsPortCustom.setText("")
+                        }
+                        else -> {
+                            editTextDnsPortCustom.setText(initialDnsPort)
+                        }
+                    }
+                    dnsPortCustomVisibility(true)
+                }
+                SettingsTorFragment.DISABLED -> {
+                    dnsPortCustomVisibility(false)
+                }
+                else -> {
+                    return
+                }
+            }
+        }
+    }
+}

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/HttpPortOption.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/HttpPortOption.kt
@@ -1,0 +1,146 @@
+package io.matthewnelson.sampleapp.ui.fragments.settings.tor
+
+import android.content.Context
+import android.text.InputFilter
+import android.view.View
+import android.widget.*
+import io.matthewnelson.sampleapp.R
+import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
+import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
+import io.matthewnelson.topl_core_base.BaseConsts.PortOption
+import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
+
+class HttpPortOption(view: View, private val serviceTorSettings: ServiceTorSettings) {
+
+    // Views
+    private lateinit var spinnerHttpPort: Spinner
+    private lateinit var adapterHttpPort: ArrayAdapter<String>
+    private lateinit var listenerHttpPort: HttpPortSelectionListener
+    private lateinit var textViewHttpPortCustom: TextView
+    private lateinit var editTextHttpPortCustom: EditText
+
+    private var initialHttpPort = serviceTorSettings.httpTunnelPort
+
+    fun saveHttpPort(): Any? {
+        val httpPort = when (adapterHttpPort.getItem(listenerHttpPort.position)) {
+            SettingsTorFragment.AUTO -> {
+                PortOption.AUTO
+            }
+            SettingsTorFragment.DISABLED -> {
+                PortOption.DISABLED
+            }
+            else -> {
+                editTextHttpPortCustom.text.toString()
+            }
+        }
+
+        try {
+            serviceTorSettings.httpTunnelPortSave(httpPort)
+            initialHttpPort = httpPort
+        } catch (e: IllegalArgumentException) {
+            DashboardFragment.showMessage(
+                DashMessage("${DashMessage.EXCEPTION}${e.message}",
+                    R.drawable.dash_message_color_red,
+                    4_000
+                )
+            )
+            return null
+        }
+        return Any()
+    }
+
+    init {
+        findViews(view)
+        setViewParameters()
+        initSpinnerTorHttpPort(view.context)
+    }
+
+    private fun findViews(view: View) {
+        spinnerHttpPort = view.findViewById(R.id.settings_tor_spinner_http_port)
+        textViewHttpPortCustom = view.findViewById(R.id.settings_tor_text_view_http_port_custom)
+        editTextHttpPortCustom = view.findViewById(R.id.settings_tor_edit_text_http_port_custom)
+    }
+
+    private fun setViewParameters() {
+        editTextHttpPortCustom.filters = arrayOf(InputFilter.LengthFilter(5))
+    }
+
+    private fun initSpinnerTorHttpPort(context: Context) {
+        val categorySocksPort = arrayOf(
+            SettingsTorFragment.AUTO,
+            SettingsTorFragment.CUSTOM,
+            SettingsTorFragment.DISABLED
+        )
+        adapterHttpPort = ArrayAdapter(context, R.layout.spinner_list_item, categorySocksPort)
+        adapterHttpPort.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        spinnerHttpPort.adapter = adapterHttpPort
+        setHttpPortSpinnerValue()
+        listenerHttpPort = HttpPortSelectionListener()
+        spinnerHttpPort.onItemSelectedListener = listenerHttpPort
+    }
+
+    private fun setHttpPortSpinnerValue() {
+        when (initialHttpPort) {
+            PortOption.AUTO -> {
+                httpPortCustomVisibility(false)
+                spinnerHttpPort.setSelection(0)
+            }
+            PortOption.DISABLED -> {
+                httpPortCustomVisibility(false)
+                spinnerHttpPort.setSelection(2)
+            }
+            else -> {
+                editTextHttpPortCustom.setText(initialHttpPort)
+                spinnerHttpPort.setSelection(1)
+                httpPortCustomVisibility(true)
+            }
+        }
+    }
+
+    private fun httpPortCustomVisibility(show: Boolean) {
+        textViewHttpPortCustom.visibility = if (show) View.VISIBLE else View.GONE
+        editTextHttpPortCustom.visibility = if (show) View.VISIBLE else View.GONE
+    }
+
+    private inner class HttpPortSelectionListener: AdapterView.OnItemSelectedListener {
+        var position = 0
+            private set
+        var count = 0
+            private set
+
+        override fun onNothingSelected(parent: AdapterView<*>?) {}
+
+        override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+            this.position = position
+
+            if (count == 0) {
+                count ++
+                return
+            }
+
+            when (parent?.getItemAtPosition(position).toString()) {
+                SettingsTorFragment.AUTO -> {
+                    httpPortCustomVisibility(false)
+                }
+                SettingsTorFragment.CUSTOM -> {
+                    when (initialHttpPort) {
+                        PortOption.AUTO,
+                        PortOption.DISABLED -> {
+                            editTextHttpPortCustom.setText("")
+                        }
+                        else -> {
+                            editTextHttpPortCustom.setText(initialHttpPort)
+                        }
+                    }
+                    httpPortCustomVisibility(true)
+                }
+                SettingsTorFragment.DISABLED -> {
+                    httpPortCustomVisibility(false)
+                }
+                else -> {
+                    return
+                }
+            }
+        }
+    }
+}

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/IsolationFlagsFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/IsolationFlagsFragment.kt
@@ -144,20 +144,20 @@ class IsolationFlagsFragment(
 
     private fun setClickListeners() {
         layoutTop.setOnClickListener {
-            removeFragment()
+            removeFragment(true)
         }
         layoutBottom.setOnClickListener {
-            removeFragment()
+            removeFragment(true)
         }
         layoutEnd.setOnClickListener {
-            removeFragment()
+            removeFragment(true)
         }
         layoutStart.setOnClickListener {
-            removeFragment()
+            removeFragment(true)
         }
     }
 
-    private fun removeFragment() {
+    private fun removeFragment(saveData: Boolean) {
         // TODO: Save Data
         parentFragmentManager.beginTransaction().apply {
             remove(this@IsolationFlagsFragment)
@@ -179,7 +179,7 @@ class IsolationFlagsFragment(
     private inner class BackPressHandler(enable: Boolean): OnBackPressedCallback(enable) {
 
         override fun handleOnBackPressed() {
-            removeFragment()
+            removeFragment(false)
         }
 
     }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/IsolationFlagsFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/IsolationFlagsFragment.kt
@@ -88,6 +88,9 @@ class IsolationFlagsFragment(
 
     companion object {
         const val SOCKS_FLAGS = "SOCKS_FLAGS"
+        const val HTTP_FLAGS = "HTTP_FLAGS"
+        const val DNS_FLAGS = "DNS_FLAGS"
+        const val TRANS_FLAGS = "TRANS_FLAGS"
     }
 
     private val backPressHandler = BackPressHandler(true)

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/IsolationFlagsFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/IsolationFlagsFragment.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.sampleapp.ui.fragments.settings.tor
 
 import android.os.Bundle
@@ -8,9 +74,6 @@ import android.widget.Button
 import android.widget.LinearLayout
 import androidx.activity.OnBackPressedCallback
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.view.marginBottom
-import androidx.core.view.marginEnd
-import androidx.core.view.marginStart
 import androidx.core.view.marginTop
 import androidx.fragment.app.Fragment
 import io.matthewnelson.sampleapp.R

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/IsolationFlagsFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/IsolationFlagsFragment.kt
@@ -1,0 +1,120 @@
+package io.matthewnelson.sampleapp.ui.fragments.settings.tor
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.LinearLayout
+import androidx.activity.OnBackPressedCallback
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.marginBottom
+import androidx.core.view.marginEnd
+import androidx.core.view.marginStart
+import androidx.core.view.marginTop
+import androidx.fragment.app.Fragment
+import io.matthewnelson.sampleapp.R
+import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
+
+
+class IsolationFlagsFragment(
+    private val bottomMarginAdjust: Int,
+    private val flagType: String,
+    private val serviceTorSettings: ServiceTorSettings
+) : Fragment() {
+
+    companion object {
+        const val SOCKS_FLAGS = "SOCKS_FLAGS"
+    }
+
+    private val backPressHandler = BackPressHandler(true)
+
+    private lateinit var layoutTop: LinearLayout
+    private lateinit var layoutBottom: LinearLayout
+    private lateinit var layoutEnd: LinearLayout
+    private lateinit var layoutStart: LinearLayout
+    private lateinit var layoutConstraintInner: ConstraintLayout
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        activity?.apply {
+            onBackPressedDispatcher.addCallback(viewLifecycleOwner, backPressHandler)
+        }
+        return inflater.inflate(R.layout.fragment_isolation_flags, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        findViews(view)
+        setMargins()
+        setClickListeners()
+        enableParentViews(false)
+    }
+
+    override fun onDestroyView() {
+        enableParentViews(true)
+        super.onDestroyView()
+    }
+
+    private fun findViews(view: View) {
+        layoutTop = view.findViewById(R.id.isolation_flags_space_top)
+        layoutBottom = view.findViewById(R.id.isolation_flags_layout_bottom)
+        layoutEnd = view.findViewById(R.id.isolation_flags_layout_end)
+        layoutStart = view.findViewById(R.id.isolation_flags_layout_start)
+        layoutConstraintInner = view.findViewById(R.id.isolation_flags_layout_constraint_inner)
+    }
+
+    private fun setMargins() {
+        val marginSize = layoutConstraintInner.marginTop
+
+        val layoutParams = layoutConstraintInner.layoutParams as ConstraintLayout.LayoutParams
+        layoutParams.apply {
+            this.setMargins(marginSize, marginSize, marginSize, marginSize + bottomMarginAdjust)
+        }
+    }
+
+    private fun setClickListeners() {
+        layoutTop.setOnClickListener {
+            removeFragment()
+        }
+        layoutBottom.setOnClickListener {
+            removeFragment()
+        }
+        layoutEnd.setOnClickListener {
+            removeFragment()
+        }
+        layoutStart.setOnClickListener {
+            removeFragment()
+        }
+    }
+
+    private fun removeFragment() {
+        // TODO: Save Data
+        parentFragmentManager.beginTransaction().apply {
+            remove(this@IsolationFlagsFragment)
+            commit()
+        }
+    }
+
+    private fun enableParentViews(enable: Boolean) {
+        parentFragment?.view?.apply {
+            val layoutSecondary = findViewById<ConstraintLayout>(R.id.settings_tor_layout_constraint_scroll)
+            for (i in 0 until layoutSecondary.childCount) {
+                val child = layoutSecondary.getChildAt(i)
+                child.isEnabled = enable
+            }
+            findViewById<Button>(R.id.settings_tor_button_save).isEnabled = enable
+        }
+    }
+
+    private inner class BackPressHandler(enable: Boolean): OnBackPressedCallback(enable) {
+
+        override fun handleOnBackPressed() {
+            removeFragment()
+        }
+
+    }
+}

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
@@ -89,6 +89,7 @@ class SettingsTorFragment : Fragment() {
     private lateinit var serviceTorSettings: ServiceTorSettings
     private lateinit var socksPortOption: SocksPortOption
     private lateinit var httpPortOption: HttpPortOption
+    private lateinit var dnsPortOption: DnsPortOption
     private lateinit var buttonSave: Button
 
     override fun onCreateView(
@@ -104,6 +105,7 @@ class SettingsTorFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         socksPortOption = SocksPortOption(view, serviceTorSettings)
         httpPortOption = HttpPortOption(view, serviceTorSettings)
+        dnsPortOption = DnsPortOption(view, serviceTorSettings)
         findViews(view)
         setButtonClickListener()
     }
@@ -120,6 +122,7 @@ class SettingsTorFragment : Fragment() {
         buttonSave.setOnClickListener {
             socksPortOption.saveSocksPort() ?: return@setOnClickListener
             httpPortOption.saveHttpPort() ?: return@setOnClickListener
+            dnsPortOption.saveDnsPort() ?: return@setOnClickListener
 
             DashboardFragment.showMessage(
                 DashMessage("Settings Saved", R.drawable.dash_message_color_green, 3_000L)

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
@@ -66,9 +66,7 @@
 * */
 package io.matthewnelson.sampleapp.ui.fragments.settings.tor
 
-import android.content.Context
 import android.os.Bundle
-import android.text.InputFilter
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -79,24 +77,17 @@ import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
 import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
-import io.matthewnelson.topl_core_base.BaseConsts.PortOption
 
 class SettingsTorFragment : Fragment() {
 
-    private companion object {
+    companion object {
         const val AUTO = "Auto"
         const val DISABLED = "Disabled"
         const val CUSTOM = "Custom"
     }
 
     private lateinit var serviceTorSettings: ServiceTorSettings
-
-    // Views
-    private lateinit var spinnerSocksPort: Spinner
-    private lateinit var adapterSocksPort: ArrayAdapter<String>
-    private lateinit var listenerSocksPort: TorOptionSelectionListener
-    private lateinit var textViewSocksPortCustom: TextView
-    private lateinit var editTextSocksPortCustom: EditText
+    private lateinit var socksPortOption: SocksPortOption
     private lateinit var buttonSave: Button
 
     override fun onCreateView(
@@ -110,10 +101,8 @@ class SettingsTorFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setInitialValues()
+        socksPortOption = SocksPortOption(view, serviceTorSettings)
         findViews(view)
-        setViewParameters()
-        initSpinnerTorSocksPort(view.context)
         setButtonClickListener()
     }
 
@@ -121,146 +110,17 @@ class SettingsTorFragment : Fragment() {
         super.onDestroyView()
     }
 
-    private fun setInitialValues() {
-        initialSocksPort = serviceTorSettings.socksPort
-    }
-
     private fun findViews(view: View) {
-        spinnerSocksPort = view.findViewById(R.id.settings_tor_spinner_socks_port)
-        textViewSocksPortCustom = view.findViewById(R.id.settings_tor_text_view_socks_port_custom)
-        editTextSocksPortCustom = view.findViewById(R.id.settings_tor_edit_text_socks_port_custom)
         buttonSave = view.findViewById(R.id.settings_tor_button_save)
-    }
-
-    private fun setViewParameters() {
-        editTextSocksPortCustom.filters = arrayOf(InputFilter.LengthFilter(5))
     }
 
     private fun setButtonClickListener() {
         buttonSave.setOnClickListener {
-            saveSocksPort() ?: return@setOnClickListener
+            socksPortOption.saveSocksPort() ?: return@setOnClickListener
 
             DashboardFragment.showMessage(
                 DashMessage("Settings Saved", R.drawable.dash_message_color_green, 3_000L)
             )
-        }
-    }
-
-    //////////////////
-    /// Socks Port ///
-    //////////////////
-    private lateinit var initialSocksPort: String
-
-    private fun initSpinnerTorSocksPort(context: Context) {
-        val categorySocksPort = arrayOf(
-            AUTO,
-            CUSTOM,
-            DISABLED
-        )
-        adapterSocksPort = ArrayAdapter(context, R.layout.spinner_list_item, categorySocksPort)
-        adapterSocksPort.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-        spinnerSocksPort.adapter = adapterSocksPort
-        setSocksPortSpinnerValue()
-        listenerSocksPort = TorOptionSelectionListener()
-        spinnerSocksPort.onItemSelectedListener = listenerSocksPort
-    }
-
-    private fun setSocksPortSpinnerValue() {
-        when (initialSocksPort) {
-            PortOption.AUTO -> {
-                socksPortCustomVisibility(false)
-                spinnerSocksPort.setSelection(0)
-            }
-            PortOption.DISABLED -> {
-                socksPortCustomVisibility(false)
-                spinnerSocksPort.setSelection(2)
-            }
-            else -> {
-                editTextSocksPortCustom.setText(initialSocksPort)
-                spinnerSocksPort.setSelection(1)
-                socksPortCustomVisibility(true)
-            }
-        }
-    }
-
-    private fun socksPortCustomVisibility(show: Boolean) {
-        textViewSocksPortCustom.visibility = if (show) View.VISIBLE else View.GONE
-        editTextSocksPortCustom.visibility = if (show) View.VISIBLE else View.GONE
-    }
-
-    private fun saveSocksPort(): Any? {
-        val socksPort = when (adapterSocksPort.getItem(listenerSocksPort.position)) {
-            AUTO -> {
-                PortOption.AUTO
-            }
-            DISABLED -> {
-                PortOption.DISABLED
-            }
-            else -> {
-                editTextSocksPortCustom.text.toString()
-            }
-        }
-
-        try {
-            serviceTorSettings.socksPortSave(socksPort)
-            initialSocksPort = socksPort
-        } catch (e: IllegalArgumentException) {
-            DashboardFragment.showMessage(
-                DashMessage("${DashMessage.EXCEPTION}${e.message}",
-                    R.drawable.dash_message_color_red,
-                    4_000
-                )
-            )
-            return null
-        }
-        return Any()
-    }
-
-    /////////////////
-    /// Http Port ///
-    /////////////////
-
-    private inner class TorOptionSelectionListener: AdapterView.OnItemSelectedListener {
-        var position = 0
-            private set
-        var count = 0
-            private set
-
-        override fun onNothingSelected(parent: AdapterView<*>?) {}
-
-        override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
-            this.position = position
-
-            if (count == 0) {
-                count ++
-                return
-            }
-
-            val item = parent?.getItemAtPosition(position) ?: return
-
-            when (parent.adapter) {
-                adapterSocksPort -> {
-                    when (item.toString()) {
-                        AUTO -> {
-                            socksPortCustomVisibility(false)
-                        }
-                        DISABLED -> {
-                            socksPortCustomVisibility(false)
-                        }
-                        else -> {
-                            when (initialSocksPort) {
-                                PortOption.AUTO, PortOption.DISABLED -> {
-                                    editTextSocksPortCustom.setText("")
-                                }
-                                else -> {
-                                    editTextSocksPortCustom.setText(initialSocksPort)
-                                }
-                            }
-                            socksPortCustomVisibility(true)
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
@@ -82,6 +82,8 @@ import io.matthewnelson.sampleapp.ui.fragments.settings.CloseKeyBoardNavListener
 import io.matthewnelson.sampleapp.ui.fragments.settings.tor.components.DnsPortOption
 import io.matthewnelson.sampleapp.ui.fragments.settings.tor.components.HttpPortOption
 import io.matthewnelson.sampleapp.ui.fragments.settings.tor.components.SocksPortOption
+import io.matthewnelson.sampleapp.ui.fragments.settings.tor.components.TransPortOption
+import io.matthewnelson.topl_core_base.BaseConsts.IsolationFlag
 import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
 
@@ -127,10 +129,52 @@ class SettingsTorFragment : Fragment() {
 
         findViews(view)
         setButtonClickListener(view)
+        initIsolationFlags()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
+    }
+
+    private val socksIsolationFlags = mutableListOf<@IsolationFlag String>()
+    private val httpIsolationFlags = mutableListOf<@IsolationFlag String>()
+    private val dnsIsolationFlags = mutableListOf<@IsolationFlag String>()
+//    private val transIsolationFlags = mutableListOf<@IsolationFlag String>()
+
+    fun setIsolationFlags(portType: String, selectedList: List<@IsolationFlag String>) {
+        when (portType) {
+            IsolationFlagsFragment.SOCKS_FLAGS -> {
+                socksIsolationFlags.clear()
+                socksIsolationFlags.addAll(selectedList)
+            }
+            IsolationFlagsFragment.HTTP_FLAGS -> {
+                httpIsolationFlags.clear()
+                httpIsolationFlags.addAll(selectedList)
+            }
+            IsolationFlagsFragment.DNS_FLAGS -> {
+                dnsIsolationFlags.clear()
+                dnsIsolationFlags.addAll(selectedList)
+            }
+//            IsolationFlagsFragment.TRANS_FLAGS -> {
+//                transIsolationFlags.clear()
+//                transIsolationFlags.addAll(selectedList)
+//            }
+        }
+    }
+
+    private fun initIsolationFlags() {
+        serviceTorSettings.socksPortIsolationFlags?.let {
+            setIsolationFlags(IsolationFlagsFragment.SOCKS_FLAGS, it)
+        }
+        serviceTorSettings.httpTunnelPortIsolationFlags?.let {
+            setIsolationFlags(IsolationFlagsFragment.HTTP_FLAGS, it)
+        }
+        serviceTorSettings.dnsPortIsolationFlags?.let {
+            setIsolationFlags(IsolationFlagsFragment.DNS_FLAGS, it)
+        }
+//        serviceTorSettings.transPortIsolationFlags?.let {
+//            setIsolationFlags(IsolationFlagsFragment.TRANS_FLAGS, it)
+//        }
     }
 
     private fun findViews(view: View) {
@@ -160,6 +204,11 @@ class SettingsTorFragment : Fragment() {
             dnsPortOption.saveDnsPort() ?: return@setOnClickListener
 //            transPortOption.saveTransPort() ?: return@setOnClickListener
 
+            serviceTorSettings.socksPortIsolationFlagsSave(socksIsolationFlags)
+            serviceTorSettings.httpPortIsolationFlagsSave(httpIsolationFlags)
+            serviceTorSettings.dnsPortIsolationFlagsSave(dnsIsolationFlags)
+//            serviceTorSettings.transPortIsolationFlagsSave(transIsolationFlags)
+
             DashboardFragment.showMessage(
                 DashMessage("Settings Saved\nTor may need to be restarted", R.drawable.dash_message_color_green, 4_000L)
             )
@@ -185,7 +234,14 @@ class SettingsTorFragment : Fragment() {
                 IsolationFlagsFragment(
                     saveButtonHeight,
                     portType,
-                    serviceTorSettings
+                    serviceTorSettings.defaultTorSettings,
+                    when (portType) {
+                        IsolationFlagsFragment.SOCKS_FLAGS -> socksIsolationFlags.toMutableSet()
+                        IsolationFlagsFragment.HTTP_FLAGS -> httpIsolationFlags.toMutableSet()
+                        IsolationFlagsFragment.DNS_FLAGS -> dnsIsolationFlags.toMutableSet()
+//                        IsolationFlagsFragment.TRANS_FLAGS -> transIsolationFlags.toMutableSet()
+                        else -> return
+                    }
                 )
             )
             commit()

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
@@ -72,9 +72,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.*
+import androidx.annotation.NavigationRes
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination
+import androidx.navigation.fragment.findNavController
 import io.matthewnelson.sampleapp.R
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
+import io.matthewnelson.sampleapp.ui.fragments.settings.CloseKeyBoardNavListener
 import io.matthewnelson.sampleapp.ui.fragments.settings.tor.components.DnsPortOption
 import io.matthewnelson.sampleapp.ui.fragments.settings.tor.components.HttpPortOption
 import io.matthewnelson.sampleapp.ui.fragments.settings.tor.components.SocksPortOption
@@ -106,21 +111,12 @@ class SettingsTorFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        socksPortOption =
-            SocksPortOption(
-                view,
-                serviceTorSettings
-            )
-        httpPortOption =
-            HttpPortOption(
-                view,
-                serviceTorSettings
-            )
-        dnsPortOption =
-            DnsPortOption(
-                view,
-                serviceTorSettings
-            )
+        socksPortOption = SocksPortOption(view, serviceTorSettings)
+        httpPortOption = HttpPortOption(view, serviceTorSettings)
+        dnsPortOption = DnsPortOption(view, serviceTorSettings)
+
+        findNavController().addOnDestinationChangedListener(CloseKeyBoardNavListener(view))
+
         findViews(view)
         setButtonClickListener()
     }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
@@ -88,6 +88,7 @@ class SettingsTorFragment : Fragment() {
 
     private lateinit var serviceTorSettings: ServiceTorSettings
     private lateinit var socksPortOption: SocksPortOption
+    private lateinit var httpPortOption: HttpPortOption
     private lateinit var buttonSave: Button
 
     override fun onCreateView(
@@ -102,6 +103,7 @@ class SettingsTorFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         socksPortOption = SocksPortOption(view, serviceTorSettings)
+        httpPortOption = HttpPortOption(view, serviceTorSettings)
         findViews(view)
         setButtonClickListener()
     }
@@ -117,6 +119,7 @@ class SettingsTorFragment : Fragment() {
     private fun setButtonClickListener() {
         buttonSave.setOnClickListener {
             socksPortOption.saveSocksPort() ?: return@setOnClickListener
+            httpPortOption.saveHttpPort() ?: return@setOnClickListener
 
             DashboardFragment.showMessage(
                 DashMessage("Settings Saved", R.drawable.dash_message_color_green, 3_000L)

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
@@ -75,6 +75,9 @@ import android.widget.*
 import io.matthewnelson.sampleapp.R
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
+import io.matthewnelson.sampleapp.ui.fragments.settings.tor.components.DnsPortOption
+import io.matthewnelson.sampleapp.ui.fragments.settings.tor.components.HttpPortOption
+import io.matthewnelson.sampleapp.ui.fragments.settings.tor.components.SocksPortOption
 import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
 
@@ -103,9 +106,21 @@ class SettingsTorFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        socksPortOption = SocksPortOption(view, serviceTorSettings)
-        httpPortOption = HttpPortOption(view, serviceTorSettings)
-        dnsPortOption = DnsPortOption(view, serviceTorSettings)
+        socksPortOption =
+            SocksPortOption(
+                view,
+                serviceTorSettings
+            )
+        httpPortOption =
+            HttpPortOption(
+                view,
+                serviceTorSettings
+            )
+        dnsPortOption =
+            DnsPortOption(
+                view,
+                serviceTorSettings
+            )
         findViews(view)
         setButtonClickListener()
     }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
@@ -83,6 +83,7 @@ import io.matthewnelson.sampleapp.ui.fragments.settings.CloseKeyBoardNavListener
 import io.matthewnelson.sampleapp.ui.fragments.settings.tor.components.DnsPortOption
 import io.matthewnelson.sampleapp.ui.fragments.settings.tor.components.HttpPortOption
 import io.matthewnelson.sampleapp.ui.fragments.settings.tor.components.SocksPortOption
+import io.matthewnelson.sampleapp.ui.fragments.settings.tor.components.TransPortOption
 import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
 
@@ -98,6 +99,8 @@ class SettingsTorFragment : Fragment() {
     private lateinit var socksPortOption: SocksPortOption
     private lateinit var httpPortOption: HttpPortOption
     private lateinit var dnsPortOption: DnsPortOption
+    private lateinit var transPortOption: TransPortOption
+
     private lateinit var buttonSave: Button
 
     override fun onCreateView(
@@ -114,6 +117,7 @@ class SettingsTorFragment : Fragment() {
         socksPortOption = SocksPortOption(view, serviceTorSettings)
         httpPortOption = HttpPortOption(view, serviceTorSettings)
         dnsPortOption = DnsPortOption(view, serviceTorSettings)
+//        transPortOption = TransPortOption(view, serviceTorSettings)
 
         findNavController().addOnDestinationChangedListener(CloseKeyBoardNavListener(view))
 
@@ -134,6 +138,7 @@ class SettingsTorFragment : Fragment() {
             socksPortOption.saveSocksPort() ?: return@setOnClickListener
             httpPortOption.saveHttpPort() ?: return@setOnClickListener
             dnsPortOption.saveDnsPort() ?: return@setOnClickListener
+//            transPortOption.saveTransPort() ?: return@setOnClickListener
 
             DashboardFragment.showMessage(
                 DashMessage("Settings Saved\nTor may need to be restarted", R.drawable.dash_message_color_green, 4_000L)

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
@@ -100,6 +100,9 @@ class SettingsTorFragment : Fragment() {
 //    private lateinit var transPortOption: TransPortOption
 
     private lateinit var buttonSocksFlags: Button
+    private lateinit var buttonHttpFlags: Button
+    private lateinit var buttonDnsFlags: Button
+//    private lateinit var buttonTransFlags: Button
     private var saveButtonHeight = 0
 
     private lateinit var buttonSave: Button
@@ -132,6 +135,10 @@ class SettingsTorFragment : Fragment() {
 
     private fun findViews(view: View) {
         buttonSocksFlags = view.findViewById(R.id.settings_tor_button_socks_isolation_flags)
+        buttonHttpFlags = view.findViewById(R.id.settings_tor_button_http_isolation_flags)
+        buttonDnsFlags = view.findViewById(R.id.settings_tor_button_dns_isolation_flags)
+//        buttonTransFlags = view.findViewById(R.id.settings_tor_button_trans_isolation_flags)
+
         buttonSave = view.findViewById(R.id.settings_tor_button_save)
 
         val viewTreeObserver = view.viewTreeObserver
@@ -158,17 +165,30 @@ class SettingsTorFragment : Fragment() {
             )
         }
         buttonSocksFlags.setOnClickListener {
-            childFragmentManager.beginTransaction().apply {
-                add(
-                    R.id.settings_tor_fragment_container,
-                    IsolationFlagsFragment(
-                        saveButtonHeight,
-                        IsolationFlagsFragment.SOCKS_FLAGS,
-                        serviceTorSettings
-                    )
+            openIsolationFlagsFragment(IsolationFlagsFragment.SOCKS_FLAGS)
+        }
+        buttonHttpFlags.setOnClickListener {
+            openIsolationFlagsFragment(IsolationFlagsFragment.HTTP_FLAGS)
+        }
+        buttonDnsFlags.setOnClickListener {
+            openIsolationFlagsFragment(IsolationFlagsFragment.DNS_FLAGS)
+        }
+//        buttonTransFlags.setOnClickListener {
+//            openIsolationFlagsFragment(IsolationFlagsFragment.TRANS_FLAGS)
+//        }
+    }
+
+    private fun openIsolationFlagsFragment(portType: String) {
+        childFragmentManager.beginTransaction().apply {
+            add(
+                R.id.settings_tor_fragment_container,
+                IsolationFlagsFragment(
+                    saveButtonHeight,
+                    portType,
+                    serviceTorSettings
                 )
-                commit()
-            }
+            )
+            commit()
         }
     }
 }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
@@ -125,7 +125,7 @@ class SettingsTorFragment : Fragment() {
             dnsPortOption.saveDnsPort() ?: return@setOnClickListener
 
             DashboardFragment.showMessage(
-                DashMessage("Settings Saved", R.drawable.dash_message_color_green, 3_000L)
+                DashMessage("Settings Saved\nTor may need to be restarted", R.drawable.dash_message_color_green, 4_000L)
             )
         }
     }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SettingsTorFragment.kt
@@ -66,28 +66,201 @@
 * */
 package io.matthewnelson.sampleapp.ui.fragments.settings.tor
 
+import android.content.Context
 import android.os.Bundle
+import android.text.InputFilter
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.*
 import io.matthewnelson.sampleapp.R
+import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
+import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
+import io.matthewnelson.topl_service.TorServiceController
+import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
+import io.matthewnelson.topl_core_base.BaseConsts.PortOption
 
 class SettingsTorFragment : Fragment() {
+
+    private companion object {
+        const val AUTO = "Auto"
+        const val DISABLED = "Disabled"
+        const val CUSTOM = "Custom"
+    }
+
+    private lateinit var serviceTorSettings: ServiceTorSettings
+
+    // Views
+    private lateinit var spinnerSocksPort: Spinner
+    private lateinit var adapterSocksPort: ArrayAdapter<String>
+    private lateinit var listenerSocksPort: TorOptionSelectionListener
+    private lateinit var textViewSocksPortCustom: TextView
+    private lateinit var editTextSocksPortCustom: EditText
+    private lateinit var buttonSave: Button
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        serviceTorSettings = TorServiceController.getServiceTorSettings(inflater.context)
         return inflater.inflate(R.layout.fragment_settings_tor, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setInitialValues()
+        findViews(view)
+        setViewParameters()
+        initSpinnerTorSocksPort(view.context)
+        setButtonClickListener()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
+    }
+
+    private fun setInitialValues() {
+        initialSocksPort = serviceTorSettings.socksPort
+    }
+
+    private fun findViews(view: View) {
+        spinnerSocksPort = view.findViewById(R.id.settings_tor_spinner_socks_port)
+        textViewSocksPortCustom = view.findViewById(R.id.settings_tor_text_view_socks_port_custom)
+        editTextSocksPortCustom = view.findViewById(R.id.settings_tor_edit_text_socks_port_custom)
+        buttonSave = view.findViewById(R.id.settings_tor_button_save)
+    }
+
+    private fun setViewParameters() {
+        editTextSocksPortCustom.filters = arrayOf(InputFilter.LengthFilter(5))
+    }
+
+    private fun setButtonClickListener() {
+        buttonSave.setOnClickListener {
+            saveSocksPort() ?: return@setOnClickListener
+
+            DashboardFragment.showMessage(
+                DashMessage("Settings Saved", R.drawable.dash_message_color_green, 3_000L)
+            )
+        }
+    }
+
+    //////////////////
+    /// Socks Port ///
+    //////////////////
+    private lateinit var initialSocksPort: String
+
+    private fun initSpinnerTorSocksPort(context: Context) {
+        val categorySocksPort = arrayOf(
+            AUTO,
+            CUSTOM,
+            DISABLED
+        )
+        adapterSocksPort = ArrayAdapter(context, R.layout.spinner_list_item, categorySocksPort)
+        adapterSocksPort.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        spinnerSocksPort.adapter = adapterSocksPort
+        setSocksPortSpinnerValue()
+        listenerSocksPort = TorOptionSelectionListener()
+        spinnerSocksPort.onItemSelectedListener = listenerSocksPort
+    }
+
+    private fun setSocksPortSpinnerValue() {
+        when (initialSocksPort) {
+            PortOption.AUTO -> {
+                socksPortCustomVisibility(false)
+                spinnerSocksPort.setSelection(0)
+            }
+            PortOption.DISABLED -> {
+                socksPortCustomVisibility(false)
+                spinnerSocksPort.setSelection(2)
+            }
+            else -> {
+                editTextSocksPortCustom.setText(initialSocksPort)
+                spinnerSocksPort.setSelection(1)
+                socksPortCustomVisibility(true)
+            }
+        }
+    }
+
+    private fun socksPortCustomVisibility(show: Boolean) {
+        textViewSocksPortCustom.visibility = if (show) View.VISIBLE else View.GONE
+        editTextSocksPortCustom.visibility = if (show) View.VISIBLE else View.GONE
+    }
+
+    private fun saveSocksPort(): Any? {
+        val socksPort = when (adapterSocksPort.getItem(listenerSocksPort.position)) {
+            AUTO -> {
+                PortOption.AUTO
+            }
+            DISABLED -> {
+                PortOption.DISABLED
+            }
+            else -> {
+                editTextSocksPortCustom.text.toString()
+            }
+        }
+
+        try {
+            serviceTorSettings.socksPortSave(socksPort)
+            initialSocksPort = socksPort
+        } catch (e: IllegalArgumentException) {
+            DashboardFragment.showMessage(
+                DashMessage("${DashMessage.EXCEPTION}${e.message}",
+                    R.drawable.dash_message_color_red,
+                    4_000
+                )
+            )
+            return null
+        }
+        return Any()
+    }
+
+    /////////////////
+    /// Http Port ///
+    /////////////////
+
+    private inner class TorOptionSelectionListener: AdapterView.OnItemSelectedListener {
+        var position = 0
+            private set
+        var count = 0
+            private set
+
+        override fun onNothingSelected(parent: AdapterView<*>?) {}
+
+        override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+            this.position = position
+
+            if (count == 0) {
+                count ++
+                return
+            }
+
+            val item = parent?.getItemAtPosition(position) ?: return
+
+            when (parent.adapter) {
+                adapterSocksPort -> {
+                    when (item.toString()) {
+                        AUTO -> {
+                            socksPortCustomVisibility(false)
+                        }
+                        DISABLED -> {
+                            socksPortCustomVisibility(false)
+                        }
+                        else -> {
+                            when (initialSocksPort) {
+                                PortOption.AUTO, PortOption.DISABLED -> {
+                                    editTextSocksPortCustom.setText("")
+                                }
+                                else -> {
+                                    editTextSocksPortCustom.setText(initialSocksPort)
+                                }
+                            }
+                            socksPortCustomVisibility(true)
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SocksPortOption.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SocksPortOption.kt
@@ -1,0 +1,149 @@
+package io.matthewnelson.sampleapp.ui.fragments.settings.tor
+
+import android.content.Context
+import android.text.InputFilter
+import android.view.View
+import android.widget.*
+import io.matthewnelson.sampleapp.R
+import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
+import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
+import io.matthewnelson.topl_core_base.BaseConsts
+import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
+
+class SocksPortOption(view: View, private val serviceTorSettings: ServiceTorSettings) {
+
+    // Views
+    private lateinit var spinnerSocksPort: Spinner
+    private lateinit var adapterSocksPort: ArrayAdapter<String>
+    private lateinit var listenerSocksPort: SocksPortSelectionListener
+    private lateinit var textViewSocksPortCustom: TextView
+    private lateinit var editTextSocksPortCustom: EditText
+    private lateinit var buttonSave: Button
+
+    private var initialSocksPort = serviceTorSettings.socksPort
+
+    fun saveSocksPort(): Any? {
+        val socksPort = when (adapterSocksPort.getItem(listenerSocksPort.position)) {
+            SettingsTorFragment.AUTO -> {
+                BaseConsts.PortOption.AUTO
+            }
+            SettingsTorFragment.DISABLED -> {
+                BaseConsts.PortOption.DISABLED
+            }
+            else -> {
+                editTextSocksPortCustom.text.toString()
+            }
+        }
+
+        try {
+            serviceTorSettings.socksPortSave(socksPort)
+            initialSocksPort = socksPort
+        } catch (e: IllegalArgumentException) {
+            DashboardFragment.showMessage(
+                DashMessage("${DashMessage.EXCEPTION}${e.message}",
+                    R.drawable.dash_message_color_red,
+                    4_000
+                )
+            )
+            return null
+        }
+        return Any()
+    }
+
+    init {
+        findViews(view)
+        setViewParameters()
+        initSpinnerTorSocksPort(view.context)
+    }
+
+    private fun findViews(view: View) {
+        spinnerSocksPort = view.findViewById(R.id.settings_tor_spinner_socks_port)
+        textViewSocksPortCustom = view.findViewById(R.id.settings_tor_text_view_socks_port_custom)
+        editTextSocksPortCustom = view.findViewById(R.id.settings_tor_edit_text_socks_port_custom)
+        buttonSave = view.findViewById(R.id.settings_tor_button_save)
+    }
+
+    private fun setViewParameters() {
+        editTextSocksPortCustom.filters = arrayOf(InputFilter.LengthFilter(5))
+    }
+
+    private fun initSpinnerTorSocksPort(context: Context) {
+        val categorySocksPort = arrayOf(
+            SettingsTorFragment.AUTO,
+            SettingsTorFragment.CUSTOM,
+            SettingsTorFragment.DISABLED
+        )
+        adapterSocksPort = ArrayAdapter(context, R.layout.spinner_list_item, categorySocksPort)
+        adapterSocksPort.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        spinnerSocksPort.adapter = adapterSocksPort
+        setSocksPortSpinnerValue()
+        listenerSocksPort = SocksPortSelectionListener()
+        spinnerSocksPort.onItemSelectedListener = listenerSocksPort
+    }
+
+    private fun setSocksPortSpinnerValue() {
+        when (initialSocksPort) {
+            BaseConsts.PortOption.AUTO -> {
+                socksPortCustomVisibility(false)
+                spinnerSocksPort.setSelection(0)
+            }
+            BaseConsts.PortOption.DISABLED -> {
+                socksPortCustomVisibility(false)
+                spinnerSocksPort.setSelection(2)
+            }
+            else -> {
+                editTextSocksPortCustom.setText(initialSocksPort)
+                spinnerSocksPort.setSelection(1)
+                socksPortCustomVisibility(true)
+            }
+        }
+    }
+
+    private fun socksPortCustomVisibility(show: Boolean) {
+        textViewSocksPortCustom.visibility = if (show) View.VISIBLE else View.GONE
+        editTextSocksPortCustom.visibility = if (show) View.VISIBLE else View.GONE
+    }
+
+    private inner class SocksPortSelectionListener: AdapterView.OnItemSelectedListener {
+        var position = 0
+            private set
+        var count = 0
+            private set
+
+        override fun onNothingSelected(parent: AdapterView<*>?) {}
+
+        override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+            this.position = position
+
+            if (count == 0) {
+                count ++
+                return
+            }
+
+            when (parent?.getItemAtPosition(position).toString()) {
+                SettingsTorFragment.AUTO -> {
+                    socksPortCustomVisibility(false)
+                }
+                SettingsTorFragment.CUSTOM -> {
+                    when (initialSocksPort) {
+                        BaseConsts.PortOption.AUTO,
+                        BaseConsts.PortOption.DISABLED -> {
+                            editTextSocksPortCustom.setText("")
+                        }
+                        else -> {
+                            editTextSocksPortCustom.setText(initialSocksPort)
+                        }
+                    }
+                    socksPortCustomVisibility(true)
+                }
+                SettingsTorFragment.DISABLED -> {
+                    socksPortCustomVisibility(false)
+                }
+                else -> {
+                    return
+                }
+            }
+        }
+    }
+
+}

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SocksPortOption.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/SocksPortOption.kt
@@ -18,7 +18,6 @@ class SocksPortOption(view: View, private val serviceTorSettings: ServiceTorSett
     private lateinit var listenerSocksPort: SocksPortSelectionListener
     private lateinit var textViewSocksPortCustom: TextView
     private lateinit var editTextSocksPortCustom: EditText
-    private lateinit var buttonSave: Button
 
     private var initialSocksPort = serviceTorSettings.socksPort
 
@@ -60,7 +59,6 @@ class SocksPortOption(view: View, private val serviceTorSettings: ServiceTorSett
         spinnerSocksPort = view.findViewById(R.id.settings_tor_spinner_socks_port)
         textViewSocksPortCustom = view.findViewById(R.id.settings_tor_text_view_socks_port_custom)
         editTextSocksPortCustom = view.findViewById(R.id.settings_tor_edit_text_socks_port_custom)
-        buttonSave = view.findViewById(R.id.settings_tor_button_save)
     }
 
     private fun setViewParameters() {
@@ -145,5 +143,4 @@ class SocksPortOption(view: View, private val serviceTorSettings: ServiceTorSett
             }
         }
     }
-
 }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/DnsPortOption.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/DnsPortOption.kt
@@ -67,12 +67,12 @@ class DnsPortOption(view: View, private val serviceTorSettings: ServiceTorSettin
     }
 
     private fun initSpinnerTorDnsPort(context: Context) {
-        val categorySocksPort = arrayOf(
+        val categoryDnsPort = arrayOf(
             SettingsTorFragment.AUTO,
             SettingsTorFragment.CUSTOM,
             SettingsTorFragment.DISABLED
         )
-        adapterDnsPort = ArrayAdapter(context, R.layout.spinner_list_item, categorySocksPort)
+        adapterDnsPort = ArrayAdapter(context, R.layout.spinner_list_item, categoryDnsPort)
         adapterDnsPort.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         spinnerDnsPort.adapter = adapterDnsPort
         setDnsPortSpinnerValue()

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/DnsPortOption.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/DnsPortOption.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.sampleapp.ui.fragments.settings.tor.components
 
 import android.content.Context

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/DnsPortOption.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/DnsPortOption.kt
@@ -1,4 +1,4 @@
-package io.matthewnelson.sampleapp.ui.fragments.settings.tor
+package io.matthewnelson.sampleapp.ui.fragments.settings.tor.components
 
 import android.content.Context
 import android.text.InputFilter
@@ -7,6 +7,7 @@ import android.widget.*
 import io.matthewnelson.sampleapp.R
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
+import io.matthewnelson.sampleapp.ui.fragments.settings.tor.SettingsTorFragment
 import io.matthewnelson.topl_core_base.BaseConsts
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/HttpPortOption.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/HttpPortOption.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.sampleapp.ui.fragments.settings.tor.components
 
 import android.content.Context

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/HttpPortOption.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/HttpPortOption.kt
@@ -1,4 +1,4 @@
-package io.matthewnelson.sampleapp.ui.fragments.settings.tor
+package io.matthewnelson.sampleapp.ui.fragments.settings.tor.components
 
 import android.content.Context
 import android.text.InputFilter
@@ -7,6 +7,7 @@ import android.widget.*
 import io.matthewnelson.sampleapp.R
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
+import io.matthewnelson.sampleapp.ui.fragments.settings.tor.SettingsTorFragment
 import io.matthewnelson.topl_core_base.BaseConsts.PortOption
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/HttpPortOption.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/HttpPortOption.kt
@@ -67,12 +67,12 @@ class HttpPortOption(view: View, private val serviceTorSettings: ServiceTorSetti
     }
 
     private fun initSpinnerTorHttpPort(context: Context) {
-        val categorySocksPort = arrayOf(
+        val categoryHttpPort = arrayOf(
             SettingsTorFragment.AUTO,
             SettingsTorFragment.CUSTOM,
             SettingsTorFragment.DISABLED
         )
-        adapterHttpPort = ArrayAdapter(context, R.layout.spinner_list_item, categorySocksPort)
+        adapterHttpPort = ArrayAdapter(context, R.layout.spinner_list_item, categoryHttpPort)
         adapterHttpPort.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         spinnerHttpPort.adapter = adapterHttpPort
         setHttpPortSpinnerValue()

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/SocksPortOption.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/SocksPortOption.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.sampleapp.ui.fragments.settings.tor.components
 
 import android.content.Context

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/SocksPortOption.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/SocksPortOption.kt
@@ -1,4 +1,4 @@
-package io.matthewnelson.sampleapp.ui.fragments.settings.tor
+package io.matthewnelson.sampleapp.ui.fragments.settings.tor.components
 
 import android.content.Context
 import android.text.InputFilter
@@ -7,6 +7,7 @@ import android.widget.*
 import io.matthewnelson.sampleapp.R
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
+import io.matthewnelson.sampleapp.ui.fragments.settings.tor.SettingsTorFragment
 import io.matthewnelson.topl_core_base.BaseConsts
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/TransPortOption.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/TransPortOption.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.sampleapp.ui.fragments.settings.tor.components
 
 import android.content.Context

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/TransPortOption.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/settings/tor/components/TransPortOption.kt
@@ -1,0 +1,147 @@
+package io.matthewnelson.sampleapp.ui.fragments.settings.tor.components
+
+import android.content.Context
+import android.text.InputFilter
+import android.view.View
+import android.widget.*
+import io.matthewnelson.sampleapp.R
+import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
+import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
+import io.matthewnelson.sampleapp.ui.fragments.settings.tor.SettingsTorFragment
+import io.matthewnelson.topl_core_base.BaseConsts.PortOption
+import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
+
+class TransPortOption(view: View, private val serviceTorSettings: ServiceTorSettings) {
+
+    // Views
+    private lateinit var spinnerTransPort: Spinner
+    private lateinit var adapterTransPort: ArrayAdapter<String>
+    private lateinit var listenerTransPort: TransPortSelectionListener
+    private lateinit var textViewTransPortCustom: TextView
+    private lateinit var editTextTransPortCustom: EditText
+
+    private var initialTransPort = serviceTorSettings.transPort
+
+    fun saveTransPort(): Any? {
+        val transPort = when (adapterTransPort.getItem(listenerTransPort.position)) {
+            SettingsTorFragment.AUTO -> {
+                PortOption.AUTO
+            }
+            SettingsTorFragment.DISABLED -> {
+                PortOption.DISABLED
+            }
+            else -> {
+                editTextTransPortCustom.text.toString()
+            }
+        }
+
+        try {
+            serviceTorSettings.transPortSave(transPort)
+            initialTransPort = transPort
+        } catch (e: IllegalArgumentException) {
+            DashboardFragment.showMessage(
+                DashMessage("${DashMessage.EXCEPTION}${e.message}",
+                    R.drawable.dash_message_color_red,
+                    4_000
+                )
+            )
+            return null
+        }
+        return Any()
+    }
+
+    init {
+        findViews(view)
+        setViewParameters()
+        initSpinnerTorTransPort(view.context)
+    }
+
+    private fun findViews(view: View) {
+        spinnerTransPort = view.findViewById(R.id.settings_tor_spinner_trans_port)
+        textViewTransPortCustom = view.findViewById(R.id.settings_tor_text_view_trans_port_custom)
+        editTextTransPortCustom = view.findViewById(R.id.settings_tor_edit_text_trans_port_custom)
+    }
+
+    private fun setViewParameters() {
+        editTextTransPortCustom.filters = arrayOf(InputFilter.LengthFilter(5))
+    }
+
+    private fun initSpinnerTorTransPort(context: Context) {
+        val categoryTransPort = arrayOf(
+            SettingsTorFragment.AUTO,
+            SettingsTorFragment.CUSTOM,
+            SettingsTorFragment.DISABLED
+        )
+        adapterTransPort = ArrayAdapter(context, R.layout.spinner_list_item, categoryTransPort)
+        adapterTransPort.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        spinnerTransPort.adapter = adapterTransPort
+        setTransPortSpinnerValue()
+        listenerTransPort = TransPortSelectionListener()
+        spinnerTransPort.onItemSelectedListener = listenerTransPort
+    }
+
+    private fun setTransPortSpinnerValue() {
+        when (initialTransPort) {
+            PortOption.AUTO -> {
+                transPortCustomVisibility(false)
+                spinnerTransPort.setSelection(0)
+            }
+            PortOption.DISABLED -> {
+                transPortCustomVisibility(false)
+                spinnerTransPort.setSelection(2)
+            }
+            else -> {
+                editTextTransPortCustom.setText(initialTransPort)
+                spinnerTransPort.setSelection(1)
+                transPortCustomVisibility(true)
+            }
+        }
+    }
+
+    private fun transPortCustomVisibility(show: Boolean) {
+        textViewTransPortCustom.visibility = if (show) View.VISIBLE else View.GONE
+        editTextTransPortCustom.visibility = if (show) View.VISIBLE else View.GONE
+    }
+
+    private inner class TransPortSelectionListener: AdapterView.OnItemSelectedListener {
+        var position = 0
+            private set
+        var count = 0
+            private set
+
+        override fun onNothingSelected(parent: AdapterView<*>?) {}
+
+        override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+            this.position = position
+
+            if (count == 0) {
+                count ++
+                return
+            }
+
+            when (parent?.getItemAtPosition(position).toString()) {
+                SettingsTorFragment.AUTO -> {
+                    transPortCustomVisibility(false)
+                }
+                SettingsTorFragment.CUSTOM -> {
+                    when (initialTransPort) {
+                        PortOption.AUTO,
+                        PortOption.DISABLED -> {
+                            editTextTransPortCustom.setText("")
+                        }
+                        else -> {
+                            editTextTransPortCustom.setText(initialTransPort)
+                        }
+                    }
+                    transPortCustomVisibility(true)
+                }
+                SettingsTorFragment.DISABLED -> {
+                    transPortCustomVisibility(false)
+                }
+                else -> {
+                    return
+                }
+            }
+        }
+    }
+}

--- a/sampleapp/src/main/res/drawable/dash_message_color_green.xml
+++ b/sampleapp/src/main/res/drawable/dash_message_color_green.xml
@@ -2,4 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/green" />
+    <corners android:radius="8dp" />
+    <stroke android:width="2dp" android:color="@color/dash_message_drawable_border" />
 </shape>

--- a/sampleapp/src/main/res/drawable/dash_message_color_primary_light.xml
+++ b/sampleapp/src/main/res/drawable/dash_message_color_primary_light.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@color/primaryLightColor" />
-</shape>

--- a/sampleapp/src/main/res/drawable/dash_message_color_red.xml
+++ b/sampleapp/src/main/res/drawable/dash_message_color_red.xml
@@ -2,4 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/red" />
+    <corners android:radius="8dp" />
+    <stroke android:width="2dp" android:color="@color/dash_message_drawable_border" />
 </shape>

--- a/sampleapp/src/main/res/drawable/dash_message_color_secondary_light.xml
+++ b/sampleapp/src/main/res/drawable/dash_message_color_secondary_light.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/secondaryLightColor" />
+    <corners android:radius="8dp" />
+    <stroke android:width="2dp" android:color="@color/dash_message_drawable_border" />
+</shape>

--- a/sampleapp/src/main/res/drawable/isolation_flag_fragment_background.xml
+++ b/sampleapp/src/main/res/drawable/isolation_flag_fragment_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/tor_service_white" />
+    <corners android:radius="16dp" />
+    <stroke android:width="4dp" android:color="@color/secondaryColor" />
+</shape>

--- a/sampleapp/src/main/res/layout/fragment_dashboard.xml
+++ b/sampleapp/src/main/res/layout/fragment_dashboard.xml
@@ -203,13 +203,15 @@
         android:id="@+id/dash_text_view_message"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
         android:gravity="center_horizontal"
         android:padding="8dp"
         android:textColor="@color/primaryTextColor"
         android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_port_socks"
-        app:layout_constraintStart_toStartOf="@+id/dash_text_view_port_dns"
-        app:layout_constraintTop_toBottomOf="@+id/dash_button_app_restart" />
+        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_tor_network_state"
+        app:layout_constraintStart_toStartOf="@+id/dash_text_view_tor_state"
+        app:layout_constraintTop_toTopOf="@+id/dash_text_view_tor_state" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sampleapp/src/main/res/layout/fragment_dashboard.xml
+++ b/sampleapp/src/main/res/layout/fragment_dashboard.xml
@@ -186,19 +186,6 @@
         app:layout_constraintTop_toBottomOf="@+id/dash_text_view_port_http_header"
         tools:text="127.0.0.1:40195" />
 
-    <TextView
-        android:id="@+id/dash_text_view_message"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:gravity="center_horizontal"
-        android:padding="8dp"
-        android:textColor="@color/primaryTextColor"
-        android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_port_http"
-        app:layout_constraintStart_toStartOf="@+id/dash_text_view_port_control"
-        app:layout_constraintTop_toBottomOf="@+id/dash_text_view_port_http" />
-
     <Button
         android:id="@+id/dash_button_app_restart"
         android:layout_width="0dp"
@@ -210,6 +197,19 @@
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="@+id/dash_text_view_port_http"
         app:layout_constraintStart_toStartOf="@+id/dash_text_view_port_control"
-        app:layout_constraintTop_toBottomOf="@+id/dash_text_view_message" />
+        app:layout_constraintTop_toBottomOf="@+id/dash_text_view_port_http" />
+
+    <TextView
+        android:id="@+id/dash_text_view_message"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:gravity="center_horizontal"
+        android:padding="8dp"
+        android:textColor="@color/primaryTextColor"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_port_http"
+        app:layout_constraintStart_toStartOf="@+id/dash_text_view_port_control"
+        app:layout_constraintTop_toBottomOf="@+id/dash_button_app_restart" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sampleapp/src/main/res/layout/fragment_dashboard.xml
+++ b/sampleapp/src/main/res/layout/fragment_dashboard.xml
@@ -127,44 +127,24 @@
         tools:text="Network: enabled" />
 
     <TextView
-        android:id="@+id/dash_text_view_port_control_header"
+        android:id="@+id/dash_text_view_port_dns_header"
         style="@style/DashboardTextViewTopPadding"
         android:layout_marginTop="8dp"
         android:paddingBottom="4dp"
-        android:text="@string/dashboard_text_view_control_port"
+        android:text="@string/dashboard_text_view_dns_port"
         app:layout_constraintEnd_toEndOf="@+id/dash_text_view_tor_state"
         app:layout_constraintStart_toStartOf="@+id/dash_text_view_tor_state"
         app:layout_constraintTop_toBottomOf="@+id/dash_text_view_tor_state" />
 
     <TextView
-        android:id="@+id/dash_text_view_port_control"
+        android:id="@+id/dash_text_view_port_dns"
         style="@style/DashboardTextViewBotPadding"
         android:textColorHighlight="@android:color/holo_blue_bright"
         android:textIsSelectable="true"
-        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_port_control_header"
-        app:layout_constraintStart_toStartOf="@+id/dash_text_view_port_control_header"
-        app:layout_constraintTop_toBottomOf="@+id/dash_text_view_port_control_header"
-        tools:text="127.0.0.1:41429" />
-
-    <TextView
-        android:id="@+id/dash_text_view_port_socks_header"
-        style="@style/DashboardTextViewTopPadding"
-        android:layout_marginTop="8dp"
-        android:paddingBottom="4dp"
-        android:text="@string/dashboard_text_view_socks_port"
-        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_bandwidth"
-        app:layout_constraintStart_toStartOf="@+id/dash_text_view_bandwidth"
-        app:layout_constraintTop_toBottomOf="@+id/dash_text_view_bandwidth" />
-
-    <TextView
-        android:id="@+id/dash_text_view_port_socks"
-        style="@style/DashboardTextViewBotPadding"
-        android:textColorHighlight="@android:color/holo_blue_bright"
-        android:textIsSelectable="true"
-        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_port_socks_header"
-        app:layout_constraintStart_toStartOf="@+id/dash_text_view_port_socks_header"
-        app:layout_constraintTop_toBottomOf="@+id/dash_text_view_port_socks_header"
-        tools:text="127.0.0.1:35145" />
+        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_port_dns_header"
+        app:layout_constraintStart_toStartOf="@+id/dash_text_view_port_dns_header"
+        app:layout_constraintTop_toBottomOf="@+id/dash_text_view_port_dns_header"
+        tools:text="127.0.0.1:5400" />
 
     <TextView
         android:id="@+id/dash_text_view_port_http_header"
@@ -172,9 +152,9 @@
         android:layout_marginTop="8dp"
         android:paddingBottom="4dp"
         android:text="@string/dashboard_text_view_http_port"
-        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_tor_network_state"
-        app:layout_constraintStart_toStartOf="@+id/dash_text_view_tor_network_state"
-        app:layout_constraintTop_toBottomOf="@+id/dash_text_view_tor_network_state" />
+        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_bandwidth"
+        app:layout_constraintStart_toStartOf="@+id/dash_text_view_bandwidth"
+        app:layout_constraintTop_toBottomOf="@+id/dash_text_view_bandwidth" />
 
     <TextView
         android:id="@+id/dash_text_view_port_http"
@@ -184,7 +164,27 @@
         app:layout_constraintEnd_toEndOf="@+id/dash_text_view_port_http_header"
         app:layout_constraintStart_toStartOf="@+id/dash_text_view_port_http_header"
         app:layout_constraintTop_toBottomOf="@+id/dash_text_view_port_http_header"
-        tools:text="127.0.0.1:40195" />
+        tools:text="127.0.0.1:8118" />
+
+    <TextView
+        android:id="@+id/dash_text_view_port_socks_header"
+        style="@style/DashboardTextViewTopPadding"
+        android:layout_marginTop="8dp"
+        android:paddingBottom="4dp"
+        android:text="@string/dashboard_text_view_socks_port"
+        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_tor_network_state"
+        app:layout_constraintStart_toStartOf="@+id/dash_text_view_tor_network_state"
+        app:layout_constraintTop_toBottomOf="@+id/dash_text_view_tor_network_state" />
+
+    <TextView
+        android:id="@+id/dash_text_view_port_socks"
+        style="@style/DashboardTextViewBotPadding"
+        android:textColorHighlight="@android:color/holo_blue_bright"
+        android:textIsSelectable="true"
+        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_port_socks_header"
+        app:layout_constraintStart_toStartOf="@+id/dash_text_view_port_socks_header"
+        app:layout_constraintTop_toBottomOf="@+id/dash_text_view_port_socks_header"
+        tools:text="127.0.0.1:9050" />
 
     <Button
         android:id="@+id/dash_button_app_restart"
@@ -195,9 +195,9 @@
         android:text="@string/dash_button_app_restart"
         android:textAllCaps="false"
         android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_port_http"
-        app:layout_constraintStart_toStartOf="@+id/dash_text_view_port_control"
-        app:layout_constraintTop_toBottomOf="@+id/dash_text_view_port_http" />
+        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_port_socks"
+        app:layout_constraintStart_toStartOf="@+id/dash_text_view_port_dns"
+        app:layout_constraintTop_toBottomOf="@+id/dash_text_view_port_socks" />
 
     <TextView
         android:id="@+id/dash_text_view_message"
@@ -208,8 +208,8 @@
         android:padding="8dp"
         android:textColor="@color/primaryTextColor"
         android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_port_http"
-        app:layout_constraintStart_toStartOf="@+id/dash_text_view_port_control"
+        app:layout_constraintEnd_toEndOf="@+id/dash_text_view_port_socks"
+        app:layout_constraintStart_toStartOf="@+id/dash_text_view_port_dns"
         app:layout_constraintTop_toBottomOf="@+id/dash_button_app_restart" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sampleapp/src/main/res/layout/fragment_dashboard.xml
+++ b/sampleapp/src/main/res/layout/fragment_dashboard.xml
@@ -208,7 +208,7 @@
         android:layout_marginEnd="8dp"
         android:gravity="center_horizontal"
         android:padding="8dp"
-        android:textColor="@color/primaryTextColor"
+        android:textColor="@color/black"
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="@+id/dash_text_view_tor_network_state"
         app:layout_constraintStart_toStartOf="@+id/dash_text_view_tor_state"

--- a/sampleapp/src/main/res/layout/fragment_dashboard.xml
+++ b/sampleapp/src/main/res/layout/fragment_dashboard.xml
@@ -208,7 +208,6 @@
         android:layout_marginEnd="8dp"
         android:gravity="center_horizontal"
         android:padding="8dp"
-        android:textColor="@color/black"
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="@+id/dash_text_view_tor_network_state"
         app:layout_constraintStart_toStartOf="@+id/dash_text_view_tor_state"

--- a/sampleapp/src/main/res/layout/fragment_isolation_flags.xml
+++ b/sampleapp/src/main/res/layout/fragment_isolation_flags.xml
@@ -128,6 +128,33 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
+        <Button
+            android:id="@+id/isolation_flags_button_reset"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/button_color_grey"
+            android:text="@string/isolation_fragment_reset_socks"
+            android:textAllCaps="false"
+            app:layout_constraintEnd_toEndOf="@+id/recycler_view_isolation_flags"
+            app:layout_constraintStart_toStartOf="@+id/recycler_view_isolation_flags"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recycler_view_isolation_flags"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="4dp"
+            android:fadeScrollbars="false"
+            android:scrollbars="vertical"
+            app:layout_constraintBottom_toBottomOf="@+id/isolation_flags_layout_constraint_inner"
+            app:layout_constraintEnd_toEndOf="@+id/isolation_flags_layout_constraint_inner"
+            app:layout_constraintStart_toStartOf="@+id/isolation_flags_layout_constraint_inner"
+            app:layout_constraintTop_toBottomOf="@id/isolation_flags_button_reset" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 

--- a/sampleapp/src/main/res/layout/fragment_isolation_flags.xml
+++ b/sampleapp/src/main/res/layout/fragment_isolation_flags.xml
@@ -1,3 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
+-->
+
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/sampleapp/src/main/res/layout/fragment_isolation_flags.xml
+++ b/sampleapp/src/main/res/layout/fragment_isolation_flags.xml
@@ -1,0 +1,65 @@
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="io.matthewnelson.sampleapp.ui.fragments.settings.tor.IsolationFlagsFragment">
+
+    <LinearLayout
+        android:id="@+id/isolation_flags_space_top"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toTopOf="@+id/isolation_flags_layout_constraint_inner"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <LinearLayout
+        android:id="@+id/isolation_flags_layout_bottom"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/isolation_flags_layout_constraint_inner" />
+
+    <LinearLayout
+        android:id="@+id/isolation_flags_layout_end"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toTopOf="@+id/isolation_flags_layout_bottom"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/isolation_flags_layout_constraint_inner"
+        app:layout_constraintTop_toBottomOf="@id/isolation_flags_space_top" />
+
+    <LinearLayout
+        android:id="@+id/isolation_flags_layout_start"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toTopOf="@+id/isolation_flags_layout_bottom"
+        app:layout_constraintEnd_toStartOf="@+id/isolation_flags_layout_constraint_inner"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/isolation_flags_space_top" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/isolation_flags_layout_constraint_inner"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="60dp"
+        android:layout_marginTop="60dp"
+        android:layout_marginEnd="60dp"
+        android:layout_marginBottom="60dp"
+        android:background="@drawable/isolation_flag_fragment_background"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sampleapp/src/main/res/layout/fragment_settings_tor.xml
+++ b/sampleapp/src/main/res/layout/fragment_settings_tor.xml
@@ -74,4 +74,86 @@
     android:layout_height="match_parent"
     tools:context="io.matthewnelson.sampleapp.ui.fragments.settings.tor.SettingsTorFragment">
 
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        android:fadeScrollbars="false"
+        app:layout_constraintBottom_toTopOf="@+id/settings_tor_button_save"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp">
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/settings_tor_guide_left"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_percent=".40" />
+
+            <TextView
+                android:id="@+id/settings_tor_text_view_socks_port"
+                style="@style/SpinnerTextView"
+                android:text="@string/settings_tor_text_view_socks_port"
+                app:layout_constraintBottom_toBottomOf="@+id/settings_tor_spinner_socks_port"
+                app:layout_constraintEnd_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/settings_tor_spinner_socks_port" />
+
+            <Spinner
+                android:id="@+id/settings_tor_spinner_socks_port"
+                style="@style/SpinnerStyle"
+                android:background="@color/primaryLightColor"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:listitem="@layout/spinner_list_item" />
+
+            <TextView
+                android:id="@+id/settings_tor_text_view_socks_port_custom"
+                style="@style/SpinnerTextView"
+                android:text="@string/settings_tor_text_view_socks_port_custom"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@+id/settings_tor_edit_text_socks_port_custom"
+                app:layout_constraintEnd_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/settings_tor_edit_text_socks_port_custom" />
+
+            <EditText
+                android:id="@+id/settings_tor_edit_text_socks_port_custom"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:hint="@string/settings_tor_edit_text_hint_socks_port_custom"
+                android:inputType="number"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_spinner_socks_port" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </ScrollView>
+
+    <Button
+        android:id="@+id/settings_tor_button_save"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:background="@drawable/button_color_secondary"
+        android:text="@string/settings_library_button_save"
+        android:textAllCaps="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sampleapp/src/main/res/layout/fragment_settings_tor.xml
+++ b/sampleapp/src/main/res/layout/fragment_settings_tor.xml
@@ -140,7 +140,7 @@
                 app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
                 app:layout_constraintTop_toBottomOf="@+id/settings_tor_spinner_socks_port" />
 
-            <!-- Http Port -->
+            <!-- HTTP Port -->
 
             <TextView
                 android:id="@+id/settings_tor_text_view_http_port"
@@ -181,6 +181,48 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
                 app:layout_constraintTop_toBottomOf="@+id/settings_tor_spinner_http_port" />
+
+            <!-- DNS Port -->
+
+            <TextView
+                android:id="@+id/settings_tor_text_view_dns_port"
+                style="@style/SpinnerTextView"
+                android:text="@string/settings_tor_text_view_dns_port"
+                app:layout_constraintBottom_toBottomOf="@+id/settings_tor_spinner_dns_port"
+                app:layout_constraintEnd_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/settings_tor_spinner_dns_port" />
+
+            <Spinner
+                android:id="@+id/settings_tor_spinner_dns_port"
+                style="@style/SpinnerStyle"
+                android:background="@color/primaryLightColor"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_edit_text_http_port_custom"
+                tools:listitem="@layout/spinner_list_item" />
+
+            <TextView
+                android:id="@+id/settings_tor_text_view_dns_port_custom"
+                style="@style/SpinnerTextView"
+                android:text="@string/settings_tor_text_view_dns_port_custom"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@+id/settings_tor_edit_text_dns_port_custom"
+                app:layout_constraintEnd_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/settings_tor_edit_text_dns_port_custom" />
+
+            <EditText
+                android:id="@+id/settings_tor_edit_text_dns_port_custom"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:hint="@string/settings_tor_edit_text_hint_port_custom"
+                android:inputType="number"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_spinner_dns_port" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/sampleapp/src/main/res/layout/fragment_settings_tor.xml
+++ b/sampleapp/src/main/res/layout/fragment_settings_tor.xml
@@ -98,6 +98,8 @@
                 android:orientation="vertical"
                 app:layout_constraintGuide_percent=".40" />
 
+            <!-- Socks Port -->
+
             <TextView
                 android:id="@+id/settings_tor_text_view_socks_port"
                 style="@style/SpinnerTextView"
@@ -131,12 +133,54 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:gravity="center_horizontal"
-                android:hint="@string/settings_tor_edit_text_hint_socks_port_custom"
+                android:hint="@string/settings_tor_edit_text_hint_port_custom"
                 android:inputType="number"
                 android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
                 app:layout_constraintTop_toBottomOf="@+id/settings_tor_spinner_socks_port" />
+
+            <!-- Http Port -->
+
+            <TextView
+                android:id="@+id/settings_tor_text_view_http_port"
+                style="@style/SpinnerTextView"
+                android:text="@string/settings_tor_text_view_http_port"
+                app:layout_constraintBottom_toBottomOf="@+id/settings_tor_spinner_http_port"
+                app:layout_constraintEnd_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/settings_tor_spinner_http_port" />
+
+            <Spinner
+                android:id="@+id/settings_tor_spinner_http_port"
+                style="@style/SpinnerStyle"
+                android:background="@color/primaryLightColor"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_edit_text_socks_port_custom"
+                tools:listitem="@layout/spinner_list_item" />
+
+            <TextView
+                android:id="@+id/settings_tor_text_view_http_port_custom"
+                style="@style/SpinnerTextView"
+                android:text="@string/settings_tor_text_view_http_port_custom"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@+id/settings_tor_edit_text_http_port_custom"
+                app:layout_constraintEnd_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/settings_tor_edit_text_http_port_custom" />
+
+            <EditText
+                android:id="@+id/settings_tor_edit_text_http_port_custom"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:hint="@string/settings_tor_edit_text_hint_port_custom"
+                android:inputType="number"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_spinner_http_port" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/sampleapp/src/main/res/layout/fragment_settings_tor.xml
+++ b/sampleapp/src/main/res/layout/fragment_settings_tor.xml
@@ -226,11 +226,13 @@
 
 
             <!-- Trans Port -->
+            <!-- TEMPORARILY DISABLED -->
 
             <TextView
                 android:id="@+id/settings_tor_text_view_trans_port"
                 style="@style/SpinnerTextView"
                 android:text="@string/settings_tor_text_view_trans_port"
+                android:visibility="gone"
                 app:layout_constraintBottom_toBottomOf="@+id/settings_tor_spinner_trans_port"
                 app:layout_constraintEnd_toEndOf="@+id/settings_tor_guide_left"
                 app:layout_constraintStart_toStartOf="parent"
@@ -240,6 +242,7 @@
                 android:id="@+id/settings_tor_spinner_trans_port"
                 style="@style/SpinnerStyle"
                 android:background="@color/primaryLightColor"
+                android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
                 app:layout_constraintTop_toBottomOf="@+id/settings_tor_edit_text_dns_port_custom"

--- a/sampleapp/src/main/res/layout/fragment_settings_tor.xml
+++ b/sampleapp/src/main/res/layout/fragment_settings_tor.xml
@@ -70,11 +70,13 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/settings_tor_layout_constraint_primary"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="io.matthewnelson.sampleapp.ui.fragments.settings.tor.SettingsTorFragment">
 
     <ScrollView
+        android:id="@+id/settings_tor_scroll_view"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_marginStart="16dp"
@@ -88,6 +90,7 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/settings_tor_layout_constraint_scroll"
             android:layout_width="match_parent"
             android:layout_height="0dp">
 
@@ -118,6 +121,14 @@
                 app:layout_constraintTop_toTopOf="parent"
                 tools:listitem="@layout/spinner_list_item" />
 
+            <Space
+                android:id="@+id/settings_tor_space_socks_port_custom_top"
+                android:layout_width="match_parent"
+                android:layout_height="4dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/settings_tor_spinner_socks_port" />
+
             <TextView
                 android:id="@+id/settings_tor_text_view_socks_port_custom"
                 style="@style/SpinnerTextView"
@@ -138,7 +149,26 @@
                 android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
-                app:layout_constraintTop_toBottomOf="@+id/settings_tor_spinner_socks_port" />
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_space_socks_port_custom_top" />
+
+            <Space
+                android:id="@+id/settings_tor_space_socks_port_custom_bottom"
+                android:layout_width="match_parent"
+                android:layout_height="4dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/settings_tor_edit_text_socks_port_custom" />
+
+            <Button
+                android:id="@+id/settings_tor_button_socks_isolation_flags"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:background="@drawable/button_color_grey"
+                android:text="@string/settings_tor_button_socks_isolation_flags"
+                android:textAllCaps="false"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/settings_tor_guide_left"
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_space_socks_port_custom_bottom" />
 
             <!-- HTTP Port -->
 
@@ -157,8 +187,16 @@
                 android:background="@color/primaryLightColor"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
-                app:layout_constraintTop_toBottomOf="@+id/settings_tor_edit_text_socks_port_custom"
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_button_socks_isolation_flags"
                 tools:listitem="@layout/spinner_list_item" />
+
+            <Space
+                android:id="@+id/settings_tor_space_http_port_custom_top"
+                android:layout_width="match_parent"
+                android:layout_height="4dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/settings_tor_spinner_http_port" />
 
             <TextView
                 android:id="@+id/settings_tor_text_view_http_port_custom"
@@ -180,7 +218,26 @@
                 android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
-                app:layout_constraintTop_toBottomOf="@+id/settings_tor_spinner_http_port" />
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_space_http_port_custom_top" />
+
+            <Space
+                android:id="@+id/settings_tor_space_http_port_custom_bottom"
+                android:layout_width="match_parent"
+                android:layout_height="4dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/settings_tor_edit_text_http_port_custom" />
+
+            <Button
+                android:id="@+id/settings_tor_button_http_isolation_flags"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:background="@drawable/button_color_grey"
+                android:text="@string/settings_tor_button_http_isolation_flags"
+                android:textAllCaps="false"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/settings_tor_guide_left"
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_space_http_port_custom_bottom" />
 
             <!-- DNS Port -->
 
@@ -199,8 +256,16 @@
                 android:background="@color/primaryLightColor"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
-                app:layout_constraintTop_toBottomOf="@+id/settings_tor_edit_text_http_port_custom"
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_button_http_isolation_flags"
                 tools:listitem="@layout/spinner_list_item" />
+
+            <Space
+                android:id="@+id/settings_tor_space_dns_port_custom_top"
+                android:layout_width="match_parent"
+                android:layout_height="4dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/settings_tor_spinner_dns_port" />
 
             <TextView
                 android:id="@+id/settings_tor_text_view_dns_port_custom"
@@ -222,8 +287,26 @@
                 android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
-                app:layout_constraintTop_toBottomOf="@+id/settings_tor_spinner_dns_port" />
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_space_dns_port_custom_top" />
 
+            <Space
+                android:id="@+id/settings_tor_space_dns_port_custom_bottom"
+                android:layout_width="match_parent"
+                android:layout_height="4dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/settings_tor_edit_text_dns_port_custom" />
+
+            <Button
+                android:id="@+id/settings_tor_button_dns_isolation_flags"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:background="@drawable/button_color_grey"
+                android:text="@string/settings_tor_button_dns_isolation_flags"
+                android:textAllCaps="false"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/settings_tor_guide_left"
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_space_dns_port_custom_bottom" />
 
             <!-- Trans Port -->
             <!-- TEMPORARILY DISABLED -->
@@ -245,8 +328,17 @@
                 android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
-                app:layout_constraintTop_toBottomOf="@+id/settings_tor_edit_text_dns_port_custom"
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_button_dns_isolation_flags"
                 tools:listitem="@layout/spinner_list_item" />
+
+            <Space
+                android:id="@+id/settings_tor_space_trans_port_custom_top"
+                android:layout_width="match_parent"
+                android:layout_height="4dp"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/settings_tor_spinner_trans_port" />
 
             <TextView
                 android:id="@+id/settings_tor_text_view_trans_port_custom"
@@ -268,7 +360,28 @@
                 android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
-                app:layout_constraintTop_toBottomOf="@+id/settings_tor_spinner_trans_port" />
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_space_trans_port_custom_top" />
+
+            <Space
+                android:id="@+id/settings_tor_space_trans_port_custom_bottom"
+                android:layout_width="match_parent"
+                android:layout_height="4dp"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/settings_tor_edit_text_trans_port_custom" />
+
+            <Button
+                android:id="@+id/settings_tor_button_trans_isolation_flags"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:background="@drawable/button_color_grey"
+                android:text="@string/settings_tor_button_trans_isolation_flags"
+                android:textAllCaps="false"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/settings_tor_guide_left"
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_space_trans_port_custom_bottom" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -287,5 +400,14 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/settings_tor_fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sampleapp/src/main/res/layout/fragment_settings_tor.xml
+++ b/sampleapp/src/main/res/layout/fragment_settings_tor.xml
@@ -224,6 +224,49 @@
                 app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
                 app:layout_constraintTop_toBottomOf="@+id/settings_tor_spinner_dns_port" />
 
+
+            <!-- Trans Port -->
+
+            <TextView
+                android:id="@+id/settings_tor_text_view_trans_port"
+                style="@style/SpinnerTextView"
+                android:text="@string/settings_tor_text_view_trans_port"
+                app:layout_constraintBottom_toBottomOf="@+id/settings_tor_spinner_trans_port"
+                app:layout_constraintEnd_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/settings_tor_spinner_trans_port" />
+
+            <Spinner
+                android:id="@+id/settings_tor_spinner_trans_port"
+                style="@style/SpinnerStyle"
+                android:background="@color/primaryLightColor"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_edit_text_dns_port_custom"
+                tools:listitem="@layout/spinner_list_item" />
+
+            <TextView
+                android:id="@+id/settings_tor_text_view_trans_port_custom"
+                style="@style/SpinnerTextView"
+                android:text="@string/settings_tor_text_view_trans_port_custom"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@+id/settings_tor_edit_text_trans_port_custom"
+                app:layout_constraintEnd_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/settings_tor_edit_text_trans_port_custom" />
+
+            <EditText
+                android:id="@+id/settings_tor_edit_text_trans_port_custom"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:hint="@string/settings_tor_edit_text_hint_port_custom"
+                android:inputType="number"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/settings_tor_guide_left"
+                app:layout_constraintTop_toBottomOf="@+id/settings_tor_spinner_trans_port" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </ScrollView>

--- a/sampleapp/src/main/res/layout/holder_isolation_flag.xml
+++ b/sampleapp/src/main/res/layout/holder_isolation_flag.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
+-->
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/holder_isolation_flag_layout_constraint"
+    android:layout_marginBottom="8dp"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/holder_isolation_flag_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:gravity="center_vertical"
+        android:singleLine="true"
+        android:textIsSelectable="false"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="OnionTrafficOnly" />
+
+    <CheckBox
+        android:id="@+id/holder_isolation_flag_check_box"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:checked="true" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sampleapp/src/main/res/layout/spinner_list_item.xml
+++ b/sampleapp/src/main/res/layout/spinner_list_item.xml
@@ -1,4 +1,72 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
+-->
+
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"

--- a/sampleapp/src/main/res/navigation/mobile_navigation.xml
+++ b/sampleapp/src/main/res/navigation/mobile_navigation.xml
@@ -118,19 +118,19 @@
     <fragment
         android:id="@+id/navigation_settings_app"
         android:name="io.matthewnelson.sampleapp.ui.fragments.settings.app.SettingsAppFragment"
-        android:label="@string/navigation_label"
+        android:label="@string/navigation_settings_application"
         tools:layout="@layout/fragment_settings_app" />
 
     <fragment
         android:id="@+id/navigation_settings_library"
         android:name="io.matthewnelson.sampleapp.ui.fragments.settings.library.SettingsLibraryFragment"
-        android:label="@string/navigation_label"
+        android:label="@string/navigation_settings_library"
         tools:layout="@layout/fragment_settings_library" />
 
     <fragment
         android:id="@+id/navigation_settings_tor"
         android:name="io.matthewnelson.sampleapp.ui.fragments.settings.tor.SettingsTorFragment"
-        android:label="@string/navigation_label"
+        android:label="@string/navigation_settings_tor"
         tools:layout="@layout/fragment_settings_tor" />
 
 </navigation>

--- a/sampleapp/src/main/res/values/colors.xml
+++ b/sampleapp/src/main/res/values/colors.xml
@@ -12,6 +12,7 @@
     <color name="green">#4CAF50</color>
     <color name="blue">#3F51B5</color>
     <color name="red">#BD1B1B</color>
+    <color name="black">#000000</color>
 
     <color name="dash_message_drawable_border">#70000000</color>
 </resources>

--- a/sampleapp/src/main/res/values/colors.xml
+++ b/sampleapp/src/main/res/values/colors.xml
@@ -12,4 +12,6 @@
     <color name="green">#4CAF50</color>
     <color name="blue">#3F51B5</color>
     <color name="red">#BD1B1B</color>
+
+    <color name="dash_message_drawable_border">#70000000</color>
 </resources>

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -3,9 +3,9 @@
     <string name="navigation_label">TOPL-Android Demo</string>
 
     <!-- DashboardFragment -->
-    <string name="dashboard_text_view_control_port">Control Port:</string>
+    <string name="dashboard_text_view_dns_port">DNS Port:</string>
+    <string name="dashboard_text_view_http_port">HTTP Port:</string>
     <string name="dashboard_text_view_socks_port">Socks Port:</string>
-    <string name="dashboard_text_view_http_port">Http Port:</string>
     <string name="dash_button_app_restart">Application Restart Needed</string>
 
     <!-- HomeFragment -->

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -75,4 +75,6 @@
     <string name="settings_tor_text_view_socks_port_custom">Custom (eg. 9050):</string>
     <string name="settings_tor_text_view_http_port">Http Port:</string>
     <string name="settings_tor_text_view_http_port_custom">Custom (eg. 8118):</string>
+    <string name="settings_tor_text_view_dns_port">Dns Port:</string>
+    <string name="settings_tor_text_view_dns_port_custom">Custom (eg. 5400):</string>
 </resources>

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -73,10 +73,16 @@
     <string name="settings_tor_edit_text_hint_port_custom">1024 to 65535</string>
     <string name="settings_tor_text_view_socks_port">Socks Port:</string>
     <string name="settings_tor_text_view_socks_port_custom">Custom (eg. 9050):</string>
+    <string name="settings_tor_button_socks_isolation_flags">Socks Isolation Flags</string>
     <string name="settings_tor_text_view_http_port">HTTP Port:</string>
     <string name="settings_tor_text_view_http_port_custom">Custom (eg. 8118):</string>
+    <string name="settings_tor_button_http_isolation_flags">HTTP Isolation Flags</string>
     <string name="settings_tor_text_view_dns_port">DNS Port:</string>
     <string name="settings_tor_text_view_dns_port_custom">Custom (eg. 5400):</string>
+    <string name="settings_tor_button_dns_isolation_flags">DNS Isolation Flags</string>
     <string name="settings_tor_text_view_trans_port">Trans Port:</string>
     <string name="settings_tor_text_view_trans_port_custom">Custom (eg. 9040):</string>
+    <string name="settings_tor_button_trans_isolation_flags">Trans Isolation Flags</string>
+
+    <!-- IsolationFlagsFragment -->
 </resources>

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -68,6 +68,9 @@
     <string name="settings_library_edit_text_controller_stop_delay">100ms + your value</string>
     <string name="settings_library_text_view_controller_stop_on_task_removed">On Task Removed:</string>
     <string name="settings_library_text_view_controller_build_config">Build Config:</string>
+    <string name="settings_tor_text_view_socks_port">Socks Port:</string>
+    <string name="settings_tor_text_view_socks_port_custom">Custom (eg. 9050):</string>
+    <string name="settings_tor_edit_text_hint_socks_port_custom">1024 to 65535</string>
 
     <!-- SettingsTorFragment -->
 </resources>

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -68,9 +68,11 @@
     <string name="settings_library_edit_text_controller_stop_delay">100ms + your value</string>
     <string name="settings_library_text_view_controller_stop_on_task_removed">On Task Removed:</string>
     <string name="settings_library_text_view_controller_build_config">Build Config:</string>
-    <string name="settings_tor_text_view_socks_port">Socks Port:</string>
-    <string name="settings_tor_text_view_socks_port_custom">Custom (eg. 9050):</string>
-    <string name="settings_tor_edit_text_hint_socks_port_custom">1024 to 65535</string>
 
     <!-- SettingsTorFragment -->
+    <string name="settings_tor_edit_text_hint_port_custom">1024 to 65535</string>
+    <string name="settings_tor_text_view_socks_port">Socks Port:</string>
+    <string name="settings_tor_text_view_socks_port_custom">Custom (eg. 9050):</string>
+    <string name="settings_tor_text_view_http_port">Http Port:</string>
+    <string name="settings_tor_text_view_http_port_custom">Custom (eg. 8118):</string>
 </resources>

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -3,9 +3,9 @@
     <string name="navigation_label">TOPL-Android Demo</string>
 
     <!-- DashboardFragment -->
-    <string name="dashboard_text_view_dns_port">DNS Port:</string>
-    <string name="dashboard_text_view_http_port">HTTP Port:</string>
-    <string name="dashboard_text_view_socks_port">Socks Port:</string>
+    <string name="dashboard_text_view_dns_port">DNS:</string>
+    <string name="dashboard_text_view_http_port">HTTP:</string>
+    <string name="dashboard_text_view_socks_port">Socks:</string>
     <string name="dash_button_app_restart">Application Restart Needed</string>
 
     <!-- HomeFragment -->

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -73,8 +73,10 @@
     <string name="settings_tor_edit_text_hint_port_custom">1024 to 65535</string>
     <string name="settings_tor_text_view_socks_port">Socks Port:</string>
     <string name="settings_tor_text_view_socks_port_custom">Custom (eg. 9050):</string>
-    <string name="settings_tor_text_view_http_port">Http Port:</string>
+    <string name="settings_tor_text_view_http_port">HTTP Port:</string>
     <string name="settings_tor_text_view_http_port_custom">Custom (eg. 8118):</string>
-    <string name="settings_tor_text_view_dns_port">Dns Port:</string>
+    <string name="settings_tor_text_view_dns_port">DNS Port:</string>
     <string name="settings_tor_text_view_dns_port_custom">Custom (eg. 5400):</string>
+    <string name="settings_tor_text_view_trans_port">Trans Port:</string>
+    <string name="settings_tor_text_view_trans_port_custom">Custom (eg. 9040):</string>
 </resources>

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -88,4 +88,8 @@
     <string name="settings_tor_button_trans_isolation_flags">Trans Isolation Flags</string>
 
     <!-- IsolationFlagsFragment -->
+    <string name="isolation_fragment_reset_socks">Reset Socks Flags</string>
+    <string name="isolation_fragment_reset_http">Reset HTTP Flags</string>
+    <string name="isolation_fragment_reset_dns">Reset DNS Flags</string>
+    <string name="isolation_fragment_reset_trans">Reset Trans Flags</string>
 </resources>

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -1,6 +1,9 @@
 <resources>
     <!--    <string name="app_name">SampleApp</string>   See build.gradle buildTypes -->
     <string name="navigation_label">TOPL-Android Demo</string>
+    <string name="navigation_settings_application">Application Settings</string>
+    <string name="navigation_settings_library">Library Settings</string>
+    <string name="navigation_settings_tor">Tor Settings</string>
 
     <!-- DashboardFragment -->
     <string name="dashboard_text_view_dns_port">DNS:</string>

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/BaseConsts.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/BaseConsts.kt
@@ -253,9 +253,7 @@ abstract class BaseConsts {
         AnnotationTarget.PROPERTY
     )
     @StringDef(
-        IsolationFlag.ISOLATE_CLIENT_ADDR,
         IsolationFlag.NO_ISOLATE_CLIENT_ADDR,
-        IsolationFlag.ISOLATE_SOCKS_AUTH,
         IsolationFlag.NO_ISOLATE_SOCKS_AUTH,
         IsolationFlag.ISOLATE_CLIENT_PROTOCOL,
         IsolationFlag.ISOLATE_DEST_PORT,
@@ -279,9 +277,7 @@ abstract class BaseConsts {
     @Retention(AnnotationRetention.SOURCE)
     annotation class IsolationFlag {
         companion object {
-            const val ISOLATE_CLIENT_ADDR = "IsolateClientAddr" // on by default
             const val NO_ISOLATE_CLIENT_ADDR = "NoIsolateClientAddr"
-            const val ISOLATE_SOCKS_AUTH = "IsolateSOCKSAuth" // on by default
             const val NO_ISOLATE_SOCKS_AUTH = "NoIsolateSOCKSAuth"
             const val ISOLATE_CLIENT_PROTOCOL = "IsolateClientProtocol"
             const val ISOLATE_DEST_PORT = "IsolateDestPort"
@@ -304,9 +300,7 @@ abstract class BaseConsts {
 
             fun getAll(): List<@IsolationFlag String> {
                 return arrayListOf(
-                    ISOLATE_CLIENT_ADDR,
                     NO_ISOLATE_CLIENT_ADDR,
-                    ISOLATE_SOCKS_AUTH,
                     NO_ISOLATE_SOCKS_AUTH,
                     ISOLATE_CLIENT_PROTOCOL,
                     ISOLATE_DEST_PORT,

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/BaseConsts.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/BaseConsts.kt
@@ -177,6 +177,19 @@ abstract class BaseConsts {
         }
     }
 
+    @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE, AnnotationTarget.VALUE_PARAMETER)
+    @StringDef(
+        PortOption.AUTO,
+        PortOption.DISABLED
+    )
+    @Retention(AnnotationRetention.SOURCE)
+    annotation class PortOption {
+        companion object {
+            const val AUTO = "auto"
+            const val DISABLED = "0"
+        }
+    }
+
 
     ///////////////////////////
     /// TorConfigFile Names ///

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/BaseConsts.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/BaseConsts.kt
@@ -67,7 +67,6 @@
 package io.matthewnelson.topl_core_base
 
 import androidx.annotation.StringDef
-import java.lang.Error
 
 abstract class BaseConsts {
 
@@ -147,22 +146,38 @@ abstract class BaseConsts {
     ///////////////////
     /// TorSettings ///
     ///////////////////
-    @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)
+    @Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.TYPE
+    )
     @StringDef(
-        SupportedBridges.MEEK,
-        SupportedBridges.OBFS4,
-        SupportedBridges.SNOWFLAKE
+        SupportedBridgeType.MEEK,
+        SupportedBridgeType.OBFS4,
+        SupportedBridgeType.SNOWFLAKE
     )
     @Retention(AnnotationRetention.SOURCE)
-    annotation class SupportedBridges {
+    annotation class SupportedBridgeType {
         companion object {
             const val MEEK = "meek"
             const val OBFS4 = "obfs4"
             const val SNOWFLAKE = "snowflake"
+
+            fun getAll(): List<@SupportedBridgeType String> {
+                return arrayListOf(
+                    MEEK,
+                    OBFS4,
+                    SNOWFLAKE
+                )
+            }
         }
     }
 
-    @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE, AnnotationTarget.VALUE_PARAMETER)
+    @Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.TYPE,
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.PROPERTY
+    )
     @StringDef(
         ConnectionPadding.AUTO,
         ConnectionPadding.OFF,
@@ -174,10 +189,23 @@ abstract class BaseConsts {
             const val AUTO = "auto"
             const val OFF = "0"
             const val ON = "1"
+
+            fun getAll(): List<@ConnectionPadding String> {
+                return arrayListOf(
+                    AUTO,
+                    OFF,
+                    ON
+                )
+            }
         }
     }
 
-    @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE, AnnotationTarget.VALUE_PARAMETER)
+    @Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.TYPE,
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.PROPERTY
+    )
     @StringDef(
         PortOption.AUTO,
         PortOption.DISABLED
@@ -190,11 +218,44 @@ abstract class BaseConsts {
         }
     }
 
+    @Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.TYPE,
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.PROPERTY
+    )
+    @StringDef(
+        ProxyType.DISABLED,
+        ProxyType.HTTPS,
+        ProxyType.SOCKS_5
+    )
+    @Retention(AnnotationRetention.SOURCE)
+    annotation class ProxyType {
+        companion object {
+            const val DISABLED = ""
+            const val HTTPS = "HTTPS"
+            const val SOCKS_5 = "Socks5"
+
+            fun getAll(): List<@ProxyType String> {
+                return arrayListOf(
+                    DISABLED,
+                    HTTPS,
+                    SOCKS_5
+                )
+            }
+        }
+    }
+
 
     ///////////////////////////
     /// TorConfigFile Names ///
     ///////////////////////////
-    @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE, AnnotationTarget.VALUE_PARAMETER)
+    @Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.TYPE,
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.PROPERTY
+    )
     @StringDef(
         ConfigFileName.CONTROL_PORT,
         ConfigFileName.COOKIE_AUTH,

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/BaseConsts.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/BaseConsts.kt
@@ -246,6 +246,91 @@ abstract class BaseConsts {
         }
     }
 
+    @Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.TYPE,
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.PROPERTY
+    )
+    @StringDef(
+        IsolationFlag.ISOLATE_CLIENT_ADDR,
+        IsolationFlag.NO_ISOLATE_CLIENT_ADDR,
+        IsolationFlag.ISOLATE_SOCKS_AUTH,
+        IsolationFlag.NO_ISOLATE_SOCKS_AUTH,
+        IsolationFlag.ISOLATE_CLIENT_PROTOCOL,
+        IsolationFlag.ISOLATE_DEST_PORT,
+        IsolationFlag.ISOLATE_DEST_ADDR,
+        IsolationFlag.KEEP_ALIVE_ISOLATE_SOCKS_AUTH,
+        IsolationFlag.NO_IPV4_TRAFFIC,
+        IsolationFlag.IPV6_TRAFFIC,
+        IsolationFlag.PREFER_IPV6,
+        IsolationFlag.NO_DNS_REQUEST,
+        IsolationFlag.NO_ONION_TRAFFIC,
+        IsolationFlag.ONION_TRAFFIC_ONLY,
+        IsolationFlag.CACHE_IPV4_DNS,
+        IsolationFlag.CACHE_IPV6_DNS,
+        IsolationFlag.CACHE_DNS,
+        IsolationFlag.USE_IPV4_CACHE,
+        IsolationFlag.USE_IPV6_CACHE,
+        IsolationFlag.USE_DNS_CACHE,
+        IsolationFlag.PREFER_IPV6_AUTOMAP,
+        IsolationFlag.PREFER_SOCKS_NO_AUTH
+    )
+    @Retention(AnnotationRetention.SOURCE)
+    annotation class IsolationFlag {
+        companion object {
+            const val ISOLATE_CLIENT_ADDR = "IsolateClientAddr" // on by default
+            const val NO_ISOLATE_CLIENT_ADDR = "NoIsolateClientAddr"
+            const val ISOLATE_SOCKS_AUTH = "IsolateSOCKSAuth" // on by default
+            const val NO_ISOLATE_SOCKS_AUTH = "NoIsolateSOCKSAuth"
+            const val ISOLATE_CLIENT_PROTOCOL = "IsolateClientProtocol"
+            const val ISOLATE_DEST_PORT = "IsolateDestPort"
+            const val ISOLATE_DEST_ADDR = "IsolateDestAddr"
+            const val KEEP_ALIVE_ISOLATE_SOCKS_AUTH = "KeepAliveIsolateSOCKSAuth"
+            const val NO_IPV4_TRAFFIC = "NoIPv4Traffic"
+            const val IPV6_TRAFFIC = "IPv6Traffic"
+            const val PREFER_IPV6 = "PreferIPv6"
+            const val NO_DNS_REQUEST = "NoDNSRequest"
+            const val NO_ONION_TRAFFIC = "NoOnionTraffic"
+            const val ONION_TRAFFIC_ONLY = "OnionTrafficOnly"
+            const val CACHE_IPV4_DNS = "CacheIPv4DNS"
+            const val CACHE_IPV6_DNS = "CacheIPv6DNS"
+            const val CACHE_DNS = "CacheDNS"
+            const val USE_IPV4_CACHE = "UseIPv4Cache"
+            const val USE_IPV6_CACHE = "UseIPv6Cache"
+            const val USE_DNS_CACHE = "UseDNSCache"
+            const val PREFER_IPV6_AUTOMAP = "PreferIPv6Automap"
+            const val PREFER_SOCKS_NO_AUTH = "PreferSOCKSNoAuth"
+
+            fun getAll(): List<@IsolationFlag String> {
+                return arrayListOf(
+                    ISOLATE_CLIENT_ADDR,
+                    NO_ISOLATE_CLIENT_ADDR,
+                    ISOLATE_SOCKS_AUTH,
+                    NO_ISOLATE_SOCKS_AUTH,
+                    ISOLATE_CLIENT_PROTOCOL,
+                    ISOLATE_DEST_PORT,
+                    ISOLATE_DEST_ADDR,
+                    KEEP_ALIVE_ISOLATE_SOCKS_AUTH,
+                    NO_IPV4_TRAFFIC,
+                    IPV6_TRAFFIC,
+                    PREFER_IPV6,
+                    NO_DNS_REQUEST,
+                    NO_ONION_TRAFFIC,
+                    ONION_TRAFFIC_ONLY,
+                    CACHE_IPV4_DNS,
+                    CACHE_IPV6_DNS,
+                    CACHE_DNS,
+                    USE_IPV4_CACHE,
+                    USE_IPV6_CACHE,
+                    USE_DNS_CACHE,
+                    PREFER_IPV6_AUTOMAP,
+                    PREFER_SOCKS_NO_AUTH
+                )
+            }
+        }
+    }
+
 
     ///////////////////////////
     /// TorConfigFile Names ///

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorSettings.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorSettings.kt
@@ -132,7 +132,6 @@ abstract class TorSettings: BaseConsts() {
         const val DEFAULT__PROXY_USER = ""
         const val DEFAULT__REACHABLE_ADDRESS_PORTS = "" // "*:80,*:443"
         const val DEFAULT__RELAY_NICKNAME = ""
-        const val DEFAULT__RELAY_PORT = ""
         const val DEFAULT__RUN_AS_DAEMON = true
         const val DEFAULT__USE_SOCKS5 = false
     }
@@ -441,7 +440,7 @@ abstract class TorSettings: BaseConsts() {
      *
      * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#ORPort
      *
-     * See [DEFAULT__RELAY_PORT]
+     * See [BaseConsts.PortOption.DISABLED]
      * */
     abstract val relayPort: String
 

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorSettings.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorSettings.kt
@@ -138,16 +138,25 @@ abstract class TorSettings: BaseConsts() {
     }
 
     /**
+     * Adds to the torrc file "ConnectionPadding <0, 1, or auto>"
+     *
      * See [BaseConsts.ConnectionPadding.OFF]
      * */
     abstract val connectionPadding: @ConnectionPadding String
 
     /**
+     * If not null/not empty, will add the string value to the torrc file
+     *
      * Default [java.null]
      * */
     abstract val customTorrc: String?
 
     /**
+     * OnionProxyManager will enable this on startup using the TorControlConnection based off
+     * of the device's network state. Setting this to `true` is highly recommended.
+     *
+     * Adds to the torrc file "DisableNetwork <1 or 0>"
+     *
      * See [DEFAULT__DISABLE_NETWORK]
      * */
     abstract val disableNetwork: Boolean
@@ -155,6 +164,11 @@ abstract class TorSettings: BaseConsts() {
     /**
      * TorBrowser and Orbot use "5400" by default. It may be wise to pick something
      * that won't conflict.
+     *
+     * Disabled by default by Tor. Set to "O" to disable. Can also be "auto", or a specific
+     * port between "1024" and "65535"
+     *
+     * Adds to the torrc file "DNSPort <port or auto> <[dnsPortIsolationFlags]>"
      *
      * See [BaseConsts.PortOption.DISABLED]
      * */
@@ -164,70 +178,137 @@ abstract class TorSettings: BaseConsts() {
      * Express isolation flags to be added when enabling the [dnsPort]
      *
      * See [BaseConsts.IsolationFlag] for available options
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#SocksPort
      * */
     abstract val dnsPortIsolationFlags: List<@IsolationFlag String>?
 
     /**
+     * Set with a comma separated list of Entry Nodes.
+     *
+     * Adds to the torrc file "EntryNodes <node,node,node,...>"
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#EntryNodes
+     *
      * See [DEFAULT__ENTRY_NODES]
      * */
     abstract val entryNodes: String?
 
     /**
+     * Set with a comma separated list of Exit Nodes to be excluded.
+     *
+     * Adds to the torrc file "ExcludeExitNodes <node,node,node,...>"
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#ExcludeExitNodes
+     *
      * See [DEFAULT__EXCLUDED_NODES]
      * */
     abstract val excludeNodes: String?
 
     /**
+     * Set with a comma separated list of Exit Nodes to use.
+     *
+     * Adds to the torrc file "ExitNodes <node,node,node,...>"
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#ExitNodes
+     *
      * See [DEFAULT__EXIT_NODES]
      * */
     abstract val exitNodes: String?
 
     /**
+     * If `true`, adds to the torrc file "UseBridges 1" and will proc the adding of bridges.
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#UseBridges
+     *
      * See [DEFAULT__HAS_BRIDGES]
      * */
     abstract val hasBridges: Boolean
 
     /**
+     * **Highly** recommended to be set to `true` for securing the ControlPort
+     *
+     * Adds to the torrc file:
+     *
+     *   "CookieAuthentication 1"
+     *   "CookieAuthFile <[TorConfigFiles.cookieAuthFile] path>
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#CookieAuthentication
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#CookieAuthFile
+     *
      * See [DEFAULT__HAS_COOKIE_AUTHENTICATION]
      * */
     abstract val hasCookieAuthentication: Boolean
 
     /**
+     * Adds to the torrc file:
+     *
+     *   "Log debug syslog"
+     *   "Log info syslog"
+     *
      * See [DEFAULT__HAS_DEBUG_LOGS]
      * */
     abstract val hasDebugLogs: Boolean
 
     /**
+     * **Highly** recommended to be set to `true` for Android applications.
+     *
+     * If true, adds to the torrc file "DormantCanceledByStartup 1"
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#DormantCanceledByStartup
+     *
      * See [DEFAULT__HAS_DORMANT_CANCELED_BY_STARTUP]
      * */
     abstract val hasDormantCanceledByStartup: Boolean
 
     /**
+     * If true, adds to the torrc file "SocksListenAddress 0.0.0.0"
+     *
      * See [DEFAULT__HAS_OPEN_PROXY_ON_ALL_INTERFACES]
      * */
     abstract val hasOpenProxyOnAllInterfaces: Boolean
 
     /**
+     * If true, adds to the torrc file "ReachableAddresses <[reachableAddressPorts]>"
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#ReachableAddresses
+     *
      * See [DEFAULT__HAS_REACHABLE_ADDRESS]
      * */
     abstract val hasReachableAddress: Boolean
 
     /**
+     * If true, adds to the torrc file "ReducedConnectionPadding 1"
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#ReducedConnectionPadding
+     *
      * See [DEFAULT__HAS_REDUCED_CONNECTION_PADDING]
      * */
     abstract val hasReducedConnectionPadding: Boolean
 
     /**
+     * If true, adds to the torrc file "SafeSocks 1"
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#SafeSocks
+     *
      * See [DEFAULT__HAS_SAFE_SOCKS]
      * */
     abstract val hasSafeSocks: Boolean
 
     /**
+     * If true, adds to the torrc file "StrictNodes 1"
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#StrictNodes
+     *
      * See [DEFAULT__HAS_STRICT_NODES]
      * */
     abstract val hasStrictNodes: Boolean
 
     /**
+     * If true, adds to the torrc file "TestSocks 1"
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#TestSocks
+     *
      * See [DEFAULT__HAS_TEST_SOCKS]
      * */
     abstract val hasTestSocks: Boolean
@@ -235,10 +316,10 @@ abstract class TorSettings: BaseConsts() {
     /**
      * Could be "auto" or a specific port, such as "8288".
      *
-     * TorBrowser and Orbot use "8218" by default. It may be wise to pick something
-     * that won't conflict if you're using this setting.
+     * TorBrowser and Orbot use "8218" and "8118", respectively, by default.
+     * It may be wise to pick something that won't conflict if you're using this setting.
      *
-     * Docs: https://2019.www.torproject.org/docs/tor-manual.html.en#HTTPTunnelPort
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#HTTPTunnelPort
      *
      * See [BaseConsts.PortOption.DISABLED]
      * */
@@ -247,6 +328,8 @@ abstract class TorSettings: BaseConsts() {
     /**
      * Express isolation flags to be added when enabling the [httpTunnelPort]
      *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#SocksPort
+     *
      * See [BaseConsts.IsolationFlag] for available options
      * */
     abstract val httpTunnelPortIsolationFlags: List<@IsolationFlag String>?
@@ -254,7 +337,7 @@ abstract class TorSettings: BaseConsts() {
     /**
      * See [DEFAULT__IS_AUTO_MAP_HOSTS_ON_RESOLVE]
      *
-     * Docs: https://2019.www.torproject.org/docs/tor-manual.html.en#AutomapHostsOnResolve
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#AutomapHostsOnResolve
      * */
     abstract val isAutoMapHostsOnResolve: Boolean
 
@@ -289,11 +372,17 @@ abstract class TorSettings: BaseConsts() {
     abstract val proxyPort: Int?
 
     /**
+     * Adds to the torrc file "Socks5Proxy [proxySocks5Host]:[proxySocks5ServerPort]"
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#Socks5Proxy
+     *
      * See [DEFAULT__PROXY_SOCKS5_HOST]
      * */
     abstract val proxySocks5Host: String?
 
     /**
+     * Adds to the torrc file "Socks5Proxy [proxySocks5Host]:[proxySocks5ServerPort]"
+     *
      * Default = [java.null]
      *
      * Try ((Math.random() * 1000) + 10000).toInt()
@@ -301,6 +390,19 @@ abstract class TorSettings: BaseConsts() {
     abstract val proxySocks5ServerPort: Int?
 
     /**
+     * Depending on the [BaseConsts.ProxyType], will add authenticated Socks5 or HTTPS proxy,
+     * if other settings are configured properly.
+     *
+     * This only gets used if you declare the following settings set as:
+     *
+     *   [useSocks5] is set to `false`
+     *   [hasBridges] is set to `false`
+     *   [proxyType] is [BaseConsts.ProxyType.SOCKS_5] or [BaseConsts.ProxyType.HTTPS]
+     *   [proxyHost] is set (eg. 127.0.0.1)
+     *   [proxyPort] is `null`, or a port between 1024 and 65535
+     *   [proxyUser] is set
+     *   [proxyPassword] is set
+     *
      * See [BaseConsts.ProxyType.DISABLED]
      * */
     abstract val proxyType: @ProxyType String
@@ -311,6 +413,8 @@ abstract class TorSettings: BaseConsts() {
     abstract val proxyUser: String?
 
     /**
+     * Adds to the torrc file "ReachableAddresses <[reachableAddressPorts]>"
+     *
      * See [DEFAULT__REACHABLE_ADDRESS_PORTS]
      * */
     abstract val reachableAddressPorts: String
@@ -318,8 +422,7 @@ abstract class TorSettings: BaseConsts() {
     /**
      * See [DEFAULT__RELAY_NICKNAME]
      *
-     * If setting this value to something other than null or an empty String, see
-     * [relayPort] documentation.
+     * See [relayPort] documentation.
      * */
     abstract val relayNickname: String?
 
@@ -327,18 +430,23 @@ abstract class TorSettings: BaseConsts() {
      * TorBrowser and Orbot use 9001 by default. It may be wise to pick something
      * that won't conflict.
      *
+     * Adds to the torrc file "ORPort <[relayPort]>"
+     *
      * This only gets used if you declare the following settings set as:
      *   [hasReachableAddress] false
      *   [hasBridges] false
      *   [isRelay] true
      *   [relayNickname] "your nickname"
-     *   [relayPort] "auto", or a port between 1024 and 65535
+     *   [relayPort] "auto", or a port between "1024" and "65535"
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#ORPort
      *
      * See [DEFAULT__RELAY_PORT]
      * */
     abstract val relayPort: String
 
     /**
+     * If `true`, adds to the torrc file "RunAsDaemon 1"
      * See [DEFAULT__RUN_AS_DAEMON]
      * */
     abstract val runAsDaemon: Boolean
@@ -355,6 +463,8 @@ abstract class TorSettings: BaseConsts() {
 
     /**
      * Express isolation flags to be added when enabling the [socksPort]
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#SocksPort
      *
      * See [BaseConsts.IsolationFlag] for available options
      * */
@@ -374,6 +484,8 @@ abstract class TorSettings: BaseConsts() {
 
     /**
      * Express isolation flags to be added when enabling the [transPort]
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-manual.html.en#SocksPort
      *
      * See [BaseConsts.IsolationFlag] for available options
      * */

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorSettings.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorSettings.kt
@@ -114,13 +114,6 @@ abstract class TorSettings: BaseConsts() {
         const val DEFAULT__ENTRY_NODES = ""
         const val DEFAULT__EXCLUDED_NODES = ""
         const val DEFAULT__EXIT_NODES = ""
-        const val DEFAULT__PROXY_HOST = ""
-        const val DEFAULT__PROXY_PASSWORD = ""
-        const val DEFAULT__PROXY_SOCKS5_HOST = "" // "127.0.0.1"
-        const val DEFAULT__PROXY_USER = ""
-        const val DEFAULT__REACHABLE_ADDRESS_PORTS = "" // "*:80,*:443"
-        const val DEFAULT__RELAY_NICKNAME = ""
-        const val DEFAULT__RELAY_PORT = ""
         const val DEFAULT__HAS_BRIDGES = false
         const val DEFAULT__HAS_COOKIE_AUTHENTICATION = true
         const val DEFAULT__HAS_DEBUG_LOGS = false
@@ -133,9 +126,26 @@ abstract class TorSettings: BaseConsts() {
         const val DEFAULT__HAS_TEST_SOCKS = false
         const val DEFAULT__IS_AUTO_MAP_HOSTS_ON_RESOLVE = true
         const val DEFAULT__IS_RELAY = false
+        const val DEFAULT__PROXY_HOST = ""
+        const val DEFAULT__PROXY_PASSWORD = ""
+        const val DEFAULT__PROXY_SOCKS5_HOST = "" // "127.0.0.1"
+        const val DEFAULT__PROXY_USER = ""
+        const val DEFAULT__REACHABLE_ADDRESS_PORTS = "" // "*:80,*:443"
+        const val DEFAULT__RELAY_NICKNAME = ""
+        const val DEFAULT__RELAY_PORT = ""
         const val DEFAULT__RUN_AS_DAEMON = true
         const val DEFAULT__USE_SOCKS5 = false
     }
+
+    /**
+     * See [BaseConsts.ConnectionPadding.OFF]
+     * */
+    abstract val connectionPadding: @ConnectionPadding String
+
+    /**
+     * Default [java.null]
+     * */
+    abstract val customTorrc: String?
 
     /**
      * See [DEFAULT__DISABLE_NETWORK]
@@ -158,11 +168,6 @@ abstract class TorSettings: BaseConsts() {
     abstract val dnsPortIsolationFlags: List<@IsolationFlag String>?
 
     /**
-     * Default [java.null]
-     * */
-    abstract val customTorrc: String?
-
-    /**
      * See [DEFAULT__ENTRY_NODES]
      * */
     abstract val entryNodes: String?
@@ -176,6 +181,56 @@ abstract class TorSettings: BaseConsts() {
      * See [DEFAULT__EXIT_NODES]
      * */
     abstract val exitNodes: String?
+
+    /**
+     * See [DEFAULT__HAS_BRIDGES]
+     * */
+    abstract val hasBridges: Boolean
+
+    /**
+     * See [DEFAULT__HAS_COOKIE_AUTHENTICATION]
+     * */
+    abstract val hasCookieAuthentication: Boolean
+
+    /**
+     * See [DEFAULT__HAS_DEBUG_LOGS]
+     * */
+    abstract val hasDebugLogs: Boolean
+
+    /**
+     * See [DEFAULT__HAS_DORMANT_CANCELED_BY_STARTUP]
+     * */
+    abstract val hasDormantCanceledByStartup: Boolean
+
+    /**
+     * See [DEFAULT__HAS_OPEN_PROXY_ON_ALL_INTERFACES]
+     * */
+    abstract val hasOpenProxyOnAllInterfaces: Boolean
+
+    /**
+     * See [DEFAULT__HAS_REACHABLE_ADDRESS]
+     * */
+    abstract val hasReachableAddress: Boolean
+
+    /**
+     * See [DEFAULT__HAS_REDUCED_CONNECTION_PADDING]
+     * */
+    abstract val hasReducedConnectionPadding: Boolean
+
+    /**
+     * See [DEFAULT__HAS_SAFE_SOCKS]
+     * */
+    abstract val hasSafeSocks: Boolean
+
+    /**
+     * See [DEFAULT__HAS_STRICT_NODES]
+     * */
+    abstract val hasStrictNodes: Boolean
+
+    /**
+     * See [DEFAULT__HAS_TEST_SOCKS]
+     * */
+    abstract val hasTestSocks: Boolean
 
     /**
      * Could be "auto" or a specific port, such as "8288".
@@ -195,6 +250,20 @@ abstract class TorSettings: BaseConsts() {
      * See [BaseConsts.IsolationFlag] for available options
      * */
     abstract val httpTunnelPortIsolationFlags: List<@IsolationFlag String>?
+
+    /**
+     * See [DEFAULT__IS_AUTO_MAP_HOSTS_ON_RESOLVE]
+     *
+     * Docs: https://2019.www.torproject.org/docs/tor-manual.html.en#AutomapHostsOnResolve
+     * */
+    abstract val isAutoMapHostsOnResolve: Boolean
+
+    /**
+     * See [DEFAULT__IS_RELAY]
+     *
+     * If setting this to true, see [relayPort] documentation.
+     * */
+    abstract val isRelay: Boolean
 
     /**
      * Must have the transport binaries for obfs4 and/or snowflake, depending
@@ -270,6 +339,11 @@ abstract class TorSettings: BaseConsts() {
     abstract val relayPort: String
 
     /**
+     * See [DEFAULT__RUN_AS_DAEMON]
+     * */
+    abstract val runAsDaemon: Boolean
+
+    /**
      * Could be "auto" or a specific port, such as "9051".
      *
      * TorBrowser uses "9150", and Orbot uses "9050" by default. It may be wise
@@ -285,90 +359,6 @@ abstract class TorSettings: BaseConsts() {
      * See [BaseConsts.IsolationFlag] for available options
      * */
     abstract val socksPortIsolationFlags: List<@IsolationFlag String>?
-
-    /**
-     * TorBrowser and Orbot use "10.192.0.1/10", it may be wise to pick something
-     * that won't conflict if you are using this setting.
-     *
-     * Docs: https://2019.www.torproject.org/docs/tor-manual.html.en#VirtualAddrNetworkIPv6
-     * */
-    abstract val virtualAddressNetwork: String?
-
-    /**
-     * See [DEFAULT__HAS_BRIDGES]
-     * */
-    abstract val hasBridges: Boolean
-
-    /**
-     * See [BaseConsts.ConnectionPadding.OFF]
-     * */
-    abstract val connectionPadding: @ConnectionPadding String
-
-    /**
-     * See [DEFAULT__HAS_COOKIE_AUTHENTICATION]
-     * */
-    abstract val hasCookieAuthentication: Boolean
-
-    /**
-     * See [DEFAULT__HAS_DEBUG_LOGS]
-     *
-     * 
-     * */
-    abstract val hasDebugLogs: Boolean
-
-    /**
-     * See [DEFAULT__HAS_DORMANT_CANCELED_BY_STARTUP]
-     * */
-    abstract val hasDormantCanceledByStartup: Boolean
-
-    /**
-     * See [DEFAULT__HAS_OPEN_PROXY_ON_ALL_INTERFACES]
-     * */
-    abstract val hasOpenProxyOnAllInterfaces: Boolean
-
-    /**
-     * See [DEFAULT__HAS_REACHABLE_ADDRESS]
-     * */
-    abstract val hasReachableAddress: Boolean
-
-    /**
-     * See [DEFAULT__HAS_REDUCED_CONNECTION_PADDING]
-     * */
-    abstract val hasReducedConnectionPadding: Boolean
-
-    /**
-     * See [DEFAULT__HAS_SAFE_SOCKS]
-     * */
-    abstract val hasSafeSocks: Boolean
-
-    /**
-     * See [DEFAULT__HAS_STRICT_NODES]
-     * */
-    abstract val hasStrictNodes: Boolean
-
-    /**
-     * See [DEFAULT__HAS_TEST_SOCKS]
-     * */
-    abstract val hasTestSocks: Boolean
-
-    /**
-     * See [DEFAULT__IS_AUTO_MAP_HOSTS_ON_RESOLVE]
-     *
-     * Docs: https://2019.www.torproject.org/docs/tor-manual.html.en#AutomapHostsOnResolve
-     * */
-    abstract val isAutoMapHostsOnResolve: Boolean
-
-    /**
-     * See [DEFAULT__IS_RELAY]
-     *
-     * If setting this to true, see [relayPort] documentation.
-     * */
-    abstract val isRelay: Boolean
-
-    /**
-     * See [DEFAULT__RUN_AS_DAEMON]
-     * */
-    abstract val runAsDaemon: Boolean
 
     /**
      * Can be "auto", or a specified port such as "9141"
@@ -393,6 +383,14 @@ abstract class TorSettings: BaseConsts() {
      * See [DEFAULT__USE_SOCKS5]
      * */
     abstract val useSocks5: Boolean
+
+    /**
+     * TorBrowser and Orbot use "10.192.0.1/10", it may be wise to pick something
+     * that won't conflict if you are using this setting.
+     *
+     * Docs: https://2019.www.torproject.org/docs/tor-manual.html.en#VirtualAddrNetworkIPv6
+     * */
+    abstract val virtualAddressNetwork: String?
 
 //    override fun toString(): String {
 //        return "TorSettings{ " +

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/settings/TorSettingsBuilder.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/settings/TorSettingsBuilder.kt
@@ -284,12 +284,15 @@ class TorSettingsBuilder internal constructor(
 
     @SettingsConfig
     fun connectionPaddingFromSettings(): TorSettingsBuilder {
-        when (torSettings.connectionPadding) {
-            ConnectionPadding.AUTO, ConnectionPadding.OFF, ConnectionPadding.ON -> {
-                return connectionPadding(torSettings.connectionPadding)
+        return when (val padding = torSettings.connectionPadding) {
+            ConnectionPadding.OFF,
+            ConnectionPadding.ON -> {
+                return connectionPadding(padding)
+            }
+            else -> {
+                this
             }
         }
-        return this
     }
 
     fun controlPortWriteToFile(torConfigFiles: TorConfigFiles): TorSettingsBuilder {
@@ -329,15 +332,25 @@ class TorSettingsBuilder internal constructor(
         else
             this
 
-    fun dnsPort(dnsPort: String): TorSettingsBuilder {
-        buffer.append("DNSPort $dnsPort\n")
+    fun dnsPort(dnsPort: String, isolationFlags: List<@IsolationFlag String>?): TorSettingsBuilder {
+        if (dnsPort.isEmpty()) return this
+
+        buffer.append("DNSPort $dnsPort")
+
+        if (!isolationFlags.isNullOrEmpty()) {
+            isolationFlags.forEach { flag ->
+                buffer.append(" $flag")
+            }
+        }
+
+        buffer.append("\n")
         return this
     }
 
     @SettingsConfig
     fun dnsPortFromSettings(): TorSettingsBuilder =
-        if (torSettings.dnsPort != TorSettings.DEFAULT__DNS_PORT)
-            dnsPort(torSettings.dnsPort)
+        if (torSettings.dnsPort != PortOption.DISABLED)
+            dnsPort(torSettings.dnsPort, torSettings.dnsPortIsolationFlags)
         else
             this
 
@@ -384,33 +397,36 @@ class TorSettingsBuilder internal constructor(
         return this
     }
 
-    fun httpTunnelPort(port: String, isolationFlags: String?): TorSettingsBuilder {
+    fun httpTunnelPort(port: String, isolationFlags: List<@IsolationFlag String>?): TorSettingsBuilder {
+        if (port.isEmpty()) return this
+
         buffer.append("HTTPTunnelPort $port")
-        if (!isolationFlags.isNullOrEmpty())
-            buffer.append(" $isolationFlags")
+
+        if (!isolationFlags.isNullOrEmpty()) {
+            isolationFlags.forEach { flag ->
+                buffer.append(" $flag")
+            }
+        }
+
         buffer.append("\n")
         return this
     }
 
     @SettingsConfig
     fun httpTunnelPortFromSettings(): TorSettingsBuilder {
-        if (torSettings.httpTunnelPort == TorSettings.DEFAULT__HTTP_TUNNEL_PORT)
+        if (torSettings.httpTunnelPort == PortOption.DISABLED)
             return this
 
-        return httpTunnelPort(
-            torSettings.httpTunnelPort,
-            if (torSettings.hasIsolationAddressFlagForTunnel)
-                "IsolateDestAddr"
-            else
-                null
-        )
+        return httpTunnelPort(torSettings.httpTunnelPort, torSettings.httpTunnelPortIsolationFlags)
     }
 
-    fun makeNonExitRelay(dnsFile: String, orPort: Int, nickname: String): TorSettingsBuilder {
-        buffer.append("ServerDNSResolvConfFile $dnsFile\n")
-        buffer.append("ORPort $orPort\n")
-        buffer.append("Nickname $nickname\n")
-        buffer.append("ExitPolicy reject *:*\n")
+    fun makeNonExitRelay(dnsFile: String, orPort: String, nickname: String): TorSettingsBuilder {
+        if (orPort != PortOption.DISABLED) {
+            buffer.append("ServerDNSResolvConfFile $dnsFile\n")
+            buffer.append("ORPort $orPort\n")
+            buffer.append("Nickname $nickname\n")
+            buffer.append("ExitPolicy reject *:*\n")
+        }
         return this
     }
 
@@ -436,7 +452,11 @@ class TorSettingsBuilder internal constructor(
         ) {
             val relayPort = torSettings.relayPort
             val relayNickname = torSettings.relayNickname
-            if (relayPort != null && !relayNickname.isNullOrEmpty()) {
+
+            if (relayPort.isNotEmpty() &&
+                !relayNickname.isNullOrEmpty() &&
+                relayPort != PortOption.DISABLED
+            ) {
                 try {
                     val resolv = onionProxyContext.createQuad9NameserverFile()
                     makeNonExitRelay(resolv.canonicalPath, relayPort, relayNickname)
@@ -464,8 +484,10 @@ class TorSettingsBuilder internal constructor(
      * Set socks5 proxy with no authentication.
      */
     fun proxySocks5(host: String?, port: Int?): TorSettingsBuilder {
-        if (!host.isNullOrEmpty() && port != null)
-            buffer.append("socks5Proxy $host:$port\n")
+        if (!host.isNullOrEmpty()) {
+            val socks5Port = port?.let { ":$it" } ?: "" // Defaults to 1080 if port is empty
+            buffer.append("Socks5Proxy $host$socks5Port\n")
+        }
         return this
     }
 
@@ -480,13 +502,11 @@ class TorSettingsBuilder internal constructor(
             this
 
     /**
-     * Sets proxyWithAuthentication information. If proxyType, proxyHost or proxyPort is
-     * empty/null, then this method does nothing.
+     * Sets proxyWithAuthentication information.
      *
-     * HTTPProxyAuthenticator is deprecated as of 0.3.1.0-alpha, *use HTTPS/Socks5* authentication.
+     * requires that [TorSettings.useSocks5] && [TorSettings.hasBridges] are set to `false`
      *
-     * TODO: Remove support for HTTPProxyAuthenticator
-     * TODO: Re-work this mess with annotation types and when statements...
+     * NOTE: Only supports Socks5 or HTTPS
      * */
     fun proxyWithAuthentication(
         proxyType: String?,
@@ -495,20 +515,27 @@ class TorSettingsBuilder internal constructor(
         proxyUser: String?,
         proxyPass: String?
     ): TorSettingsBuilder {
-        if (!proxyType.isNullOrEmpty() && !proxyHost.isNullOrEmpty() && proxyPort != null) {
-            buffer.append("${proxyType}Proxy $proxyHost:$proxyPort\n")
-            if (proxyUser != null && proxyPass != null) {
-                if (proxyType.equals("socks5", ignoreCase = true)) {
-                    buffer.append("Socks5ProxyUsername $proxyUser\n")
-                    buffer.append("Socks5ProxyPassword $proxyPass\n")
-                } else {
-                    buffer.append("${proxyType}ProxyAuthenticator $proxyUser:$proxyPort\n")
-                }
-            } else if (proxyPass != null) {
-                buffer.append("${proxyType}ProxyAuthenticator $proxyUser:$proxyPort\n").append(proxyUser)
-                    .append(":").append(proxyPort.toString()).append("\n")
+        when {
+            proxyHost.isNullOrEmpty() ||
+            proxyUser.isNullOrEmpty() ||
+            proxyPass.isNullOrEmpty() -> {
+                return this
+            }
+            proxyType == ProxyType.SOCKS_5 -> {
+                buffer.append("Socks5ProxyUsername $proxyUser\n")
+                buffer.append("Socks5ProxyPassword $proxyPass\n")
+            }
+            proxyType == ProxyType.HTTPS -> {
+                buffer.append("${proxyType}ProxyAuthenticator $proxyUser:$proxyPass\n")
+            }
+            else -> {
+                return this
             }
         }
+
+        val port = proxyPort?.let { ":$it" } ?: "" // Will default to port 1080 if empty
+        buffer.append("${proxyType}Proxy $proxyHost$port\n")
+
         return this
     }
 
@@ -527,7 +554,7 @@ class TorSettingsBuilder internal constructor(
 
     fun reachableAddressPorts(reachableAddressesPorts: String?): TorSettingsBuilder {
         if (!reachableAddressesPorts.isNullOrEmpty())
-            buffer.append("ReachableAddresses ").append(reachableAddressesPorts).append("\n")
+            buffer.append("ReachableAddresses $reachableAddressesPorts\n")
         return this
     }
 
@@ -540,7 +567,7 @@ class TorSettingsBuilder internal constructor(
 
     fun reducedConnectionPadding(enable: Boolean): TorSettingsBuilder {
         val reducedPadding = if (enable) "1" else "0"
-        buffer.append("ReducedConnectionPadding $reducedPadding").append("\n")
+        buffer.append("ReducedConnectionPadding $reducedPadding\n")
         return this
     }
 
@@ -595,17 +622,17 @@ class TorSettingsBuilder internal constructor(
         return this
     }
 
-    fun socksPort(socksPort: String, isolationFlag: String?): TorSettingsBuilder {
+    fun socksPort(socksPort: String, isolationFlags: List<@IsolationFlag String>?): TorSettingsBuilder {
         if (socksPort.isEmpty()) return this
 
-        buffer.append("SOCKSPort ").append(socksPort)
+        buffer.append("SocksPort $socksPort")
 
-        if (!isolationFlag.isNullOrEmpty())
-            buffer.append(" ").append(isolationFlag)
+        if (!isolationFlags.isNullOrEmpty()) {
+            isolationFlags.forEach { flag ->
+                buffer.append(" $flag")
+            }
+        }
 
-        buffer.append(" KeepAliveIsolateSOCKSAuth")
-        buffer.append(" IPv6Traffic")
-        buffer.append(" PreferIPv6")
         buffer.append("\n")
         return this
     }
@@ -620,13 +647,7 @@ class TorSettingsBuilder internal constructor(
         if (!socksPort.equals("auto", ignoreCase = true) && isLocalPortOpen(socksPort.toInt()))
             socksPort = "auto"
 
-        return socksPort(
-            socksPort,
-            if (torSettings.hasIsolationAddressFlagForTunnel)
-                "IsolateDestAddr"
-            else
-                null
-        )
+        return socksPort(socksPort, torSettings.socksPortIsolationFlags)
     }
 
     fun strictNodes(enable: Boolean): TorSettingsBuilder {
@@ -665,21 +686,36 @@ class TorSettingsBuilder internal constructor(
             this
     }
 
-    fun transPort(transPort: String): TorSettingsBuilder {
-        buffer.append("TransPort ").append(transPort).append("\n")
+    fun transPort(transPort: String, isolationFlags: List<@IsolationFlag String>?): TorSettingsBuilder {
+        if (transPort.isEmpty()) return this
+
+        buffer.append("TransPort $transPort")
+
+        if (!isolationFlags.isNullOrEmpty()) {
+            isolationFlags.forEach { flag ->
+                buffer.append(" $flag")
+            }
+        }
+
+        buffer.append("\n")
         return this
     }
 
     @SettingsConfig
-    fun transPortFromSettings(): TorSettingsBuilder =
-        if (torSettings.transPort != TorSettings.DEFAULT__TRANS_PORT)
-            transPort(torSettings.transPort)
-        else
-            this
+    fun transPortFromSettings(): TorSettingsBuilder {
+        return when (val port = torSettings.transPort) {
+            PortOption.DISABLED -> {
+                this
+            }
+            else -> {
+                transPort(port, torSettings.transPortIsolationFlags)
+            }
+        }
+    }
 
     fun useBridges(useThem: Boolean): TorSettingsBuilder {
         val useBridges = if (useThem) "1" else "0"
-        buffer.append("UseBridges $useBridges").append("\n")
+        buffer.append("UseBridges $useBridges\n")
         return this
     }
 
@@ -692,7 +728,7 @@ class TorSettingsBuilder internal constructor(
 
     fun virtualAddressNetwork(address: String?): TorSettingsBuilder {
         if (!address.isNullOrEmpty())
-            buffer.append("VirtualAddrNetwork ").append(address).append("\n")
+            buffer.append("VirtualAddrNetwork $address\n")
         return this
     }
 

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/settings/TorSettingsBuilder.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/settings/TorSettingsBuilder.kt
@@ -308,7 +308,6 @@ class TorSettingsBuilder internal constructor(
     fun debugLogs(): TorSettingsBuilder {
         buffer.append("Log debug syslog\n")
         buffer.append("Log info syslog\n")
-        buffer.append("SafeLogging 1\n")
         return this
     }
 
@@ -597,7 +596,7 @@ class TorSettingsBuilder internal constructor(
 
     fun safeSocks(enable: Boolean): TorSettingsBuilder {
         val safeSocksSetting = if (enable) "1" else "0"
-        buffer.append("SafeSocks $safeSocksSetting").append("\n")
+        buffer.append("SafeSocks $safeSocksSetting\n")
         return this
     }
 
@@ -665,7 +664,7 @@ class TorSettingsBuilder internal constructor(
 
     fun testSocks(enable: Boolean): TorSettingsBuilder {
         val testSocksSetting = if (enable) "1" else "0"
-        buffer.append("TestSocks $testSocksSetting").append("\n")
+        buffer.append("TestSocks $testSocksSetting\n")
         return this
     }
 
@@ -758,7 +757,7 @@ class TorSettingsBuilder internal constructor(
     @Throws(IOException::class)
     fun addBridgesFromResources(): TorSettingsBuilder {
         if (torSettings.hasBridges) {
-            val bridgesStream = torInstaller.openBridgesStream()
+            val bridgesStream: InputStream? = torInstaller.openBridgesStream()
             if (bridgesStream != null) {
                 val formatType = bridgesStream.read()
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -80,7 +80,7 @@ import io.matthewnelson.topl_service.service.components.actions.ServiceActionPro
 import io.matthewnelson.topl_service.service.components.actions.ServiceActions
 import io.matthewnelson.topl_service.service.components.binding.TorServiceConnection
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
-import io.matthewnelson.topl_service.service.components.onionproxy.TorServiceEventBroadcaster
+import io.matthewnelson.topl_service.service.components.onionproxy.model.TorServiceEventBroadcaster
 import io.matthewnelson.topl_service.util.ServiceConsts
 
 class TorServiceController private constructor(): ServiceConsts() {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -75,9 +75,11 @@ import io.matthewnelson.topl_core_base.TorConfigFiles
 import io.matthewnelson.topl_core_base.TorSettings
 import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.lifecycle.BackgroundManager
+import io.matthewnelson.topl_service.prefs.TorServicePrefs
 import io.matthewnelson.topl_service.service.components.actions.ServiceActionProcessor
 import io.matthewnelson.topl_service.service.components.actions.ServiceActions
 import io.matthewnelson.topl_service.service.components.binding.TorServiceConnection
+import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
 import io.matthewnelson.topl_service.service.components.onionproxy.TorServiceEventBroadcaster
 import io.matthewnelson.topl_service.util.ServiceConsts
 
@@ -129,10 +131,16 @@ class TorServiceController private constructor(): ServiceConsts() {
         private val torServiceNotificationBuilder: ServiceNotification.Builder,
         private val backgroundManagerPolicy: BackgroundManager.Builder.Policy,
         private val buildConfigVersionCode: Int,
-        private val torSettings: TorSettings,
+        torSettings: TorSettings,
         private val geoipAssetPath: String,
         private val geoip6AssetPath: String
     ) {
+
+        init {
+            // Ensure TorSettings gets initialized no matter if exceptions are thrown
+            // elsewhere in the builder
+            BaseService.initializTorSettings(torSettings)
+        }
 
         private var appEventBroadcaster: TorServiceEventBroadcaster? = Companion.appEventBroadcaster
 //        private var heartbeatTime = BackgroundManager.heartbeatTime
@@ -281,7 +289,7 @@ class TorServiceController private constructor(): ServiceConsts() {
          * to operate with.
          *
          * @return [Builder]
-         * @sample [io.matthewnelson.sampleapp.App.customTorConfigFilesSetup]
+         * @sample [io.matthewnelson.sampleapp.topl_android.CodeSamples.customTorConfigFilesSetup]
          * @see [Builder.build]
          * */
         fun useCustomTorConfigFiles(torConfigFiles: TorConfigFiles): Builder {
@@ -311,7 +319,6 @@ class TorServiceController private constructor(): ServiceConsts() {
                 geoipAssetPath,
                 geoip6AssetPath,
                 torConfigFiles ?: TorConfigFiles.createConfig(application.applicationContext),
-                torSettings,
                 stopServiceOnTaskRemoved
             )
 
@@ -344,22 +351,33 @@ class TorServiceController private constructor(): ServiceConsts() {
         @JvmStatic
         @Throws(RuntimeException::class)
         fun getTorConfigFiles(): TorConfigFiles {
-            BaseService.getAppContext()
-            return BaseService.torConfigFiles
+            return try {
+                BaseService.torConfigFiles
+            } catch (e: UninitializedPropertyAccessException) {
+                throw RuntimeException(e.message)
+            }
         }
 
         /**
-         * Get the [TorSettings] that have been set after calling [Builder.build]. These are
+         * Get the [TorSettings] that have been set after instantiating [Builder]. These are
          * the [TorSettings] you initialized [TorServiceController.Builder] with.
          *
+         * If you call [Builder.build] from Application.onCreate, no matter if it throws an
+         * exception for configuration issues elsewhere in the [Builder], this method will
+         * *never* throw the [NullPointerException]. [BaseService.initializTorSettings] is
+         * called immediately upon instantiation of [Builder], so.
+         *
          * @return Instance of [TorSettings] that are being used throughout TOPL-Android
-         * @throws [RuntimeException] if called before [Builder.build]
+         * @throws [RuntimeException] if called before [Builder] is instantiated
          * */
         @JvmStatic
         @Throws(RuntimeException::class)
         fun getTorSettings(): TorSettings {
-            BaseService.getAppContext()
-            return BaseService.torSettings
+            return try {
+                BaseService.torSettings
+            } catch (e: UninitializedPropertyAccessException) {
+                throw RuntimeException(e.message)
+            }
         }
 
         /**

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -381,6 +381,16 @@ class TorServiceController private constructor(): ServiceConsts() {
         }
 
         /**
+         * Helper method for easily obtaining [ServiceTorSettings].
+         *
+         * @throws [RuntimeException] See [getTorSettings]
+         * */
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        fun getServiceTorSettings(context: Context): ServiceTorSettings =
+            ServiceTorSettings(TorServicePrefs(context), getTorSettings())
+
+        /**
          * Starts [TorService] and then Tor. You can call this as much as you want. If
          * the Tor [Process] is already running, it will do nothing.
          *

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -362,10 +362,9 @@ class TorServiceController private constructor(): ServiceConsts() {
          * Get the [TorSettings] that have been set after instantiating [Builder]. These are
          * the [TorSettings] you initialized [TorServiceController.Builder] with.
          *
-         * If you call [Builder.build] from Application.onCreate, no matter if it throws an
-         * exception for configuration issues elsewhere in the [Builder], this method will
-         * *never* throw the [NullPointerException]. [BaseService.initializTorSettings] is
-         * called immediately upon instantiation of [Builder], so.
+         * This method will *never* throw the [RuntimeException] if you call it after
+         * you have instantiated the [Builder] object, as [TorSettings] are set immediately
+         * via [BaseService.initializTorSettings].
          *
          * @return Instance of [TorSettings] that are being used throughout TOPL-Android
          * @throws [RuntimeException] if called before [Builder] is instantiated

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefs.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefs.kt
@@ -129,6 +129,10 @@ class TorServicePrefs(context: Context): ServiceConsts() {
     fun contains(prefsKey: String): Boolean =
         prefs.contains(prefsKey)
 
+    @Throws(NullPointerException::class)
+    fun getAll(): Map<String, *> =
+        prefs.all
+
     /**
      * Returns a Boolean value for the provided [ServiceConsts.PrefKeyBoolean]. If no
      * value is stored in the SharedPreference, [defValue] will be returned.
@@ -199,6 +203,13 @@ class TorServicePrefs(context: Context): ServiceConsts() {
     //////////////
     /// Modify ///
     //////////////
+
+    fun clear() {
+        val editor = prefs.edit().clear()
+        if (!editor.commit())
+            editor.apply()
+    }
+
     /**
      * Removes from the SharedPreference the value associated with [prefsKey] if there is one.
      * Accepts the following annotation type String values:

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefs.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefs.kt
@@ -126,7 +126,7 @@ class TorServicePrefs(context: Context): ServiceConsts() {
      *  @return True if the SharedPreference contains a value for the associated
      *   [prefsKey], false if not
      *  * */
-    fun contains(@PrefKeyBoolean @PrefKeyInt @PrefKeyList @PrefKeyString prefsKey: String): Boolean =
+    fun contains(prefsKey: String): Boolean =
         prefs.contains(prefsKey)
 
     /**
@@ -209,7 +209,7 @@ class TorServicePrefs(context: Context): ServiceConsts() {
      *
      *  @param [prefsKey] String of type ServiceConsts.PrefKey*
      *  * */
-    fun remove(@PrefKeyBoolean @PrefKeyInt @PrefKeyList @PrefKeyString prefsKey: String) {
+    fun remove(prefsKey: String) {
         val editor = prefs.edit().remove(prefsKey)
         if (!editor.commit())
             editor.apply()

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -108,9 +108,16 @@ internal abstract class BaseService: Service() {
         var geoip6AssetPath: String = ""
             private set
         lateinit var torConfigFiles: TorConfigFiles
+            private set
         lateinit var torSettings: TorSettings
+            private set
         var stopServiceOnTaskRemoved: Boolean = true
             private set
+
+        fun initializTorSettings(settings: TorSettings) {
+            if (!::torSettings.isInitialized)
+                torSettings = settings
+        }
 
         fun initialize(
             application: Application,
@@ -119,7 +126,6 @@ internal abstract class BaseService: Service() {
             geoipAssetPath: String,
             geoip6AssetPath: String,
             torConfigFiles: TorConfigFiles,
-            torSettings: TorSettings,
             stopServiceOnTaskRemoved: Boolean
         ) {
             this.application = application
@@ -128,7 +134,6 @@ internal abstract class BaseService: Service() {
             this.geoipAssetPath = geoipAssetPath
             this.geoip6AssetPath = geoip6AssetPath
             this.torConfigFiles = torConfigFiles
-            this.torSettings = torSettings
             this.stopServiceOnTaskRemoved = stopServiceOnTaskRemoved
         }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -74,6 +74,7 @@ import io.matthewnelson.topl_core.broadcaster.BroadcastLogger
 import io.matthewnelson.topl_core.util.FileUtilities
 import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.lifecycle.BackgroundManager
+import io.matthewnelson.topl_service.prefs.TorServicePrefs
 import io.matthewnelson.topl_service.service.components.binding.TorServiceBinder
 import io.matthewnelson.topl_service.service.components.binding.TorServiceConnection
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceEventBroadcaster
@@ -197,7 +198,7 @@ internal class TorService: BaseService() {
             context,
             TorServiceController.getTorConfigFiles(),
             ServiceTorInstaller(this),
-            ServiceTorSettings(this, TorServiceController.getTorSettings()),
+            TorServiceController.getServiceTorSettings(context),
             ServiceEventListener(),
             ServiceEventBroadcaster(this),
             buildConfigDebug

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
@@ -67,7 +67,6 @@
 package io.matthewnelson.topl_service.service.components.onionproxy
 
 import io.matthewnelson.topl_core.OnionProxyManager
-import io.matthewnelson.topl_core.listener.BaseEventListener
 import io.matthewnelson.topl_core_base.EventBroadcaster
 import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.service.BaseService

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
@@ -229,24 +229,29 @@ internal class ServiceEventBroadcaster(private val torService: BaseService): Eve
                 handleBootstrappedMsg(msg)
             }
             // Control Port
+            // NOTICE|OnionProxyManager|Successfully connected to Control Port: 44201
             msg.contains("Successfully connected to Control Port:") -> {
-                handleControlPortMsg(msg)
+                controlPort = getPortFromMsg(msg)
             }
             // Dns Port
+            // NOTICE|OnionProxyManager|Opened DNS listener on 127.0.0.1:5400
             msg.contains("Opened DNS listener on ") -> {
-                handleDnsPortMsg(msg)
+                dnsPort = getPortFromMsg(msg)
             }
             // Http Tunnel Port
+            // NOTICE|BaseEventListener|Opened HTTP tunnel listener on 127.0.0.1:8118
             msg.contains("Opened HTTP tunnel listener on ") -> {
-                handleHttpTunnelPortMsg(msg)
+                httpTunnelPort = getPortFromMsg(msg)
             }
             // Socks Port
+            // NOTICE|BaseEventListener|Opened Socks listener on 127.0.0.1:9050
             msg.contains("Opened Socks listener on ") -> {
-                handleSocksPortMsg(msg)
+                socksPort = getPortFromMsg(msg)
             }
             // Trans Port
+            // NOTICE|BaseEventListener|Opened Transparent pf/netfilter listener on 127.0.0.1:9040
             msg.contains("Opened Transparent pf/netfilter listener on ") -> {
-                handleTransPortMsg(msg)
+                transPort = getPortFromMsg(msg)
             }
             // NEWNYM
             msg.contains(TorControlCommands.SIGNAL_NEWNYM) -> {
@@ -290,35 +295,8 @@ internal class ServiceEventBroadcaster(private val torService: BaseService): Eve
         }
     }
 
-    // NOTICE|OnionProxyManager|Successfully connected to Control Port: 44201
-    private fun handleControlPortMsg(msg: String) {
-        val port = msg.split(":")[1].trim()
-        controlPort = "127.0.0.1:$port"
-    }
-
-    // NOTICE|OnionProxyManager|Opened DNS listener on 127.0.0.1:5400
-    private fun handleDnsPortMsg(msg: String) {
-        val port = msg.split(":")[1].trim()
-        dnsPort = "127.0.0.1:$port"
-    }
-
-    // NOTICE|BaseEventListener|Opened HTTP tunnel listener on 127.0.0.1:8118
-    private fun handleHttpTunnelPortMsg(msg: String) {
-        val port = msg.split(":")[1].trim()
-        httpTunnelPort = "127.0.0.1:$port"
-    }
-
-    // NOTICE|BaseEventListener|Opened Socks listener on 127.0.0.1:9050
-    private fun handleSocksPortMsg(msg: String) {
-        val port = msg.split(":")[1].trim()
-        socksPort = "127.0.0.1:$port"
-    }
-
-    // NOTICE|BaseEventListener|Opened Transparent pf/netfilter listener on 127.0.0.1:9040
-    private fun handleTransPortMsg(msg: String) {
-        val port = msg.split(":")[1].trim()
-        transPort = "127.0.0.1:$port"
-    }
+    private fun getPortFromMsg(msg: String): String =
+        "127.0.0.1:${msg.split(":")[1].trim()}"
 
     private fun handleNewNymMsg(msg: String) {
         val msgToShow: String? =

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
@@ -214,6 +214,8 @@ internal class ServiceEventBroadcaster(private val torService: BaseService): Eve
     private var httpTunnelPort: String? = null
     @Volatile
     private var socksPort: String? = null
+    @Volatile
+    private var transPort: String? = null
 
     override fun broadcastNotice(msg: String) {
 
@@ -241,6 +243,10 @@ internal class ServiceEventBroadcaster(private val torService: BaseService): Eve
             // Socks Port
             msg.contains("Opened Socks listener on ") -> {
                 handleSocksPortMsg(msg)
+            }
+            // Trans Port
+            msg.contains("Opened Transparent pf/netfilter listener on ") -> {
+                handleTransPortMsg(msg)
             }
             // NEWNYM
             msg.contains(TorControlCommands.SIGNAL_NEWNYM) -> {
@@ -308,6 +314,12 @@ internal class ServiceEventBroadcaster(private val torService: BaseService): Eve
         socksPort = "127.0.0.1:$port"
     }
 
+    // NOTICE|BaseEventListener|Opened Transparent pf/netfilter listener on 127.0.0.1:9040
+    private fun handleTransPortMsg(msg: String) {
+        val port = msg.split(":")[1].trim()
+        transPort = "127.0.0.1:$port"
+    }
+
     private fun handleNewNymMsg(msg: String) {
         val msgToShow: String? =
             when {
@@ -368,7 +380,8 @@ internal class ServiceEventBroadcaster(private val torService: BaseService): Eve
                         controlPort,
                         dnsPort,
                         httpTunnelPort,
-                        socksPort
+                        socksPort,
+                        transPort
                     )
                 )
             }
@@ -414,6 +427,7 @@ internal class ServiceEventBroadcaster(private val torService: BaseService): Eve
             dnsPort = null
             httpTunnelPort = null
             socksPort = null
+            transPort = null
             updateAppEventBroadcasterWithPortInfo()
             torService.removeNotificationActions()
         }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorInstaller.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorInstaller.kt
@@ -168,14 +168,14 @@ internal class ServiceTorInstaller(private val torService: BaseService): TorInst
         * */
         // TODO: Completely refactor how bridges work.
         val userDefinedBridgeList: String =
-            torServicePrefs.getList(PrefKeyList.LIST_OF_SUPPORTED_BRIDGES, arrayListOf()).joinToString()
+            torServicePrefs.getList(PrefKeyList.USER_DEFINED_BRIDGES, arrayListOf()).joinToString()
         var bridgeType = (if (userDefinedBridgeList.length > 9) 1 else 0).toByte()
         // Terrible hack. Must keep in sync with topl::addBridgesFromResources.
         if (bridgeType.toInt() == 0) {
             when (userDefinedBridgeList) {
-                SupportedBridges.OBFS4 -> bridgeType = 2
-                SupportedBridges.MEEK -> bridgeType = 3
-                SupportedBridges.SNOWFLAKE -> bridgeType = 4
+                SupportedBridgeType.OBFS4 -> bridgeType = 2
+                SupportedBridgeType.MEEK -> bridgeType = 3
+                SupportedBridgeType.SNOWFLAKE -> bridgeType = 4
             }
         }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorSettings.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorSettings.kt
@@ -414,7 +414,7 @@ class ServiceTorSettings internal constructor(
         get() = servicePrefs.getString(PrefKeyString.TRANS_PORT, defaultTorSettings.transPort) ?: defaultTorSettings.transPort
 
     @Throws(IllegalArgumentException::class)
-    fun socksTransPortSave(transPort: String) {
+    fun transPortSave(transPort: String) {
         when {
             transPort == defaultTorSettings.transPort -> {
                 servicePrefs.remove(PrefKeyString.TRANS_PORT)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorSettings.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorSettings.kt
@@ -86,7 +86,9 @@ import io.matthewnelson.topl_service.prefs.TorServicePrefs
  *
  * It also makes designing of a settings screen much easier for your application.
  *
- * @param [servicePrefs] [TorServicePrefs] to query shared preferences for potential values set by user.
+ * Use [io.matthewnelson.topl_service.TorServiceController.getServiceTorSettings] to instantiate
+ *
+ * @param [servicePrefs] [TorServicePrefs] to query/save values to shared preferences
  * @param [defaultTorSettings] Default values to fall back on if nothing is returned from
  *   [TorServicePrefs]. Use [io.matthewnelson.topl_service.TorServiceController.getTorSettings] for
  *   this value.
@@ -99,6 +101,14 @@ class ServiceTorSettings internal constructor(
     override val disableNetwork: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.DISABLE_NETWORK, defaultTorSettings.disableNetwork)
 
+    /**
+     * Saves the value for [disableNetwork] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [boolean]
+     * @see [TorSettings.disableNetwork]
+     * */
     fun disableNetworkSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.disableNetwork)
             servicePrefs.remove(PrefKeyBoolean.DISABLE_NETWORK)
@@ -110,6 +120,16 @@ class ServiceTorSettings internal constructor(
         get() = servicePrefs.getString(PrefKeyString.DNS_PORT, defaultTorSettings.dnsPort)
             ?: defaultTorSettings.dnsPort
 
+    /**
+     * Saves the value for [dnsPort] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [dnsPort] A String value of 0, auto, or number between 1024 and 65535
+     * @see [checkPortSelection]
+     * @see [TorSettings.dnsPort]
+     * @throws [IllegalArgumentException] if the value is not 0, auto, or between 1024 and 65535
+     * */
     @Throws(IllegalArgumentException::class)
     fun dnsPortSave(dnsPort: String) {
         when {
@@ -133,6 +153,16 @@ class ServiceTorSettings internal constructor(
             defaultTorSettings.dnsPortIsolationFlags ?: arrayListOf()
         )
 
+    /**
+     * Saves the value for [isolationFlags] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [isolationFlags] A List of [io.matthewnelson.topl_core_base.BaseConsts.IsolationFlag]'s
+     *   for the [dnsPort]
+     * @see [io.matthewnelson.topl_core_base.BaseConsts.IsolationFlag]
+     * @see [TorSettings.dnsPortIsolationFlags]
+     * */
     fun dnsPortIsolationFlagsSave(isolationFlags: List<@IsolationFlag String>) {
         if (isolationFlags == defaultTorSettings.dnsPortIsolationFlags) {
             servicePrefs.remove(PrefKeyList.DNS_PORT_ISOLATION_FLAGS)
@@ -144,6 +174,14 @@ class ServiceTorSettings internal constructor(
     override val customTorrc: String?
         get() = servicePrefs.getString(PrefKeyString.CUSTOM_TORRC, defaultTorSettings.customTorrc)
 
+    /**
+     * Saves the value for [customTorrc] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [customTorrc] A String of values to be added to the torrc file
+     * @see [TorSettings.customTorrc]
+     * */
     fun customTorrcSave(customTorrc: String?) {
         if (customTorrc == defaultTorSettings.customTorrc)
             servicePrefs.remove(PrefKeyString.CUSTOM_TORRC)
@@ -154,6 +192,14 @@ class ServiceTorSettings internal constructor(
     override val entryNodes: String?
         get() = servicePrefs.getString(PrefKeyString.ENTRY_NODES, defaultTorSettings.entryNodes)
 
+    /**
+     * Saves the value for [entryNodes] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [entryNodes] A comma separated list of nodes
+     * @see [TorSettings.entryNodes]
+     * */
     fun entryNodesSave(entryNodes: String?) {
         if (entryNodes == defaultTorSettings.entryNodes)
             servicePrefs.remove(PrefKeyString.ENTRY_NODES)
@@ -164,6 +210,14 @@ class ServiceTorSettings internal constructor(
     override val excludeNodes: String?
         get() = servicePrefs.getString(PrefKeyString.EXCLUDED_NODES, defaultTorSettings.excludeNodes)
 
+    /**
+     * Saves the value for [excludeNodes] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [excludeNodes] A comma separated list of nodes
+     * @see [TorSettings.excludeNodes]
+     * */
     fun excludeNodesSave(excludeNodes: String?) {
         if (excludeNodes == defaultTorSettings.excludeNodes)
             servicePrefs.remove(PrefKeyString.EXCLUDED_NODES)
@@ -174,6 +228,14 @@ class ServiceTorSettings internal constructor(
     override val exitNodes: String?
         get() = servicePrefs.getString(PrefKeyString.EXIT_NODES, defaultTorSettings.exitNodes)
 
+    /**
+     * Saves the value for [exitNodes] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [exitNodes] A comma separated list of nodes
+     * @see [TorSettings.exitNodes]
+     * */
     fun exitNodesSave(exitNodes: String?) {
         if (exitNodes == defaultTorSettings.exitNodes)
             servicePrefs.remove(PrefKeyString.EXIT_NODES)
@@ -185,6 +247,16 @@ class ServiceTorSettings internal constructor(
         get() = servicePrefs.getString(PrefKeyString.HTTP_TUNNEL_PORT, defaultTorSettings.httpTunnelPort)
             ?: defaultTorSettings.httpTunnelPort
 
+    /**
+     * Saves the value for [httpPort] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [httpPort] A String value of 0, auto, or number between 1024 and 65535
+     * @see [checkPortSelection]
+     * @see [TorSettings.httpTunnelPort]
+     * @throws [IllegalArgumentException] if the value is not 0, auto, or between 1024 and 65535
+     * */
     @Throws(IllegalArgumentException::class)
     fun httpTunnelPortSave(httpPort: String) {
         when {
@@ -208,6 +280,16 @@ class ServiceTorSettings internal constructor(
             defaultTorSettings.httpTunnelPortIsolationFlags ?: arrayListOf()
         )
 
+    /**
+     * Saves the value for [isolationFlags] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [isolationFlags] A List of [io.matthewnelson.topl_core_base.BaseConsts.IsolationFlag]'s
+     *   for the [httpTunnelPort]
+     * @see [io.matthewnelson.topl_core_base.BaseConsts.IsolationFlag]
+     * @see [TorSettings.httpTunnelPortIsolationFlags]
+     * */
     fun httpPortIsolationFlagsSave(isolationFlags: List<@IsolationFlag String>) {
         if (isolationFlags == defaultTorSettings.httpTunnelPortIsolationFlags) {
             servicePrefs.remove(PrefKeyList.HTTP_TUNNEL_PORT_ISOLATION_FLAGS)
@@ -219,31 +301,186 @@ class ServiceTorSettings internal constructor(
     override val listOfSupportedBridges: List<@SupportedBridgeType String>
         get() = defaultTorSettings.listOfSupportedBridges
 
+    // TODO: write a save method after refactor
+
     override val proxyHost: String?
         get() = servicePrefs.getString(PrefKeyString.PROXY_HOST, defaultTorSettings.proxyHost)
+
+    /**
+     * Saves the value for [proxyHost] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [proxyHost]
+     * @see [TorSettings.proxyHost]
+     * */
+    fun proxyHostSave(proxyHost: String?) {
+        if (proxyHost == defaultTorSettings.proxyHost)
+            servicePrefs.remove(PrefKeyString.PROXY_HOST)
+        else
+            servicePrefs.putString(PrefKeyString.PROXY_HOST, proxyHost)
+    }
 
     override val proxyPassword: String?
         get() = servicePrefs.getString(PrefKeyString.PROXY_PASSWORD, defaultTorSettings.proxyPassword)
 
+    /**
+     * Saves the value for [proxyPassword] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [proxyPassword]
+     * @see [TorSettings.proxyPassword]
+     * */
+    fun proxyPasswordSave(proxyPassword: String?) {
+        if (proxyPassword == defaultTorSettings.proxyPassword)
+            servicePrefs.remove(PrefKeyString.PROXY_PASSWORD)
+        else
+            servicePrefs.putString(PrefKeyString.PROXY_PASSWORD, proxyPassword)
+    }
+
     override val proxyPort: Int?
         get() = servicePrefs.getInt(PrefKeyInt.PROXY_PORT, defaultTorSettings.proxyPort)
+
+    /**
+     * Saves the value for [proxyPort] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [proxyPort] An Int value between 1024 and 65535, or `null`
+     * @see [checkPortSelection]
+     * @see [TorSettings.proxyPort]
+     * @throws [IllegalArgumentException] if the value is not `null`, or between 1024 and 65535
+     * */
+    @Throws(IllegalArgumentException::class)
+    fun proxyPortSave(proxyPort: Int?) {
+        when {
+            proxyPort == defaultTorSettings.proxyPort -> {
+                servicePrefs.remove(PrefKeyInt.PROXY_PORT)
+            }
+            proxyPort == null ||
+            checkPortSelection(proxyPort, checkZero = false) -> {
+                servicePrefs.putInt(PrefKeyInt.PROXY_PORT, proxyPort)
+            }
+            else -> {
+                throw IllegalArgumentException(
+                    "Proxy Port must null, or between 1024 and 65535"
+                )
+            }
+        }
+    }
 
     override val proxySocks5Host: String?
         get() = servicePrefs.getString(PrefKeyString.PROXY_SOCKS5_HOST, defaultTorSettings.proxySocks5Host)
 
+    /**
+     * Saves the value for [proxySocks5Host] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [proxySocks5Host]
+     * @see [TorSettings.proxySocks5Host]
+     * */
+    fun proxySocks5HostSave(proxySocks5Host: String?) {
+        if (proxySocks5Host == defaultTorSettings.proxySocks5Host)
+            servicePrefs.remove(PrefKeyString.PROXY_SOCKS5_HOST)
+        else
+            servicePrefs.putString(PrefKeyString.PROXY_SOCKS5_HOST, proxySocks5Host)
+    }
+
     override val proxySocks5ServerPort: Int?
         get() = servicePrefs.getInt(PrefKeyInt.PROXY_SOCKS5_SERVER_PORT, defaultTorSettings.proxySocks5ServerPort)
+
+    /**
+     * Saves the value for [proxySocks5ServerPort] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [proxySocks5ServerPort] An Int value between 1024 and 65535, or `null`
+     * @see [checkPortSelection]
+     * @see [TorSettings.proxySocks5ServerPort]
+     * @throws [IllegalArgumentException] if the value is not `null`, or between 1024 and 65535
+     * */
+    @Throws(IllegalArgumentException::class)
+    fun proxySocks5ServerPortSave(proxySocks5ServerPort: Int?) {
+        when {
+            proxySocks5ServerPort == defaultTorSettings.proxySocks5ServerPort -> {
+                servicePrefs.remove(PrefKeyInt.PROXY_SOCKS5_SERVER_PORT)
+            }
+            proxySocks5ServerPort == null ||
+            checkPortSelection(proxySocks5ServerPort, checkZero = false) -> {
+                servicePrefs.putInt(PrefKeyInt.PROXY_SOCKS5_SERVER_PORT, proxySocks5ServerPort)
+            }
+            else -> {
+                throw IllegalArgumentException(
+                    "ProxySocks5Server Port must null, or between 1024 and 65535"
+                )
+            }
+        }
+    }
 
     override val proxyType: @ProxyType String
         get() = servicePrefs.getString(PrefKeyString.PROXY_TYPE, defaultTorSettings.proxyType) ?: defaultTorSettings.proxyType
 
+    /**
+     * Saves the value for [proxyType] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [proxyType] A [io.matthewnelson.topl_core_base.BaseConsts.ProxyType]
+     * @see [io.matthewnelson.topl_core_base.BaseConsts.ProxyType]
+     * @see [TorSettings.proxyType]
+     * @throws [IllegalArgumentException] if the value is not empty (disabled), HTTPS, or Socks5
+     * */
+    @Throws(IllegalArgumentException::class)
+    fun proxyTypeSave(@ProxyType proxyType: String) {
+        when (proxyType) {
+            ProxyType.DISABLED,
+            ProxyType.HTTPS,
+            ProxyType.SOCKS_5 -> {
+                if (proxyType == defaultTorSettings.proxyType)
+                    servicePrefs.remove(PrefKeyString.PROXY_TYPE)
+                else
+                    servicePrefs.putString(PrefKeyString.PROXY_TYPE, proxyType)
+            }
+            else -> {
+                throw IllegalArgumentException(
+                    "ProxyType must be '' (empty/disabled), HTTPS, or Socks5"
+                )
+            }
+        }
+    }
+
     override val proxyUser: String?
         get() = servicePrefs.getString(PrefKeyString.PROXY_USER, defaultTorSettings.proxyUser)
+
+    /**
+     * Saves the value for [proxyUser] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [proxyUser]
+     * @see [TorSettings.proxyUser]
+     * */
+    fun proxyUserSave(proxyUser: String?) {
+        if (proxyUser == defaultTorSettings.proxyUser)
+            servicePrefs.remove(PrefKeyString.PROXY_USER)
+        else
+            servicePrefs.putString(PrefKeyString.PROXY_USER, proxyUser)
+    }
 
     override val reachableAddressPorts: String
         get() = servicePrefs.getString(PrefKeyString.REACHABLE_ADDRESS_PORTS, defaultTorSettings.reachableAddressPorts)
             ?: defaultTorSettings.reachableAddressPorts
 
+    /**
+     * Saves the value for [reachableAddressPorts] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [reachableAddressPorts]
+     * @see [TorSettings.reachableAddressPorts]
+     * */
     fun reachableAddressPortsSave(reachableAddressPorts: String) {
         if (reachableAddressPorts == defaultTorSettings.reachableAddressPorts)
             servicePrefs.remove(PrefKeyString.REACHABLE_ADDRESS_PORTS)
@@ -254,22 +491,47 @@ class ServiceTorSettings internal constructor(
     override val relayNickname: String?
         get() = servicePrefs.getString(PrefKeyString.RELAY_NICKNAME, defaultTorSettings.relayNickname)
 
+    /**
+     * Saves the value for [relayNickname] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [relayNickname]
+     * @see [TorSettings.relayNickname]
+     * */
+    fun relayNicknameSave(relayNickname: String) {
+        if (relayNickname == defaultTorSettings.relayNickname)
+            servicePrefs.remove(PrefKeyString.RELAY_NICKNAME)
+        else
+            servicePrefs.putString(PrefKeyString.RELAY_NICKNAME, relayNickname)
+    }
+
     override val relayPort: String
         get() = servicePrefs.getString(PrefKeyString.RELAY_PORT, defaultTorSettings.relayPort)
             ?: defaultTorSettings.relayPort
 
+    /**
+     * Saves the value for [relayPort] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [relayPort] A String value of 0, auto, or number between 1024 and 65535
+     * @see [checkPortSelection]
+     * @see [TorSettings.relayPort]
+     * @throws [IllegalArgumentException] if the value is not 0, auto, or between 1024 and 65535
+     * */
     @Throws(IllegalArgumentException::class)
     fun relayPortSave(relayPort: String) {
         when {
             relayPort == defaultTorSettings.relayPort -> {
                 servicePrefs.remove(PrefKeyString.RELAY_PORT)
             }
-            checkPortSelection(relayPort) || relayPort.isEmpty() -> {
+            checkPortSelection(relayPort) -> {
                 servicePrefs.putString(PrefKeyString.RELAY_PORT, relayPort)
             }
             else -> {
                 throw IllegalArgumentException(
-                    "Relay Port must be empty, 0 (disabled), auto, or between 1024 and 65535"
+                    "Relay Port must be 0 (disabled), auto, or between 1024 and 65535"
                 )
             }
         }
@@ -279,6 +541,16 @@ class ServiceTorSettings internal constructor(
         get() = servicePrefs.getString(PrefKeyString.SOCKS_PORT, defaultTorSettings.socksPort)
             ?: defaultTorSettings.socksPort
 
+    /**
+     * Saves the value for [socksPort] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [socksPort] A String value of 0, auto, or number between 1024 and 65535
+     * @see [checkPortSelection]
+     * @see [TorSettings.socksPort]
+     * @throws [IllegalArgumentException] if the value is not 0, auto, or between 1024 and 65535
+     * */
     @Throws(IllegalArgumentException::class)
     fun socksPortSave(socksPort: String) {
         when {
@@ -302,6 +574,16 @@ class ServiceTorSettings internal constructor(
             defaultTorSettings.socksPortIsolationFlags ?: arrayListOf()
         )
 
+    /**
+     * Saves the value for [isolationFlags] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [isolationFlags] A List of [io.matthewnelson.topl_core_base.BaseConsts.IsolationFlag]'s
+     *   for the [socksPort]
+     * @see [io.matthewnelson.topl_core_base.BaseConsts.IsolationFlag]
+     * @see [TorSettings.socksPortIsolationFlags]
+     * */
     fun socksPortIsolationFlagsSave(isolationFlags: List<@IsolationFlag String>) {
         if (isolationFlags == defaultTorSettings.socksPortIsolationFlags) {
             servicePrefs.remove(PrefKeyList.SOCKS_PORT_ISOLATION_FLAGS)
@@ -313,13 +595,53 @@ class ServiceTorSettings internal constructor(
     override val virtualAddressNetwork: String?
         get() = servicePrefs.getString(PrefKeyString.VIRTUAL_ADDRESS_NETWORK, defaultTorSettings.virtualAddressNetwork)
 
+    /**
+     * Saves the value for [virtualAddressNetwork] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [virtualAddressNetwork]
+     * @see [TorSettings.virtualAddressNetwork]
+     * */
+    fun virtualAddressNetworkSave(virtualAddressNetwork: String) {
+        if (virtualAddressNetwork == defaultTorSettings.virtualAddressNetwork)
+            servicePrefs.remove(PrefKeyString.VIRTUAL_ADDRESS_NETWORK)
+        else
+            servicePrefs.putString(PrefKeyString.VIRTUAL_ADDRESS_NETWORK, virtualAddressNetwork)
+    }
+
     override val hasBridges: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_BRIDGES, defaultTorSettings.hasBridges)
+
+    /**
+     * Saves the value for [hasBridges] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [boolean] to enable/disable
+     * @see [TorSettings.hasBridges]
+     * */
+    fun hasBridgesSave(boolean: Boolean) {
+        if (boolean == defaultTorSettings.hasBridges)
+            servicePrefs.remove(PrefKeyBoolean.HAS_BRIDGES)
+        else
+            servicePrefs.putBoolean(PrefKeyBoolean.HAS_BRIDGES, boolean)
+    }
 
     override val connectionPadding: String
         get() = servicePrefs.getString(PrefKeyString.HAS_CONNECTION_PADDING, defaultTorSettings.connectionPadding)
             ?: defaultTorSettings.connectionPadding
 
+    /**
+     * Saves the value for [connectionPadding] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [connectionPadding] A [io.matthewnelson.topl_core_base.BaseConsts.ConnectionPadding]
+     * @see [io.matthewnelson.topl_core_base.BaseConsts.ConnectionPadding]
+     * @see [TorSettings.connectionPadding]
+     * @throws [IllegalArgumentException] if the value is not 0 (Off), 1 (On), or auto
+     * */
     @Throws(IllegalArgumentException::class)
     fun connectionPaddingSave(@ConnectionPadding connectionPadding: String) {
         when (connectionPadding) {
@@ -342,6 +664,14 @@ class ServiceTorSettings internal constructor(
     override val hasCookieAuthentication: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_COOKIE_AUTHENTICATION, defaultTorSettings.hasCookieAuthentication)
 
+    /**
+     * Saves the value for [hasCookieAuthentication] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [boolean] to enable/disable
+     * @see [TorSettings.hasCookieAuthentication]
+     * */
     fun hasCookieAuthenticationSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasCookieAuthentication)
             servicePrefs.remove(PrefKeyBoolean.HAS_COOKIE_AUTHENTICATION)
@@ -352,6 +682,14 @@ class ServiceTorSettings internal constructor(
     override val hasDebugLogs: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_DEBUG_LOGS, defaultTorSettings.hasDebugLogs)
 
+    /**
+     * Saves the value for [hasDebugLogs] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [boolean] to enable/disable
+     * @see [TorSettings.hasDebugLogs]
+     * */
     fun hasDebugLogsSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasDebugLogs)
             servicePrefs.remove(PrefKeyBoolean.HAS_DEBUG_LOGS)
@@ -362,6 +700,14 @@ class ServiceTorSettings internal constructor(
     override val hasDormantCanceledByStartup: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_DORMANT_CANCELED_BY_STARTUP, defaultTorSettings.hasDormantCanceledByStartup)
 
+    /**
+     * Saves the value for [hasDormantCanceledByStartup] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [boolean] to enable/disable
+     * @see [TorSettings.hasDormantCanceledByStartup]
+     * */
     fun hasDormantCanceledByStartupSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasDormantCanceledByStartup)
             servicePrefs.remove(PrefKeyBoolean.HAS_DORMANT_CANCELED_BY_STARTUP)
@@ -372,6 +718,14 @@ class ServiceTorSettings internal constructor(
     override val hasOpenProxyOnAllInterfaces: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_OPEN_PROXY_ON_ALL_INTERFACES, defaultTorSettings.hasOpenProxyOnAllInterfaces)
 
+    /**
+     * Saves the value for [hasOpenProxyOnAllInterfaces] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [boolean] to enable/disable
+     * @see [TorSettings.hasOpenProxyOnAllInterfaces]
+     * */
     fun hasOpenProxyOnAllInterfacesSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasOpenProxyOnAllInterfaces)
             servicePrefs.remove(PrefKeyBoolean.HAS_OPEN_PROXY_ON_ALL_INTERFACES)
@@ -382,6 +736,14 @@ class ServiceTorSettings internal constructor(
     override val hasReachableAddress: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_REACHABLE_ADDRESS, defaultTorSettings.hasReachableAddress)
 
+    /**
+     * Saves the value for [hasReachableAddress] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [boolean] to enable/disable
+     * @see [TorSettings.hasReachableAddress]
+     * */
     fun hasReachableAddressSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasReachableAddress)
             servicePrefs.remove(PrefKeyBoolean.HAS_REACHABLE_ADDRESS)
@@ -392,6 +754,14 @@ class ServiceTorSettings internal constructor(
     override val hasReducedConnectionPadding: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_REDUCED_CONNECTION_PADDING, defaultTorSettings.hasReducedConnectionPadding)
 
+    /**
+     * Saves the value for [hasReducedConnectionPadding] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [boolean] to enable/disable
+     * @see [TorSettings.hasReducedConnectionPadding]
+     * */
     fun hasReducedConnectionPaddingSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasReducedConnectionPadding)
             servicePrefs.remove(PrefKeyBoolean.HAS_REDUCED_CONNECTION_PADDING)
@@ -402,6 +772,14 @@ class ServiceTorSettings internal constructor(
     override val hasSafeSocks: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_SAFE_SOCKS, defaultTorSettings.hasSafeSocks)
 
+    /**
+     * Saves the value for [hasSafeSocks] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [boolean] to enable/disable
+     * @see [TorSettings.hasSafeSocks]
+     * */
     fun hasSafeSocksSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasSafeSocks)
             servicePrefs.remove(PrefKeyBoolean.HAS_SAFE_SOCKS)
@@ -412,6 +790,14 @@ class ServiceTorSettings internal constructor(
     override val hasStrictNodes: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_STRICT_NODES, defaultTorSettings.hasStrictNodes)
 
+    /**
+     * Saves the value for [hasStrictNodes] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [boolean] to enable/disable
+     * @see [TorSettings.hasStrictNodes]
+     * */
     fun hasStrictNodesSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasStrictNodes)
             servicePrefs.remove(PrefKeyBoolean.HAS_STRICT_NODES)
@@ -422,6 +808,14 @@ class ServiceTorSettings internal constructor(
     override val hasTestSocks: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_TEST_SOCKS, defaultTorSettings.hasTestSocks)
 
+    /**
+     * Saves the value for [hasTestSocks] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [boolean] to enable/disable
+     * @see [TorSettings.hasTestSocks]
+     * */
     fun hasTestSocksSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasTestSocks)
             servicePrefs.remove(PrefKeyBoolean.HAS_TEST_SOCKS)
@@ -432,6 +826,14 @@ class ServiceTorSettings internal constructor(
     override val isAutoMapHostsOnResolve: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.IS_AUTO_MAP_HOSTS_ON_RESOLVE, defaultTorSettings.isAutoMapHostsOnResolve)
 
+    /**
+     * Saves the value for [isAutoMapHostsOnResolve] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [boolean] to enable/disable
+     * @see [TorSettings.isAutoMapHostsOnResolve]
+     * */
     fun isAutoMapHostsOnResolveSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.isAutoMapHostsOnResolve)
             servicePrefs.remove(PrefKeyBoolean.IS_AUTO_MAP_HOSTS_ON_RESOLVE)
@@ -442,6 +844,14 @@ class ServiceTorSettings internal constructor(
     override val isRelay: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.IS_RELAY, defaultTorSettings.isRelay)
 
+    /**
+     * Saves the value for [isRelay] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [boolean] to enable/disable
+     * @see [TorSettings.isRelay]
+     * */
     fun isRelaySave(boolean: Boolean) {
         if (boolean == defaultTorSettings.isRelay)
             servicePrefs.remove(PrefKeyBoolean.IS_RELAY)
@@ -452,6 +862,14 @@ class ServiceTorSettings internal constructor(
     override val runAsDaemon: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.RUN_AS_DAEMON, defaultTorSettings.runAsDaemon)
 
+    /**
+     * Saves the value for [runAsDaemon] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [boolean] to enable/disable
+     * @see [TorSettings.runAsDaemon]
+     * */
     fun runAsDaemonSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.runAsDaemon)
             servicePrefs.remove(PrefKeyBoolean.RUN_AS_DAEMON)
@@ -462,6 +880,16 @@ class ServiceTorSettings internal constructor(
     override val transPort: String
         get() = servicePrefs.getString(PrefKeyString.TRANS_PORT, defaultTorSettings.transPort) ?: defaultTorSettings.transPort
 
+    /**
+     * Saves the value for [transPort] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [transPort] A String value of 0, auto, or number between 1024 and 65535
+     * @see [checkPortSelection]
+     * @see [TorSettings.transPort]
+     * @throws [IllegalArgumentException] if the value is not 0, auto, or between 1024 and 65535
+     * */
     @Throws(IllegalArgumentException::class)
     fun transPortSave(transPort: String) {
         when {
@@ -485,6 +913,16 @@ class ServiceTorSettings internal constructor(
             defaultTorSettings.transPortIsolationFlags ?: arrayListOf()
         )
 
+    /**
+     * Saves the value for [isolationFlags] to [TorServicePrefs]. If the value is the same as what is
+     * declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the setting if
+     * it exists.
+     *
+     * @param [isolationFlags] A List of [io.matthewnelson.topl_core_base.BaseConsts.IsolationFlag]'s
+     *   for the [transPort]
+     * @see [io.matthewnelson.topl_core_base.BaseConsts.IsolationFlag]
+     * @see [TorSettings.transPortIsolationFlags]
+     * */
     fun transPortIsolationFlagsSave(isolationFlags: List<@IsolationFlag String>) {
         if (isolationFlags == defaultTorSettings.transPortIsolationFlags) {
             servicePrefs.remove(PrefKeyList.TRANS_PORT_ISOLATION_FLAGS)
@@ -496,6 +934,14 @@ class ServiceTorSettings internal constructor(
     override val useSocks5: Boolean
         get() = servicePrefs.getBoolean(PrefKeyBoolean.USE_SOCKS5, defaultTorSettings.useSocks5)
 
+    /**
+     * Saves the value for [useSocks5] to [TorServicePrefs]. If the value is the same
+     * as what is declared in [defaultTorSettings], [TorServicePrefs] is queried to remove the
+     * setting if it exists.
+     *
+     * @param [boolean] to enable/disable
+     * @see [TorSettings.useSocks5]
+     * */
     fun useSocks5Save(boolean: Boolean) {
         if (boolean == defaultTorSettings.useSocks5)
             servicePrefs.remove(PrefKeyBoolean.USE_SOCKS5)
@@ -503,12 +949,22 @@ class ServiceTorSettings internal constructor(
             servicePrefs.putBoolean(PrefKeyBoolean.USE_SOCKS5, boolean)
     }
 
-    private fun checkPortSelection(port: String): Boolean {
-        if (port == PortOption.AUTO) return true
+    private fun checkPortSelection(port: Int, checkZero: Boolean): Boolean =
+        checkPortSelection(port.toString(), checkAuto = false, checkZero = checkZero)
+
+    private fun checkPortSelection(
+        port: String,
+        checkAuto: Boolean = true,
+        checkZero: Boolean = true
+    ): Boolean {
+        if (checkAuto && port == PortOption.AUTO)
+            return true
 
         return try {
             val portInt = port.toInt()
-            portInt == 0 || portInt in 1024..65535
+            if (checkZero && portInt == 0)
+                return true
+            portInt in 1024..65535
         } catch (e: Exception) {
             false
         }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorSettings.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorSettings.kt
@@ -116,7 +116,7 @@ class ServiceTorSettings internal constructor(
             dnsPort == defaultTorSettings.dnsPort -> {
                 servicePrefs.remove(PrefKeyString.DNS_PORT)
             }
-            checkPortRange(dnsPort) -> {
+            checkPortSelection(dnsPort) -> {
                 servicePrefs.putString(PrefKeyString.DNS_PORT, dnsPort)
             }
             else -> {
@@ -191,7 +191,7 @@ class ServiceTorSettings internal constructor(
             httpPort == defaultTorSettings.httpTunnelPort -> {
                 servicePrefs.remove(PrefKeyString.HTTP_TUNNEL_PORT)
             }
-            checkPortRange(httpPort) -> {
+            checkPortSelection(httpPort) -> {
                 servicePrefs.putString(PrefKeyString.HTTP_TUNNEL_PORT, httpPort)
             }
             else -> {
@@ -264,7 +264,7 @@ class ServiceTorSettings internal constructor(
             relayPort == defaultTorSettings.relayPort -> {
                 servicePrefs.remove(PrefKeyString.RELAY_PORT)
             }
-            checkPortRange(relayPort) || relayPort.isEmpty() -> {
+            checkPortSelection(relayPort) || relayPort.isEmpty() -> {
                 servicePrefs.putString(PrefKeyString.RELAY_PORT, relayPort)
             }
             else -> {
@@ -285,7 +285,7 @@ class ServiceTorSettings internal constructor(
             socksPort == defaultTorSettings.socksPort -> {
                 servicePrefs.remove(PrefKeyString.SOCKS_PORT)
             }
-            checkPortRange(socksPort) -> {
+            checkPortSelection(socksPort) -> {
                 servicePrefs.putString(PrefKeyString.SOCKS_PORT, socksPort)
             }
             else -> {
@@ -468,7 +468,7 @@ class ServiceTorSettings internal constructor(
             transPort == defaultTorSettings.transPort -> {
                 servicePrefs.remove(PrefKeyString.TRANS_PORT)
             }
-            checkPortRange(transPort) -> {
+            checkPortSelection(transPort) -> {
                 servicePrefs.putString(PrefKeyString.TRANS_PORT, transPort)
             }
             else -> {
@@ -503,7 +503,9 @@ class ServiceTorSettings internal constructor(
             servicePrefs.putBoolean(PrefKeyBoolean.USE_SOCKS5, boolean)
     }
 
-    private fun checkPortRange(port: String): Boolean {
+    private fun checkPortSelection(port: String): Boolean {
+        if (port == PortOption.AUTO) return true
+
         return try {
             val portInt = port.toInt()
             portInt == 0 || portInt in 1024..65535

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorSettings.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorSettings.kt
@@ -127,6 +127,20 @@ class ServiceTorSettings internal constructor(
         }
     }
 
+    override val dnsPortIsolationFlags: List<@IsolationFlag String>?
+        get() = servicePrefs.getList(
+            PrefKeyList.DNS_PORT_ISOLATION_FLAGS,
+            defaultTorSettings.dnsPortIsolationFlags ?: arrayListOf()
+        )
+
+    fun dnsPortIsolationFlagsSave(isolationFlags: List<@IsolationFlag String>) {
+        if (isolationFlags == defaultTorSettings.dnsPortIsolationFlags) {
+            servicePrefs.remove(PrefKeyList.DNS_PORT_ISOLATION_FLAGS)
+        } else {
+            servicePrefs.putList(PrefKeyList.DNS_PORT_ISOLATION_FLAGS, isolationFlags)
+        }
+    }
+
     override val customTorrc: String?
         get() = servicePrefs.getString(PrefKeyString.CUSTOM_TORRC, defaultTorSettings.customTorrc)
 
@@ -188,8 +202,22 @@ class ServiceTorSettings internal constructor(
         }
     }
 
-    override val listOfSupportedBridges: List<String>
-        get() = servicePrefs.getList(PrefKeyList.LIST_OF_SUPPORTED_BRIDGES, defaultTorSettings.listOfSupportedBridges)
+    override val httpTunnelPortIsolationFlags: List<@IsolationFlag String>?
+        get() = servicePrefs.getList(
+            PrefKeyList.HTTP_TUNNEL_PORT_ISOLATION_FLAGS,
+            defaultTorSettings.httpTunnelPortIsolationFlags ?: arrayListOf()
+        )
+
+    fun httpPortIsolationFlagsSave(isolationFlags: List<@IsolationFlag String>) {
+        if (isolationFlags == defaultTorSettings.httpTunnelPortIsolationFlags) {
+            servicePrefs.remove(PrefKeyList.HTTP_TUNNEL_PORT_ISOLATION_FLAGS)
+        } else {
+            servicePrefs.putList(PrefKeyList.HTTP_TUNNEL_PORT_ISOLATION_FLAGS, isolationFlags)
+        }
+    }
+
+    override val listOfSupportedBridges: List<@SupportedBridgeType String>
+        get() = defaultTorSettings.listOfSupportedBridges
 
     override val proxyHost: String?
         get() = servicePrefs.getString(PrefKeyString.PROXY_HOST, defaultTorSettings.proxyHost)
@@ -206,8 +234,8 @@ class ServiceTorSettings internal constructor(
     override val proxySocks5ServerPort: Int?
         get() = servicePrefs.getInt(PrefKeyInt.PROXY_SOCKS5_SERVER_PORT, defaultTorSettings.proxySocks5ServerPort)
 
-    override val proxyType: String?
-        get() = servicePrefs.getString(PrefKeyString.PROXY_TYPE, defaultTorSettings.proxyType)
+    override val proxyType: @ProxyType String
+        get() = servicePrefs.getString(PrefKeyString.PROXY_TYPE, defaultTorSettings.proxyType) ?: defaultTorSettings.proxyType
 
     override val proxyUser: String?
         get() = servicePrefs.getString(PrefKeyString.PROXY_USER, defaultTorSettings.proxyUser)
@@ -226,9 +254,26 @@ class ServiceTorSettings internal constructor(
     override val relayNickname: String?
         get() = servicePrefs.getString(PrefKeyString.RELAY_NICKNAME, defaultTorSettings.relayNickname)
 
-    override val relayPort: Int?
-        get() = servicePrefs.getInt(PrefKeyInt.RELAY_PORT, defaultTorSettings.relayPort)
+    override val relayPort: String
+        get() = servicePrefs.getString(PrefKeyString.RELAY_PORT, defaultTorSettings.relayPort)
             ?: defaultTorSettings.relayPort
+
+    @Throws(IllegalArgumentException::class)
+    fun relayPortSave(relayPort: String) {
+        when {
+            relayPort == defaultTorSettings.relayPort -> {
+                servicePrefs.remove(PrefKeyString.RELAY_PORT)
+            }
+            checkPortRange(relayPort) || relayPort.isEmpty() -> {
+                servicePrefs.putString(PrefKeyString.RELAY_PORT, relayPort)
+            }
+            else -> {
+                throw IllegalArgumentException(
+                    "Relay Port must be empty, 0 (disabled), auto, or between 1024 and 65535"
+                )
+            }
+        }
+    }
 
     override val socksPort: String
         get() = servicePrefs.getString(PrefKeyString.SOCKS_PORT, defaultTorSettings.socksPort)
@@ -248,6 +293,20 @@ class ServiceTorSettings internal constructor(
                     "Socks Port must be 0 (disabled), auto, or between 1024 and 65535"
                 )
             }
+        }
+    }
+
+    override val socksPortIsolationFlags: List<@IsolationFlag String>?
+        get() = servicePrefs.getList(
+            PrefKeyList.SOCKS_PORT_ISOLATION_FLAGS,
+            defaultTorSettings.socksPortIsolationFlags ?: arrayListOf()
+        )
+
+    fun socksPortIsolationFlagsSave(isolationFlags: List<@IsolationFlag String>) {
+        if (isolationFlags == defaultTorSettings.socksPortIsolationFlags) {
+            servicePrefs.remove(PrefKeyList.SOCKS_PORT_ISOLATION_FLAGS)
+        } else {
+            servicePrefs.putList(PrefKeyList.SOCKS_PORT_ISOLATION_FLAGS, isolationFlags)
         }
     }
 
@@ -308,16 +367,6 @@ class ServiceTorSettings internal constructor(
             servicePrefs.remove(PrefKeyBoolean.HAS_DORMANT_CANCELED_BY_STARTUP)
         else
             servicePrefs.putBoolean(PrefKeyBoolean.HAS_DORMANT_CANCELED_BY_STARTUP, boolean)
-    }
-
-    override val hasIsolationAddressFlagForTunnel: Boolean
-        get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_ISOLATION_ADDRESS_FLAG_FOR_TUNNEL, defaultTorSettings.hasIsolationAddressFlagForTunnel)
-
-    fun hasIsolationAddressFlagForTunnelSave(boolean: Boolean) {
-        if (boolean == defaultTorSettings.hasIsolationAddressFlagForTunnel)
-            servicePrefs.remove(PrefKeyBoolean.HAS_ISOLATION_ADDRESS_FLAG_FOR_TUNNEL)
-        else
-            servicePrefs.putBoolean(PrefKeyBoolean.HAS_ISOLATION_ADDRESS_FLAG_FOR_TUNNEL, boolean)
     }
 
     override val hasOpenProxyOnAllInterfaces: Boolean
@@ -427,6 +476,20 @@ class ServiceTorSettings internal constructor(
                     "Socks Trans Port must be 0 (disabled), auto, or between 1024 and 65535"
                 )
             }
+        }
+    }
+
+    override val transPortIsolationFlags: List<@IsolationFlag String>?
+        get() = servicePrefs.getList(
+            PrefKeyList.TRANS_PORT_ISOLATION_FLAGS,
+            defaultTorSettings.transPortIsolationFlags ?: arrayListOf()
+        )
+
+    fun transPortIsolationFlagsSave(isolationFlags: List<@IsolationFlag String>) {
+        if (isolationFlags == defaultTorSettings.transPortIsolationFlags) {
+            servicePrefs.remove(PrefKeyList.TRANS_PORT_ISOLATION_FLAGS)
+        } else {
+            servicePrefs.putList(PrefKeyList.TRANS_PORT_ISOLATION_FLAGS, isolationFlags)
         }
     }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/model/TorPortInfo.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/model/TorPortInfo.kt
@@ -1,0 +1,15 @@
+package io.matthewnelson.topl_service.service.components.onionproxy.model
+
+/**
+ * Contains information regarding what ports Tor is operating on.
+ *
+ * Example of what one of the fields will contain:
+ *
+ *   - "127.0.0.1:33432"
+ * */
+class TorPortInfo(
+    val controlPort: String?,
+    val dnsPort: String?,
+    val httpPort: String?,
+    val socksPort: String?
+)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/model/TorPortInfo.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/model/TorPortInfo.kt
@@ -11,5 +11,6 @@ class TorPortInfo(
     val controlPort: String?,
     val dnsPort: String?,
     val httpPort: String?,
-    val socksPort: String?
+    val socksPort: String?,
+    val transPort: String?
 )

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/model/TorPortInfo.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/model/TorPortInfo.kt
@@ -11,6 +11,9 @@ class TorPortInfo(
     val controlPort: String?,
     val dnsPort: String?,
     val httpPort: String?,
+    // TODO: Add proxyPort after refactor
+    // TODO: Add proxySocks5ServerPort after refactor
+    // TODO: Add relayPort after refactor
     val socksPort: String?,
     val transPort: String?
 )

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/model/TorServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/model/TorServiceEventBroadcaster.kt
@@ -71,48 +71,23 @@ import io.matthewnelson.topl_core_base.EventBroadcaster
 /**
  * Adds broadcasting methods to the [EventBroadcaster] to update you with information about
  * what addresses Tor is operating on. Very helpful when choosing "auto" in your
- * [io.matthewnelson.topl_core_base.TorSettings] to easily identifying what addresses to
+ * [io.matthewnelson.topl_core_base.TorSettings] to easily identify what addresses to
  * use for making network calls, as well as being notified when Tor is ready to be used.
  *
  * The addresses will be broadcast to you after Tor has been fully Bootstrapped. If Tor is
  * stopped (ie. it's [io.matthewnelson.topl_core_base.BaseConsts.TorState] changes from **ON**
- * to **OFF**), `null` will be broadcast.
+ * to **OFF**), a [TorPortInfo] object containing 'null' for all fields will be broadcast.
  *
- * All broadcasts to your implementation to this class will occur on the Main thread.
+ * All broadcasts to your implementation to this class will occur on the Main Thread.
  *
  * @sample [io.matthewnelson.sampleapp.topl_android.MyEventBroadcaster]
  * */
 abstract class TorServiceEventBroadcaster: EventBroadcaster() {
 
     /**
-     * Override this method to implement receiving of the control port address that Tor
-     * is operating on.
+     * Override this method to implement receiving of port information pertaining to Tor.
      *
-     * Example of what will be broadcast:
-     *
-     *   - "127.0.0.1:33432"
+     * @see [TorPortInfo]
      * */
-    abstract fun broadcastControlPortAddress(controlPortAddress: String?)
-
-    /**
-     * Override this method to implement receiving of the Socks port address that Tor
-     * is operating on (if you've specified a
-     * [io.matthewnelson.topl_core_base.TorSettings.socksPort]).
-     *
-     * Example of what will be broadcast:
-     *
-     *   - "127.0.0.1:9051"
-     * */
-    abstract fun broadcastSocksPortAddress(socksPortAddress: String?)
-
-    /**
-     * Override this method to implement receiving of the http port address that Tor
-     * is operating on (if you've specified a
-     * [io.matthewnelson.topl_core_base.TorSettings.httpTunnelPort]).
-     *
-     * Example of what will be broadcast:
-     *
-     *   - "127.0.0.1:33432"
-     * */
-    abstract fun broadcastHttpPortAddress(httpPortAddress: String?)
+    abstract fun broadcastPortInformation(torPortInfo: TorPortInfo)
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/model/TorServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/model/TorServiceEventBroadcaster.kt
@@ -64,7 +64,7 @@
 *     modified version of TorOnionProxyLibrary-Android, and you must remove this
 *     exception when you distribute your modified version.
 * */
-package io.matthewnelson.topl_service.service.components.onionproxy
+package io.matthewnelson.topl_service.service.components.onionproxy.model
 
 import io.matthewnelson.topl_core_base.EventBroadcaster
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
@@ -176,7 +176,6 @@ abstract class ServiceConsts: BaseConsts() {
         PrefKeyBoolean.HAS_COOKIE_AUTHENTICATION,
         PrefKeyBoolean.HAS_DEBUG_LOGS,
         PrefKeyBoolean.HAS_DORMANT_CANCELED_BY_STARTUP,
-        PrefKeyBoolean.HAS_ISOLATION_ADDRESS_FLAG_FOR_TUNNEL,
         PrefKeyBoolean.HAS_OPEN_PROXY_ON_ALL_INTERFACES,
         PrefKeyBoolean.HAS_REACHABLE_ADDRESS,
         PrefKeyBoolean.HAS_REDUCED_CONNECTION_PADDING,
@@ -197,7 +196,6 @@ abstract class ServiceConsts: BaseConsts() {
             const val HAS_COOKIE_AUTHENTICATION = "HAS_COOKIE_AUTHENTICATION"
             const val HAS_DEBUG_LOGS = "HAS_DEBUG_LOGS"
             const val HAS_DORMANT_CANCELED_BY_STARTUP = "HAS_DORMANT_CANCELED_BY_STARTUP"
-            const val HAS_ISOLATION_ADDRESS_FLAG_FOR_TUNNEL = "HAS_ISOLATION_ADDRESS_FLAG_FOR_TUNNEL"
             const val HAS_OPEN_PROXY_ON_ALL_INTERFACES = "HAS_OPEN_PROXY_ON_ALL_INTERFACES"
             const val HAS_REACHABLE_ADDRESS = "HAS_REACHABLE_ADDRESS"
             const val HAS_REDUCED_CONNECTION_PADDING = "HAS_REDUCED_CONNECTION_PADDING"
@@ -213,8 +211,7 @@ abstract class ServiceConsts: BaseConsts() {
 
     @StringDef(
         PrefKeyInt.PROXY_PORT,
-        PrefKeyInt.PROXY_SOCKS5_SERVER_PORT,
-        PrefKeyInt.RELAY_PORT
+        PrefKeyInt.PROXY_SOCKS5_SERVER_PORT
     )
     @Retention(AnnotationRetention.SOURCE)
     annotation class PrefKeyInt {
@@ -222,18 +219,24 @@ abstract class ServiceConsts: BaseConsts() {
             // Keys for returning Ints
             const val PROXY_PORT = "PROXY_PORT"
             const val PROXY_SOCKS5_SERVER_PORT = "PROXY_SOCKS5_SERVER_PORT"
-            const val RELAY_PORT = "RELAY_PORT"
         }
     }
 
     @StringDef(
-        PrefKeyList.LIST_OF_SUPPORTED_BRIDGES
+        PrefKeyList.DNS_PORT_ISOLATION_FLAGS,
+        PrefKeyList.HTTP_TUNNEL_PORT_ISOLATION_FLAGS,
+        PrefKeyList.SOCKS_PORT_ISOLATION_FLAGS,
+        PrefKeyList.TRANS_PORT_ISOLATION_FLAGS
     )
     @Retention(AnnotationRetention.SOURCE)
     annotation class PrefKeyList {
         companion object {
             // Keys for returning Lists
-            const val LIST_OF_SUPPORTED_BRIDGES = "LIST_OF_SUPPORTED_BRIDGES"
+            const val DNS_PORT_ISOLATION_FLAGS = "DNS_PORT_ISOLATION_FLAGS"
+            const val HTTP_TUNNEL_PORT_ISOLATION_FLAGS = "HTTP_PORT_ISOLATION_FLAGS"
+            const val SOCKS_PORT_ISOLATION_FLAGS = "SOCKS_PORT_ISOLATION_FLAGS"
+            const val TRANS_PORT_ISOLATION_FLAGS = "TRANS_PORT_ISOLATION_FLAGS"
+            const val USER_DEFINED_BRIDGES = "USER_DEFINED_BRIDGES"
         }
     }
 
@@ -251,6 +254,7 @@ abstract class ServiceConsts: BaseConsts() {
         PrefKeyString.PROXY_USER,
         PrefKeyString.REACHABLE_ADDRESS_PORTS,
         PrefKeyString.RELAY_NICKNAME,
+        PrefKeyString.RELAY_PORT,
         PrefKeyString.SOCKS_PORT,
         PrefKeyString.VIRTUAL_ADDRESS_NETWORK,
         PrefKeyString.HAS_CONNECTION_PADDING,
@@ -273,6 +277,7 @@ abstract class ServiceConsts: BaseConsts() {
             const val PROXY_USER = "PROXY_USER"
             const val REACHABLE_ADDRESS_PORTS = "REACHABLE_ADDRESS_PORTS"
             const val RELAY_NICKNAME = "RELAY_NICKNAME"
+            const val RELAY_PORT = "RELAY_PORT"
             const val SOCKS_PORT = "SOCKS_PORT"
             const val VIRTUAL_ADDRESS_NETWORK = "VIRTUAL_ADDRESS_NETWORK"
             const val HAS_CONNECTION_PADDING = "HAS_CONNECTION_PADDING"

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
@@ -226,7 +226,8 @@ abstract class ServiceConsts: BaseConsts() {
         PrefKeyList.DNS_PORT_ISOLATION_FLAGS,
         PrefKeyList.HTTP_TUNNEL_PORT_ISOLATION_FLAGS,
         PrefKeyList.SOCKS_PORT_ISOLATION_FLAGS,
-        PrefKeyList.TRANS_PORT_ISOLATION_FLAGS
+        PrefKeyList.TRANS_PORT_ISOLATION_FLAGS,
+        PrefKeyList.USER_DEFINED_BRIDGES
     )
     @Retention(AnnotationRetention.SOURCE)
     annotation class PrefKeyList {

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/application_provided_classes/TestEventBroadcaster.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/application_provided_classes/TestEventBroadcaster.kt
@@ -66,15 +66,12 @@
  */
 package io.matthewnelson.test_helpers.application_provided_classes
 
-import io.matthewnelson.topl_service.service.components.onionproxy.TorServiceEventBroadcaster
+import io.matthewnelson.topl_service.service.components.onionproxy.model.TorPortInfo
+import io.matthewnelson.topl_service.service.components.onionproxy.model.TorServiceEventBroadcaster
 
 class TestEventBroadcaster: TorServiceEventBroadcaster() {
 
-    override fun broadcastControlPortAddress(controlPortAddress: String?) {}
-
-    override fun broadcastSocksPortAddress(socksPortAddress: String?) {}
-
-    override fun broadcastHttpPortAddress(httpPortAddress: String?) {}
+    override fun broadcastPortInformation(torPortInfo: TorPortInfo) {}
 
     override fun broadcastBandwidth(bytesRead: String, bytesWritten: String) {}
 

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/application_provided_classes/TestTorSettings.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/application_provided_classes/TestTorSettings.kt
@@ -74,7 +74,12 @@ internal class TestTorSettings: TorSettings() {
         get() = DEFAULT__DISABLE_NETWORK
 
     override val dnsPort: String
-        get() = DEFAULT__DNS_PORT
+        get() = PortOption.DISABLED
+
+    override val dnsPortIsolationFlags: List<String>?
+        get() = arrayListOf(
+            IsolationFlag.ISOLATE_CLIENT_PROTOCOL
+        )
 
     override val customTorrc: String?
         get() = null
@@ -89,10 +94,15 @@ internal class TestTorSettings: TorSettings() {
         get() = DEFAULT__EXIT_NODES
 
     override val httpTunnelPort: String
-        get() = DEFAULT__HTTP_TUNNEL_PORT
+        get() = PortOption.DISABLED
 
-    override val listOfSupportedBridges: List<@SupportedBridges String>
-        get() = arrayListOf(SupportedBridges.MEEK, SupportedBridges.OBFS4)
+    override val httpTunnelPortIsolationFlags: List<String>?
+        get() = arrayListOf(
+            IsolationFlag.ISOLATE_CLIENT_PROTOCOL
+        )
+
+    override val listOfSupportedBridges: List<@SupportedBridgeType String>
+        get() = arrayListOf(SupportedBridgeType.MEEK, SupportedBridgeType.OBFS4)
 
     override val proxyHost: String?
         get() = DEFAULT__PROXY_HOST
@@ -109,8 +119,8 @@ internal class TestTorSettings: TorSettings() {
     override val proxySocks5ServerPort: Int?
         get() = null
 
-    override val proxyType: String?
-        get() = DEFAULT__PROXY_TYPE
+    override val proxyType: String
+        get() = ProxyType.DISABLED
 
     override val proxyUser: String?
         get() = DEFAULT__PROXY_USER
@@ -121,11 +131,18 @@ internal class TestTorSettings: TorSettings() {
     override val relayNickname: String?
         get() = DEFAULT__RELAY_NICKNAME
 
-    override val relayPort: Int?
-        get() = null
+    override val relayPort: String
+        get() = DEFAULT__RELAY_PORT
 
     override val socksPort: String
         get() = "9051"
+    override val socksPortIsolationFlags: List<String>?
+        get() = arrayListOf(
+            IsolationFlag.KEEP_ALIVE_ISOLATE_SOCKS_AUTH,
+            IsolationFlag.IPV6_TRAFFIC,
+            IsolationFlag.PREFER_IPV6,
+            IsolationFlag.ISOLATE_CLIENT_PROTOCOL
+        )
 
     override val virtualAddressNetwork: String?
         get() = "10.192.0.2/10"
@@ -134,7 +151,7 @@ internal class TestTorSettings: TorSettings() {
         get() = DEFAULT__HAS_BRIDGES
 
     override val connectionPadding: @ConnectionPadding String
-        get() = DEFAULT__HAS_CONNECTION_PADDING
+        get() = ConnectionPadding.OFF
 
     override val hasCookieAuthentication: Boolean
         get() = DEFAULT__HAS_COOKIE_AUTHENTICATION
@@ -144,9 +161,6 @@ internal class TestTorSettings: TorSettings() {
 
     override val hasDormantCanceledByStartup: Boolean
         get() = DEFAULT__HAS_DORMANT_CANCELED_BY_STARTUP
-
-    override val hasIsolationAddressFlagForTunnel: Boolean
-        get() = DEFAULT__HAS_ISOLATION_ADDRESS_FLAG_FOR_TUNNEL
 
     override val hasOpenProxyOnAllInterfaces: Boolean
         get() = DEFAULT__HAS_OPEN_PROXY_ON_ALL_INTERFACES
@@ -176,7 +190,12 @@ internal class TestTorSettings: TorSettings() {
         get() = DEFAULT__RUN_AS_DAEMON
 
     override val transPort: String
-        get() = DEFAULT__TRANS_PORT
+        get() = PortOption.DISABLED
+
+    override val transPortIsolationFlags: List<String>?
+        get() = arrayListOf(
+            IsolationFlag.ISOLATE_CLIENT_PROTOCOL
+        )
 
     override val useSocks5: Boolean
         get() = DEFAULT__USE_SOCKS5

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/application_provided_classes/TestTorSettings.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/application_provided_classes/TestTorSettings.kt
@@ -132,7 +132,7 @@ internal class TestTorSettings: TorSettings() {
         get() = DEFAULT__RELAY_NICKNAME
 
     override val relayPort: String
-        get() = DEFAULT__RELAY_PORT
+        get() = PortOption.DISABLED
 
     override val socksPort: String
         get() = "9051"

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
@@ -77,6 +77,7 @@ import io.matthewnelson.topl_core.broadcaster.BroadcastLogger
 import io.matthewnelson.topl_core_base.BaseConsts.TorNetworkState
 import io.matthewnelson.topl_core_base.BaseConsts.TorState
 import io.matthewnelson.topl_service.TorServiceController
+import io.matthewnelson.topl_service.prefs.TorServicePrefs
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceEventBroadcaster
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceEventListener
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorInstaller
@@ -173,7 +174,7 @@ internal class TestTorService(
         ServiceEventBroadcaster(this)
     }
     val serviceTorSettings: ServiceTorSettings by lazy {
-        ServiceTorSettings(this, TorServiceController.getTorSettings())
+        TorServiceController.getServiceTorSettings(context)
     }
     val onionProxyManager: OnionProxyManager by lazy {
         OnionProxyManager(

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/prefs/TorServicePrefsUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/prefs/TorServicePrefsUnitTest.kt
@@ -91,8 +91,8 @@ class TorServicePrefsUnitTest: ServiceConsts() {
 
     @Test
     fun testInts_null() {
-        prefs.putInt(PrefKeyInt.RELAY_PORT, null)
-        val result = prefs.getInt(PrefKeyInt.RELAY_PORT, 9999)
+        prefs.putInt(PrefKeyInt.PROXY_SOCKS5_SERVER_PORT, null)
+        val result = prefs.getInt(PrefKeyInt.PROXY_SOCKS5_SERVER_PORT, 9999)
         assertEquals(null, result)
     }
 
@@ -106,17 +106,17 @@ class TorServicePrefsUnitTest: ServiceConsts() {
     @Test
     fun testLists_empty() {
         val invalid = arrayListOf("INVALID")
-        prefs.putList(PrefKeyList.LIST_OF_SUPPORTED_BRIDGES, arrayListOf())
-        val result = prefs.getList(PrefKeyList.LIST_OF_SUPPORTED_BRIDGES, invalid)
+        prefs.putList(PrefKeyList.DNS_PORT_ISOLATION_FLAGS, arrayListOf())
+        val result = prefs.getList(PrefKeyList.DNS_PORT_ISOLATION_FLAGS, invalid)
         assertEquals(invalid, result)
     }
 
     @Test
     fun testLists() {
         val myList = arrayListOf("ONE", "TWO", "THREE")
-        val invalid = arrayListOf("INVALID")
-        prefs.putList(PrefKeyList.LIST_OF_SUPPORTED_BRIDGES, myList)
-        val result = prefs.getList(PrefKeyList.LIST_OF_SUPPORTED_BRIDGES, invalid)
+        val invalid = arrayListOf<String>()
+        prefs.putList(PrefKeyList.DNS_PORT_ISOLATION_FLAGS, myList)
+        val result = prefs.getList(PrefKeyList.DNS_PORT_ISOLATION_FLAGS, invalid)
         assertEquals(myList, result)
     }
 


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR:
 - Makes the `ServiceTorSettings` class visible to Library users to better ease the creation of a settings screen.
 - Refactors the `TorSettings` and `TorSettingsBuilder` classes to add functionality for setting `IsolationFlags` to the ports capable of accepting them, as well as updated documentation of the classes.
 - Refactors the `ServiceTorSettings` class to add functionality for saving settings to `TorServicePrefs`, and not just querying for settings.
 - Implements some of the changes in the Sample App's `SettingsTorFragment`
 - Updats some of the UI and functionality of the Sample App.
 - Cleans up code.