### PR TITLE
Bug Fix: PortInfo not being broadcast on network state change

### DIFF
--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
@@ -421,13 +421,20 @@ internal class ServiceEventBroadcaster(private val torService: BaseService): Eve
         torState = state
 
         if (networkState == TorNetworkState.DISABLED) {
+            if (isBootstrappingComplete()) {
+                setAllPortsNull()
+                updateAppEventBroadcasterWithPortInfo()
+            }
+
             // Update torNetworkState _before_ setting the icon to `disabled` so bandwidth won't
             // overwrite the icon with an update
             torNetworkState = networkState
             torService.updateNotificationIcon(NotificationImage.DISABLED)
         } else {
-            if (isBootstrappingComplete())
+            if (isBootstrappingComplete()) {
+                updateAppEventBroadcasterWithPortInfo()
                 torService.updateNotificationIcon(NotificationImage.ENABLED)
+            }
 
             // Update torNetworkState _after_ setting the icon to `enabled` so bandwidth changes
             // occur afterwards and this won't overwrite ImageState.DATA


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR fixes an issue where if the device loses connectivity, `OnionProxyManager` sets Tor's `DisableNetwork` conf to true. That change was not triggering a new broadcast of the `PortInfo` by the `topl-service:ServiceEventBroadcaster`, nor was it broadcasting new port information when connectivity was regained and Tor's `DisableNetwork` conf was set to false.

Resolves #71 