### PR TITLE
Add v3 Client Authentication

### DIFF
--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/BaseConsts.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/BaseConsts.kt
@@ -345,7 +345,8 @@ abstract class BaseConsts {
         ConfigFileName.HIDDEN_SERVICE,
         ConfigFileName.RESOLVE_CONF,
         ConfigFileName.TOR_EXECUTABLE,
-        ConfigFileName.TORRC
+        ConfigFileName.TORRC,
+        ConfigFileName.V3_AUTH_PRIVATE_DIR
     )
     @Retention(AnnotationRetention.SOURCE)
     annotation class ConfigFileName {
@@ -360,6 +361,7 @@ abstract class BaseConsts {
             const val RESOLVE_CONF = "resolv.conf"
             const val TOR_EXECUTABLE = "libTor.so"
             const val TORRC = "torrc"
+            const val V3_AUTH_PRIVATE_DIR = "auth_private_files"
         }
     }
 }

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/FileExtensions.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/FileExtensions.kt
@@ -77,7 +77,7 @@ import java.io.IOException
  * @return a [ByteArray] of the contents of the [File]
  * @throws [IOException] File errors
  * @throws [EOFException] File errors
- * @throws [SecurityException] Unauthorized access to file/directory.
+ * @throws [SecurityException] Unauthorized access to file/directory
  * */
 @Throws(IOException::class, EOFException::class, SecurityException::class)
 fun File.readTorConfigFile(): ByteArray {
@@ -104,6 +104,7 @@ fun File.readTorConfigFile(): ByteArray {
  *
  * @return `null` if the parent directories of that File could not be created, `false` if
  *   the File was not able to be created, `true` if the file exists/was created.
+ * @throws [SecurityException] Unauthorized access to file/directory
  * */
 @Throws(SecurityException::class)
 fun File.createNewFileIfDoesNotExist(): Boolean? {

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/FileExtensions.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/FileExtensions.kt
@@ -96,3 +96,24 @@ fun File.readTorConfigFile(): ByteArray {
         b
     }
 }
+
+/**
+ * Creates the file and the necessary parent directories if it does not exist. Be sure
+ * to acquire the proper lock from
+ * [io.matthewnelson.topl_core_base.TorConfigFiles] when utilizing this method.
+ *
+ * @return `null` if the parent directories of that File could not be created, `false` if
+ *   the File was not able to be created, `true` if the file exists/was created.
+ * */
+@Throws(SecurityException::class)
+fun File.createNewFileIfDoesNotExist(): Boolean? {
+    if (this.parentFile?.exists() != true && this.parentFile?.mkdirs() != true)
+        return null
+
+    return try {
+        val exists = if (this.exists()) true else this.createNewFile()
+        exists
+    } catch (e: IOException) {
+        false
+    }
+}

--- a/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorConfigFiles.kt
+++ b/topl-core-base/src/main/java/io/matthewnelson/topl_core_base/TorConfigFiles.kt
@@ -137,6 +137,8 @@ class TorConfigFiles private constructor(
     val controlPortFile: File,
     val installDir: File,
 
+    val v3AuthPrivateDir: File,
+
     /**
      * When tor starts it waits for the control port and cookie auth files to be created
      * before it proceeds to the next step in startup. If these files are not created
@@ -193,6 +195,7 @@ class TorConfigFiles private constructor(
     val geoIpv6FileLock = Object()
     val resolvConfFileLock = Object()
     val hostnameFileLock = Object()
+    val v3AuthPrivateDirLock = Object()
 
     /**
      * Resolves the tor configuration file. If the torrc file hasn't been set, then
@@ -262,6 +265,7 @@ class TorConfigFiles private constructor(
         private lateinit var mHostnameFile: File
         private lateinit var mResolveConf: File
         private lateinit var mControlPortFile: File
+        private lateinit var mV3AuthPrivateDir: File
         private var mFileCreationTimeout = 0
 
         fun torExecutable(file: File): Builder {
@@ -365,6 +369,11 @@ class TorConfigFiles private constructor(
             return this
         }
 
+        fun v3AuthPrivateDir(directory: File): Builder {
+            mV3AuthPrivateDir = directory
+            return this
+        }
+
         /**
          * When tor starts it waits for the control port and cookie auth files to be
          * created before it proceeds to the next step in startup. If these files are
@@ -422,6 +431,9 @@ class TorConfigFiles private constructor(
             if (!::mControlPortFile.isInitialized)
                 mControlPortFile = File(mDataDir, ConfigFileName.CONTROL_PORT)
 
+            if (!::mV3AuthPrivateDir.isInitialized)
+                mV3AuthPrivateDir = File(configDir, ConfigFileName.V3_AUTH_PRIVATE_DIR)
+
             if (mFileCreationTimeout <= 0)
                 mFileCreationTimeout = 15
 
@@ -439,6 +451,7 @@ class TorConfigFiles private constructor(
                 mResolveConf,
                 mControlPortFile,
                 installDir,
+                mV3AuthPrivateDir,
                 mFileCreationTimeout
             )
         }

--- a/topl-core/build.gradle
+++ b/topl-core/build.gradle
@@ -70,9 +70,12 @@ dependencies {
     implementation deps.kotlin.coroutinesCore
     implementation deps.kotlin.stdlib
 
+    testImplementation deps.androidx.test.core
     testImplementation deps.junit
+    testImplementation deps.kotlin.coroutinesTest
+    testImplementation deps.robolectric
 
     androidTestImplementation deps.androidx.test.core
-    androidTestImplementation deps.androidx.test.junit
     androidTestImplementation deps.androidx.test.espresso
+    androidTestImplementation deps.androidx.test.junit
 }

--- a/topl-core/build.gradle
+++ b/topl-core/build.gradle
@@ -7,6 +7,7 @@ android {
     compileSdkVersion versions.compileSdk
     buildToolsVersion versions.buildTools
 
+    testOptions.unitTests.includeAndroidResources = true
     defaultConfig {
         minSdkVersion versions.minSdk
         targetSdkVersion versions.compileSdk

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
@@ -315,12 +315,13 @@ internal class OnionProxyContext(
      * @throws [SecurityException] Unauthorized access to file/directory.
      */
     @Throws(RuntimeException::class, SecurityException::class)
-    fun deleteDataDirExceptHiddenService() {
+    fun deleteDataDirExceptHiddenServiceAndAuthPrivate() {
         synchronized(dataDirLock) {
             val listFiles = torConfigFiles.dataDir.listFiles() ?: return
             for (file in listFiles)
                 if (file.isDirectory)
-                    if (file.absolutePath != torConfigFiles.hiddenServiceDir.absolutePath)
+                    if (file.absolutePath != torConfigFiles.hiddenServiceDir.absolutePath &&
+                        file.absolutePath != torConfigFiles.v3AuthPrivateDir.absolutePath)
                         FileUtilities.recursiveFileDelete(file)
                     else
                         if (!file.delete())

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
@@ -97,6 +97,7 @@ import io.matthewnelson.topl_core.util.CoreConsts
 import io.matthewnelson.topl_core.util.TorInstaller
 import io.matthewnelson.topl_core.util.WriteObserver
 import io.matthewnelson.topl_core_base.TorConfigFiles
+import io.matthewnelson.topl_core_base.createNewFileIfDoesNotExist
 import io.matthewnelson.topl_core_base.readTorConfigFile
 import java.io.*
 
@@ -187,24 +188,38 @@ internal class OnionProxyContext(
     @Throws(IllegalArgumentException::class, SecurityException::class)
     fun createNewFileIfDoesNotExist(@ConfigFile configFileReference: String): Boolean {
         broadcastLogger.debug("Creating $configFileReference if DNE")
-        return when (configFileReference) {
+        val created = when (configFileReference) {
             ConfigFile.CONTROL_PORT_FILE -> {
                 synchronized(controlPortFileLock) {
-                    createNewFileIfDoesNotExist(torConfigFiles.controlPortFile)
+                    torConfigFiles.controlPortFile.createNewFileIfDoesNotExist()
                 }
             }
             ConfigFile.COOKIE_AUTH_FILE -> {
                 synchronized(cookieAuthFileLock) {
-                    createNewFileIfDoesNotExist(torConfigFiles.cookieAuthFile)
+                    torConfigFiles.cookieAuthFile.createNewFileIfDoesNotExist()
                 }
             }
             ConfigFile.HOSTNAME_FILE -> {
                 synchronized(hostnameFileLock) {
-                    createNewFileIfDoesNotExist(torConfigFiles.hostnameFile)
+                    torConfigFiles.hostnameFile.createNewFileIfDoesNotExist()
                 }
             }
             else -> {
                 throw IllegalArgumentException("$configFileReference is not a valid argument")
+            }
+        }
+
+        return when (created) {
+            null -> {
+                broadcastLogger.warn("Could not create $configFileReference parent directories")
+                false
+            }
+            false -> {
+                broadcastLogger.warn("Could not create $configFileReference file")
+                false
+            }
+            else -> {
+                true
             }
         }
     }
@@ -351,20 +366,4 @@ internal class OnionProxyContext(
      */
     val processId: String
         get() = Process.myPid().toString()
-
-    @Throws(SecurityException::class)
-    private fun createNewFileIfDoesNotExist(file: File): Boolean {
-        if (file.parentFile?.exists() != true && file.parentFile?.mkdirs() != true) {
-            broadcastLogger.warn("Could not create ${file.nameWithoutExtension} parent directory")
-            return false
-        }
-
-        return try {
-            val exists = if (file.exists()) true else file.createNewFile()
-            exists
-        } catch (e: IOException) {
-            broadcastLogger.warn("Could not create ${file.nameWithoutExtension}")
-            false
-        }
-    }
 }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/settings/TorSettingsBuilder.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/settings/TorSettingsBuilder.kt
@@ -655,6 +655,17 @@ class TorSettingsBuilder internal constructor(
         return this
     }
 
+    /**
+     * Will add to the torrc file "ClientOnionAuthDir </data/data/path/to/directory>, so
+     * be sure to create the directory if it does not exist in [TorInstaller.setup] prior
+     * to utilizing this method when building your torrc file.
+     * */
+    fun setV3AuthPrivateDir(): TorSettingsBuilder {
+        if (torConfigFiles.v3AuthPrivateDir.exists())
+            v3AuthPrivateDir(torConfigFiles.v3AuthPrivateDir.canonicalPath)
+        return this
+    }
+
     fun socksPort(socksPort: String, isolationFlags: List<@IsolationFlag String>?): TorSettingsBuilder {
         if (socksPort.isEmpty()) return this
 
@@ -758,6 +769,12 @@ class TorSettingsBuilder internal constructor(
             useBridges(true)
         else
             this
+
+    fun v3AuthPrivateDir(path: String?): TorSettingsBuilder {
+        if (!path.isNullOrEmpty())
+            buffer.append("ClientOnionAuthDir $path\n")
+        return this
+    }
 
     fun virtualAddressNetwork(address: String?): TorSettingsBuilder {
         if (!address.isNullOrEmpty())

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
@@ -1,0 +1,191 @@
+package io.matthewnelson.topl_core.util
+
+import androidx.annotation.WorkerThread
+import io.matthewnelson.topl_core_base.TorConfigFiles
+import io.matthewnelson.topl_core_base.createNewFileIfDoesNotExist
+import java.io.File
+
+object OnionAuthUtilities {
+
+
+    ///////////////////////////////////
+    /// Add v3 Client Authorization ///
+    ///////////////////////////////////
+    /**
+     * Creates a file containing v3 Client Authorization for a Hidden Service in the format of:
+     *  - Filename: [nickName].auth_private
+     *  - File Contents:  <56-char-onion-addr-without-.onion-part>:descriptor:x25519:<x25519 private key in base32>
+     *
+     * Exceptions are thrown for you with adequate messages if the values passed
+     * are non-compliant.
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-onion-service.html.en#ClientAuthorization
+     *
+     * @param [nickName] The nickname for the file. Is appended with `.auth_private` and used as the File name
+     *   [nickName] requirements are:
+     *   - between 1 and 75 characters
+     *   - alpha-numeric values (0-9, a-z, A-Z) (capitalization does not matter)
+     *   - may contain periods (.), **but** cannot be fist/last character or be used consecutively (..)
+     *   - may contain underscores (_)
+     * @param [onionAddress] The .onion address for which this Private Key will exist for
+     *   - may or may not contain the `.onion` (it gets stripped off if it's present)
+     *   - 56 characters (not including the `.onion` appendage)
+     *   - Base32 encoded ed25519 (a-z, 2-7, **uncapitalized**)
+     * @param [base32EncodedPrivateKey] The private key for authenticating to the Hidden Service
+     *   - 52 characters
+     *   - Base32 encoded x25519 (A-Z, 2-7, **capitalized**)
+     *
+     * @return The File if it was created properly, `null` if it was not
+     * @throws [IllegalArgumentException] If passed arguments are not compliant with the spec
+     * @throws [IllegalStateException] If the file already exists (and must be deleted before overwriting)
+     * @throws [SecurityException] If access is not authorized
+     * */
+    @WorkerThread
+    @JvmStatic
+    @Throws(
+        IllegalArgumentException::class,
+        IllegalStateException::class,
+        SecurityException::class
+    )
+    fun addV3AuthenticationPrivateKey(
+        nickName: String,
+        onionAddress: String,
+        base32EncodedPrivateKey: String,
+        torConfigFiles: TorConfigFiles
+    ): File? {
+        val name = nickName.trim()
+        val onion = if (onionAddress.contains(".onion"))
+            onionAddress.split(".onion")[0].trim()
+        else
+            onionAddress.trim()
+        val key = base32EncodedPrivateKey.trim()
+
+        try {
+            isV3ClientAuthNicknameCompliant(name)
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException("Nickname Exception:\n${e.message}")
+        }
+
+        try {
+            isV3OnionAddressBase32ed25519Compliant(onion)
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException("Onion address Exception:\n${e.message}")
+        }
+
+        try {
+            isV3ClientAuthKeyBase32x25519Compliant(key)
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException("Client Authorization Key Exception:\n${e.message}")
+        }
+
+        val file = File(torConfigFiles.v3AuthPrivateDir, "${name}.auth_private")
+
+        if (file.exists())
+            throw IllegalStateException(
+                "A File with $name already exists and must be deleted first"
+            )
+
+        synchronized(torConfigFiles.v3AuthPrivateDirLock) {
+            if (file.createNewFileIfDoesNotExist() != true)
+                return null
+
+            val string = "${onion}:descriptor:x25519:$key"
+
+            file.writeText(string)
+            val goodContent = file.readText() == string
+
+            return if (!goodContent) {
+                if (file.exists())
+                    file.delete()
+                null
+            } else {
+                file
+            }
+        }
+    }
+
+    private val FILE_NAME_CHARS = charArrayOf(
+        '0', '1', '2', '3', '4', '5',
+        '6', '7', '8', '9', '_', '.',
+        'a', 'b', 'c', 'd', 'e', 'f',
+        'g', 'h', 'i', 'j', 'k', 'l',
+        'm', 'n', 'o', 'p', 'q', 'r',
+        's', 't', 'u', 'v', 'w', 'x',
+        'y', 'z', 'A', 'B', 'C', 'D',
+        'E', 'F', 'G', 'H', 'I', 'J',
+        'K', 'L', 'M', 'N', 'O', 'P',
+        'Q', 'R', 'S', 'T', 'U', 'V',
+        'W', 'X', 'Y', 'Z'
+    )
+
+    private fun isV3ClientAuthNicknameCompliant(nickname: String): String =
+        checkStringCompliance(nickname, FILE_NAME_CHARS, 1, 75)
+
+    private val BASE32_ED25519_CHARS = charArrayOf(
+        '2', '3', '4', '5', '6', '7',
+        'a', 'b', 'c', 'd', 'e', 'f',
+        'g', 'h', 'i', 'j', 'k', 'l',
+        'm', 'n', 'o', 'p', 'q', 'r',
+        's', 't', 'u', 'v', 'w', 'x',
+        'y', 'z'
+    )
+
+    @Throws(IllegalArgumentException::class)
+    private fun isV3OnionAddressBase32ed25519Compliant(onionAddress: String): String =
+        checkStringCompliance(onionAddress, BASE32_ED25519_CHARS, 56, 56)
+
+    private val BASE32_X25519_CHARS = charArrayOf(
+        '2', '3', '4', '5', '6', '7',
+        'A', 'B', 'C', 'D', 'E', 'F',
+        'G', 'H', 'I', 'J', 'K', 'L',
+        'M', 'N', 'O', 'P', 'Q', 'R',
+        'S', 'T', 'U', 'V', 'W', 'X',
+        'Y', 'Z'
+    )
+
+    @Throws(IllegalArgumentException::class)
+    private fun isV3ClientAuthKeyBase32x25519Compliant(v3ClientAuthorizationKey: String): String =
+        checkStringCompliance(v3ClientAuthorizationKey, BASE32_X25519_CHARS, 52, 52)
+
+    @Throws(IllegalArgumentException::class)
+    private fun checkStringCompliance(
+        string: String,
+        charArray: CharArray,
+        minLength: Int,
+        maxLength: Int
+    ): String {
+        var length = 0
+        string.forEachIndexed { index, c ->
+            val exceptionMessage: String? = when {
+                !charArray.contains(c) -> {
+                    "Character '$c' at position $index is invalid"
+                }
+                c == '.' && index == 0 -> {
+                    "The first character cannot be '.'"
+                }
+                c == '.' && string[index - 1] == '.' -> {
+                    "Consecutive periods '..' are not allowed"
+                }
+                c == '.' && index == string.lastIndex-> {
+                    "The last character cannot be '.'"
+                }
+                else -> {
+                    null
+                }
+            }
+
+            exceptionMessage?.let {
+                throw IllegalArgumentException(it)
+            }
+
+            length++
+        }
+
+        return if (length in minLength..maxLength)
+            string
+        else
+            throw  IllegalArgumentException(
+                "Length was $length but must be between $minLength and $maxLength characters"
+            )
+    }
+}

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
@@ -220,7 +220,9 @@ object OnionAuthUtilities {
      * @param [torConfigFiles]
      * */
     fun getAllFiles(torConfigFiles: TorConfigFiles): Array<File>? =
-        torConfigFiles.v3AuthPrivateDir.listFiles()
+        synchronized(torConfigFiles.v3AuthPrivateDirLock) {
+            torConfigFiles.v3AuthPrivateDir.listFiles()
+        }
 
     /**
      * From the v3 Client Authentication directory, all files that contain the
@@ -231,9 +233,12 @@ object OnionAuthUtilities {
      * */
     fun getAllFileNicknames(torConfigFiles: TorConfigFiles): Array<String>? {
         val fileNames = mutableListOf<String>()
-        for (file in torConfigFiles.v3AuthPrivateDir.listFiles() ?: return null) {
-            if (!file.isDirectory && file.name.contains(FILE_EXTENSION))
-                fileNames.add(file.nameWithoutExtension)
+
+        synchronized(torConfigFiles.v3AuthPrivateDirLock) {
+            for (file in torConfigFiles.v3AuthPrivateDir.listFiles() ?: return null) {
+                if (!file.isDirectory && file.name.contains(FILE_EXTENSION))
+                    fileNames.add(file.nameWithoutExtension)
+            }
         }
         return fileNames.toTypedArray()
     }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
@@ -237,4 +237,21 @@ object OnionAuthUtilities {
         }
         return fileNames.toTypedArray()
     }
+
+
+    ////////////////
+    /// Deletion ///
+    ////////////////
+    fun deleteFile(nickname: String, torConfigFiles: TorConfigFiles): Boolean? {
+        val file = getFileByNickname(nickname, torConfigFiles) ?: return null
+        synchronized(torConfigFiles.v3AuthPrivateDirLock) {
+            return if (!file.isDirectory)
+                file.delete()
+            else
+                null
+        }
+    }
+
+    fun deleteFile(file: File, torConfigFiles: TorConfigFiles): Boolean? =
+        deleteFile(file.nameWithoutExtension, torConfigFiles)
 }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
@@ -4,8 +4,6 @@ import androidx.annotation.WorkerThread
 import io.matthewnelson.topl_core_base.TorConfigFiles
 import io.matthewnelson.topl_core_base.createNewFileIfDoesNotExist
 import java.io.File
-import java.io.FileFilter
-import java.io.FilenameFilter
 
 object OnionAuthUtilities {
 
@@ -17,7 +15,7 @@ object OnionAuthUtilities {
     ///////////////////////////////////
     /**
      * Creates a file containing v3 Client Authorization for a Hidden Service in the format of:
-     *  - Filename: [nickName].auth_private
+     *  - Filename: [nickname].auth_private
      *  - File Contents:  <56-char-onion-addr-without-.onion-part>:descriptor:x25519:<x25519 private key in base32>
      *
      * Exceptions are thrown for you with adequate messages if the values passed
@@ -25,8 +23,8 @@ object OnionAuthUtilities {
      *
      * **Docs:** https://2019.www.torproject.org/docs/tor-onion-service.html.en#ClientAuthorization
      *
-     * @param [nickName] The nickname for the file. Is appended with `.auth_private` and used as the File name
-     *   [nickName] requirements are:
+     * @param [nickname] The nickname for the file. Is appended with `.auth_private` and used as the File name
+     *   [nickname] requirements are:
      *   - between 1 and 75 characters
      *   - alpha-numeric values (0-9, a-z, A-Z) (capitalization does not matter)
      *   - may contain periods (.), **but** cannot be fist/last character or be used consecutively (..)
@@ -51,13 +49,13 @@ object OnionAuthUtilities {
         IllegalStateException::class,
         SecurityException::class
     )
-    fun addV3AuthenticationPrivateKey(
-        nickName: String,
+    fun addV3ClientAuthenticationPrivateKey(
+        nickname: String,
         onionAddress: String,
         base32EncodedPrivateKey: String,
         torConfigFiles: TorConfigFiles
     ): File? {
-        val name = nickName.trim()
+        val name = nickname.trim()
         val onion = if (onionAddress.contains(".onion"))
             onionAddress.split(".onion")[0].trim()
         else

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
@@ -4,8 +4,12 @@ import androidx.annotation.WorkerThread
 import io.matthewnelson.topl_core_base.TorConfigFiles
 import io.matthewnelson.topl_core_base.createNewFileIfDoesNotExist
 import java.io.File
+import java.io.FileFilter
+import java.io.FilenameFilter
 
 object OnionAuthUtilities {
+
+    private const val FILE_EXTENSION = ".auth_private"
 
 
     ///////////////////////////////////
@@ -78,7 +82,7 @@ object OnionAuthUtilities {
             throw IllegalArgumentException("Client Authorization Key Exception:\n${e.message}")
         }
 
-        val file = File(torConfigFiles.v3AuthPrivateDir, "${name}.auth_private")
+        val file = File(torConfigFiles.v3AuthPrivateDir, "$name$FILE_EXTENSION")
 
         if (file.exists())
             throw IllegalStateException(
@@ -187,5 +191,52 @@ object OnionAuthUtilities {
             throw  IllegalArgumentException(
                 "Length was $length but must be between $minLength and $maxLength characters"
             )
+    }
+
+    /////////////////
+    /// Retrieval ///
+    /////////////////
+    /**
+     * Retrieve a v3 client authentication file by the nickname, whether the file
+     * extension ".auth_private" is included or not.
+     *
+     * @param [nickname] The pre file extension name
+     * @param [torConfigFiles]
+     * */
+    fun getFileByNickname(nickname: String, torConfigFiles: TorConfigFiles): File? {
+        val file = if (nickname.contains(FILE_EXTENSION))
+            File(torConfigFiles.v3AuthPrivateDir, nickname)
+        else
+            File(torConfigFiles.v3AuthPrivateDir, "$nickname$FILE_EXTENSION")
+
+        return if (file.exists())
+            file
+        else
+            null
+    }
+
+    /**
+     * All files within the v3 Client Authentication directory are returned. If
+     * the directory is empty, returns `null`.
+     *
+     * @param [torConfigFiles]
+     * */
+    fun getAllFiles(torConfigFiles: TorConfigFiles): Array<File>? =
+        torConfigFiles.v3AuthPrivateDir.listFiles()
+
+    /**
+     * From the v3 Client Authentication directory, all files that contain the
+     * ".auth_private" extension will have their name w/o the extension returned
+     * in an array. If the directory is empty, returns `null`.
+     *
+     * @param [torConfigFiles]
+     * */
+    fun getAllFileNicknames(torConfigFiles: TorConfigFiles): Array<String>? {
+        val fileNames = mutableListOf<String>()
+        for (file in torConfigFiles.v3AuthPrivateDir.listFiles() ?: return null) {
+            if (!file.isDirectory && file.name.contains(FILE_EXTENSION))
+                fileNames.add(file.nameWithoutExtension)
+        }
+        return fileNames.toTypedArray()
     }
 }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
@@ -191,6 +191,7 @@ object OnionAuthUtilities {
             )
     }
 
+
     /////////////////
     /// Retrieval ///
     /////////////////
@@ -201,6 +202,8 @@ object OnionAuthUtilities {
      * @param [nickname] The pre file extension name
      * @param [torConfigFiles]
      * */
+    @WorkerThread
+    @JvmStatic
     fun getFileByNickname(nickname: String, torConfigFiles: TorConfigFiles): File? {
         val file = if (nickname.contains(FILE_EXTENSION))
             File(torConfigFiles.v3AuthPrivateDir, nickname)
@@ -219,6 +222,8 @@ object OnionAuthUtilities {
      *
      * @param [torConfigFiles]
      * */
+    @WorkerThread
+    @JvmStatic
     fun getAllFiles(torConfigFiles: TorConfigFiles): Array<File>? =
         synchronized(torConfigFiles.v3AuthPrivateDirLock) {
             torConfigFiles.v3AuthPrivateDir.listFiles()
@@ -231,6 +236,8 @@ object OnionAuthUtilities {
      *
      * @param [torConfigFiles]
      * */
+    @WorkerThread
+    @JvmStatic
     fun getAllFileNicknames(torConfigFiles: TorConfigFiles): Array<String>? {
         val fileNames = mutableListOf<String>()
 
@@ -247,6 +254,8 @@ object OnionAuthUtilities {
     ////////////////
     /// Deletion ///
     ////////////////
+    @WorkerThread
+    @JvmStatic
     fun deleteFile(nickname: String, torConfigFiles: TorConfigFiles): Boolean? {
         val file = getFileByNickname(nickname, torConfigFiles) ?: return null
         synchronized(torConfigFiles.v3AuthPrivateDirLock) {
@@ -257,6 +266,8 @@ object OnionAuthUtilities {
         }
     }
 
+    @WorkerThread
+    @JvmStatic
     fun deleteFile(file: File, torConfigFiles: TorConfigFiles): Boolean? =
         deleteFile(file.nameWithoutExtension, torConfigFiles)
 }

--- a/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
+++ b/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
@@ -263,4 +263,47 @@ class OnionAuthUtilitiesUnitTest {
             Assert.assertFalse(nickname.contains(".auth_private"))
         }
     }
+
+
+    ////////////////
+    /// Deletion ///
+    ////////////////
+    @Test
+    fun `deleteFile returns null if file does not exist`() {
+        val result = OnionAuthUtilities.deleteFile(validNickname, torConfigFiles)
+        Assert.assertNull(result)
+    }
+
+    @Test
+    fun `deleteFile returns null if file is directory`() {
+        val result = OnionAuthUtilities.deleteFile(torConfigFiles.v3AuthPrivateDir, torConfigFiles)
+        Assert.assertNull(result)
+    }
+
+    @Test
+    fun `deleteFile by sending file works properly`() {
+        val file = addV3ClientAuthenticationPrivateKey()
+        Assert.assertNotNull(file)
+
+        val result = OnionAuthUtilities.deleteFile(file!!, torConfigFiles)
+        Assert.assertTrue(result == true)
+    }
+
+    @Test
+    fun `deleteFile by sending nickname with extension works properly`() {
+        val file = addV3ClientAuthenticationPrivateKey()
+        Assert.assertNotNull(file)
+
+        val result = OnionAuthUtilities.deleteFile(file!!.name, torConfigFiles)
+        Assert.assertTrue(result == true)
+    }
+
+    @Test
+    fun `deleteFile by sending nickname without extension works properly`() {
+        val file = addV3ClientAuthenticationPrivateKey()
+        Assert.assertNotNull(file)
+
+        val result = OnionAuthUtilities.deleteFile(file!!.nameWithoutExtension, torConfigFiles)
+        Assert.assertTrue(result == true)
+    }
 }

--- a/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
+++ b/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
@@ -43,12 +43,12 @@ class OnionAuthUtilitiesUnitTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun `empty nickname throws exception`() {
-        addV3AuthenticationPrivateKey("")
+        addV3ClientAuthenticationPrivateKey("")
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun `nickname over 75 chars throws exception`() {
-        addV3AuthenticationPrivateKey("${validOnion}${validOnion}")
+        addV3ClientAuthenticationPrivateKey("${validOnion}${validOnion}")
     }
 
     @Test
@@ -64,7 +64,7 @@ class OnionAuthUtilitiesUnitTest {
 
         unacceptableCharacters.forEach { char ->
             val wasThrown = try {
-                addV3AuthenticationPrivateKey("$validNickname${char}p")
+                addV3ClientAuthenticationPrivateKey("$validNickname${char}p")
                 false
             } catch (e: IllegalArgumentException) {
                 e.message?.contains("at position ${validNickname.length}") == true
@@ -75,50 +75,50 @@ class OnionAuthUtilitiesUnitTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun `nickname last character cannot be a period`() {
-        addV3AuthenticationPrivateKey("${validNickname}.")
+        addV3ClientAuthenticationPrivateKey("${validNickname}.")
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun `nickname cannot contain consecutive periods`() {
-        addV3AuthenticationPrivateKey("${validNickname}..p")
+        addV3ClientAuthenticationPrivateKey("${validNickname}..p")
     }
 
     @Test
     fun `nickname with period and character after is valid`() {
         val name = "${validNickname}.p"
-        val file = addV3AuthenticationPrivateKey(name)
+        val file = addV3ClientAuthenticationPrivateKey(name)
         Assert.assertEquals(file?.name, "${name}.auth_private")
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun `nickname with spaces throws exception`() {
-        addV3AuthenticationPrivateKey("test file name")
+        addV3ClientAuthenticationPrivateKey("test file name")
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun `empty onion address throws exception`() {
-        addV3AuthenticationPrivateKey(validNickname, "")
+        addV3ClientAuthenticationPrivateKey(validNickname, "")
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun `short onion address throws exception`() {
-        addV3AuthenticationPrivateKey(validNickname, validOnion.dropLast(1))
+        addV3ClientAuthenticationPrivateKey(validNickname, validOnion.dropLast(1))
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun `long onion address throws exception`() {
-        addV3AuthenticationPrivateKey(validNickname, "${validOnion}asdfk")
+        addV3ClientAuthenticationPrivateKey(validNickname, "${validOnion}asdfk")
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun `onion address with spaces throws exception`() {
-        addV3AuthenticationPrivateKey(validNickname, validOnion.dropLast(5) + " ldo3")
+        addV3ClientAuthenticationPrivateKey(validNickname, validOnion.dropLast(5) + " ldo3")
     }
 
     @Test(expected = IllegalStateException::class)
     fun `file already exists throws exception`() {
-        addV3AuthenticationPrivateKey()
-        addV3AuthenticationPrivateKey()
+        addV3ClientAuthenticationPrivateKey()
+        addV3ClientAuthenticationPrivateKey()
     }
 
     @Test(expected = AssertionError::class)
@@ -128,48 +128,48 @@ class OnionAuthUtilitiesUnitTest {
 
     @Test
     fun `file creation successful with proper parameters`() {
-        val file = addV3AuthenticationPrivateKey()
+        val file = addV3ClientAuthenticationPrivateKey()
 
         checkAddAuthPrivateAssertions(file)
     }
 
     @Test
     fun `file creation successful with dot_onion appended to onionAddress field`() {
-        val file = addV3AuthenticationPrivateKey(validNickname, "${validOnion}.onion")
+        val file = addV3ClientAuthenticationPrivateKey(validNickname, "${validOnion}.onion")
 
         checkAddAuthPrivateAssertions(file)
     }
 
     @Test
     fun `arguments are trimmed prior to being checked for compliance`() {
-        var file = addV3AuthenticationPrivateKey(
+        var file = addV3ClientAuthenticationPrivateKey(
             "$validNickname ", "$validOnion .onion", "$validClientAuthKey "
         )
 
         checkAddAuthPrivateAssertions(file)
 
         file?.delete()
-        file = addV3AuthenticationPrivateKey(
+        file = addV3ClientAuthenticationPrivateKey(
             " $validNickname", " $validOnion", " $validClientAuthKey"
         )
 
         checkAddAuthPrivateAssertions(file)
 
         file?.delete()
-        file = addV3AuthenticationPrivateKey(
+        file = addV3ClientAuthenticationPrivateKey(
             validNickname, " $validOnion .onion  ", validClientAuthKey
         )
 
         checkAddAuthPrivateAssertions(file)
     }
 
-    private fun addV3AuthenticationPrivateKey(
+    private fun addV3ClientAuthenticationPrivateKey(
         name: String = validNickname,
         onionAddress: String = validOnion,
         privateKey: String = validClientAuthKey,
         configFiles: TorConfigFiles = torConfigFiles
     ): File? {
-        return OnionAuthUtilities.addV3AuthenticationPrivateKey(name, onionAddress, privateKey, configFiles)
+        return OnionAuthUtilities.addV3ClientAuthenticationPrivateKey(name, onionAddress, privateKey, configFiles)
     }
 
     @Throws(AssertionError::class)
@@ -194,9 +194,9 @@ class OnionAuthUtilitiesUnitTest {
         val name1 = "name1"
         val name2 = "name2"
         val name3 = "name3"
-        val file1 = addV3AuthenticationPrivateKey(name1)
-        val file2 = addV3AuthenticationPrivateKey(name2)
-        val file3 = addV3AuthenticationPrivateKey(name3)
+        val file1 = addV3ClientAuthenticationPrivateKey(name1)
+        val file2 = addV3ClientAuthenticationPrivateKey(name2)
+        val file3 = addV3ClientAuthenticationPrivateKey(name3)
         checkAddAuthPrivateAssertions(file1)
         checkAddAuthPrivateAssertions(file2)
         checkAddAuthPrivateAssertions(file3)
@@ -213,7 +213,7 @@ class OnionAuthUtilitiesUnitTest {
 
     @Test
     fun `getFileByNickname returns file if exists`() {
-        val file = addV3AuthenticationPrivateKey()
+        val file = addV3ClientAuthenticationPrivateKey()
         checkAddAuthPrivateAssertions(file)
 
         val fileResult = OnionAuthUtilities.getFileByNickname(validNickname, torConfigFiles)
@@ -223,7 +223,7 @@ class OnionAuthUtilitiesUnitTest {
 
     @Test
     fun `getFileByNickname returns null if does not exist`() {
-        val file = addV3AuthenticationPrivateKey()
+        val file = addV3ClientAuthenticationPrivateKey()
         checkAddAuthPrivateAssertions(file)
 
         var fileResult = OnionAuthUtilities.getFileByNickname("${validNickname}_does_not_exist", torConfigFiles)
@@ -245,9 +245,9 @@ class OnionAuthUtilitiesUnitTest {
         val name1 = "name1"
         val name2 = "name2"
         val name3 = "name3"
-        val file1 = addV3AuthenticationPrivateKey(name1)
-        val file2 = addV3AuthenticationPrivateKey(name2)
-        val file3 = addV3AuthenticationPrivateKey(name3)
+        val file1 = addV3ClientAuthenticationPrivateKey(name1)
+        val file2 = addV3ClientAuthenticationPrivateKey(name2)
+        val file3 = addV3ClientAuthenticationPrivateKey(name3)
         checkAddAuthPrivateAssertions(file1)
         checkAddAuthPrivateAssertions(file2)
         checkAddAuthPrivateAssertions(file3)

--- a/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
+++ b/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
@@ -178,4 +178,89 @@ class OnionAuthUtilitiesUnitTest {
         Assert.assertEquals(file?.parentFile, torConfigFiles.v3AuthPrivateDir)
         Assert.assertEquals(expectedFileContent, file?.readText())
     }
+
+
+    /////////////////
+    /// Retrieval ///
+    /////////////////
+    @Test
+    fun `getAllFiles returns null when none exist`() {
+        val files = OnionAuthUtilities.getAllFiles(torConfigFiles)
+        Assert.assertNull(files)
+    }
+
+    @Test
+    fun `getAllFiles returns list of files`() {
+        val name1 = "name1"
+        val name2 = "name2"
+        val name3 = "name3"
+        val file1 = addV3AuthenticationPrivateKey(name1)
+        val file2 = addV3AuthenticationPrivateKey(name2)
+        val file3 = addV3AuthenticationPrivateKey(name3)
+        checkAddAuthPrivateAssertions(file1)
+        checkAddAuthPrivateAssertions(file2)
+        checkAddAuthPrivateAssertions(file3)
+
+        val expectedArray = arrayOf(file1, file2, file3)
+
+        val resultArray = OnionAuthUtilities.getAllFiles(torConfigFiles)
+        Assert.assertNotNull(resultArray)
+
+        expectedArray.forEach { file ->
+            Assert.assertTrue(resultArray?.contains(file) == true)
+        }
+    }
+
+    @Test
+    fun `getFileByNickname returns file if exists`() {
+        val file = addV3AuthenticationPrivateKey()
+        checkAddAuthPrivateAssertions(file)
+
+        val fileResult = OnionAuthUtilities.getFileByNickname(validNickname, torConfigFiles)
+
+        Assert.assertEquals(file, fileResult)
+    }
+
+    @Test
+    fun `getFileByNickname returns null if does not exist`() {
+        val file = addV3AuthenticationPrivateKey()
+        checkAddAuthPrivateAssertions(file)
+
+        var fileResult = OnionAuthUtilities.getFileByNickname("${validNickname}_does_not_exist", torConfigFiles)
+        Assert.assertNotEquals(file, fileResult)
+        Assert.assertNull(fileResult)
+
+        fileResult = OnionAuthUtilities.getFileByNickname(validNickname, torConfigFiles)
+        Assert.assertEquals(file, fileResult)
+    }
+
+    @Test
+    fun `getAllFileNicknames returns null if no files exist`() {
+        val nicknames = OnionAuthUtilities.getAllFileNicknames(torConfigFiles)
+        Assert.assertNull(nicknames)
+    }
+
+    @Test
+    fun `getAllFileNicknames returns list of nicknames only without file extension`() {
+        val name1 = "name1"
+        val name2 = "name2"
+        val name3 = "name3"
+        val file1 = addV3AuthenticationPrivateKey(name1)
+        val file2 = addV3AuthenticationPrivateKey(name2)
+        val file3 = addV3AuthenticationPrivateKey(name3)
+        checkAddAuthPrivateAssertions(file1)
+        checkAddAuthPrivateAssertions(file2)
+        checkAddAuthPrivateAssertions(file3)
+
+        val expectedNicknames = arrayOf(name1, name2, name3)
+
+        val nicknames = OnionAuthUtilities.getAllFileNicknames(torConfigFiles)
+        Assert.assertEquals(3, nicknames?.size)
+
+        for (nickname in nicknames!!) {
+            Assert.assertTrue(expectedNicknames.contains(nickname))
+            Assert.assertFalse(expectedNicknames.contains(".auth_private"))
+            Assert.assertFalse(nickname.contains(".auth_private"))
+        }
+    }
 }

--- a/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
+++ b/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
@@ -1,0 +1,181 @@
+package io.matthewnelson.topl_core.util
+
+import io.matthewnelson.topl_core_base.TorConfigFiles
+import org.junit.*
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import kotlin.jvm.Throws
+
+@Config(minSdk = 16, maxSdk = 28)
+@RunWith(RobolectricTestRunner::class)
+class OnionAuthUtilitiesUnitTest {
+
+    @get:Rule
+    val testDirectory = TemporaryFolder()
+
+    private lateinit var torConfigFiles: TorConfigFiles
+    private val validNickname = "test_file_name"
+    private val validOnion = "pqojaffu4an36caasmwnkg3n5lxvf4h4nbnvsloqdloqqay5nbvrwjyd"
+    private val validClientAuthKey = "KCTSNJBCYVJ6GK3WMVBVPP6LAWNFAIHN2VHCLZ75BDQA2SZGDBOQ"
+    private val expectedFileContent = "${validOnion}:descriptor:x25519:$validClientAuthKey"
+
+    @Before
+    fun setup() {
+        testDirectory.create()
+        val installDir = File("/usr/bin")
+        val configDir = testDirectory.newFolder("configDir")
+        torConfigFiles = TorConfigFiles.Builder(installDir, configDir)
+            .torExecutable(File(installDir, "tor"))
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        testDirectory.delete()
+    }
+
+    /////////////////////////////////////
+    /// addV3AuthenticationPrivateKey ///
+    /////////////////////////////////////
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `empty nickname throws exception`() {
+        addV3AuthenticationPrivateKey("")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `nickname over 75 chars throws exception`() {
+        addV3AuthenticationPrivateKey("${validOnion}${validOnion}")
+    }
+
+    @Test
+    fun `nickname with special chars throws exceptions`() {
+        val unacceptableCharacters = charArrayOf(
+            '`', '~', '!', '@', '#', '$',
+            '%', '^', '&', '*', '(', ')',
+            '-', '=', '+', '{', '}', '[',
+            ']', '|', ';', ':', '\'', '"',
+            ',', '<', '>', '?', '/', '\\',
+            ' '
+        )
+
+        unacceptableCharacters.forEach { char ->
+            val wasThrown = try {
+                addV3AuthenticationPrivateKey("$validNickname${char}p")
+                false
+            } catch (e: IllegalArgumentException) {
+                e.message?.contains("at position ${validNickname.length}") == true
+            }
+            Assert.assertTrue(wasThrown)
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `nickname last character cannot be a period`() {
+        addV3AuthenticationPrivateKey("${validNickname}.")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `nickname cannot contain consecutive periods`() {
+        addV3AuthenticationPrivateKey("${validNickname}..p")
+    }
+
+    @Test
+    fun `nickname with period and character after is valid`() {
+        val name = "${validNickname}.p"
+        val file = addV3AuthenticationPrivateKey(name)
+        Assert.assertEquals(file?.name, "${name}.auth_private")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `nickname with spaces throws exception`() {
+        addV3AuthenticationPrivateKey("test file name")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `empty onion address throws exception`() {
+        addV3AuthenticationPrivateKey(validNickname, "")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `short onion address throws exception`() {
+        addV3AuthenticationPrivateKey(validNickname, validOnion.dropLast(1))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `long onion address throws exception`() {
+        addV3AuthenticationPrivateKey(validNickname, "${validOnion}asdfk")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `onion address with spaces throws exception`() {
+        addV3AuthenticationPrivateKey(validNickname, validOnion.dropLast(5) + " ldo3")
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `file already exists throws exception`() {
+        addV3AuthenticationPrivateKey()
+        addV3AuthenticationPrivateKey()
+    }
+
+    @Test(expected = AssertionError::class)
+    fun `check assertion method throws exception if null`() {
+        checkAddAuthPrivateAssertions(null)
+    }
+
+    @Test
+    fun `file creation successful with proper parameters`() {
+        val file = addV3AuthenticationPrivateKey()
+
+        checkAddAuthPrivateAssertions(file)
+    }
+
+    @Test
+    fun `file creation successful with dot_onion appended to onionAddress field`() {
+        val file = addV3AuthenticationPrivateKey(validNickname, "${validOnion}.onion")
+
+        checkAddAuthPrivateAssertions(file)
+    }
+
+    @Test
+    fun `arguments are trimmed prior to being checked for compliance`() {
+        var file = addV3AuthenticationPrivateKey(
+            "$validNickname ", "$validOnion .onion", "$validClientAuthKey "
+        )
+
+        checkAddAuthPrivateAssertions(file)
+
+        file?.delete()
+        file = addV3AuthenticationPrivateKey(
+            " $validNickname", " $validOnion", " $validClientAuthKey"
+        )
+
+        checkAddAuthPrivateAssertions(file)
+
+        file?.delete()
+        file = addV3AuthenticationPrivateKey(
+            validNickname, " $validOnion .onion  ", validClientAuthKey
+        )
+
+        checkAddAuthPrivateAssertions(file)
+    }
+
+    private fun addV3AuthenticationPrivateKey(
+        name: String = validNickname,
+        onionAddress: String = validOnion,
+        privateKey: String = validClientAuthKey,
+        configFiles: TorConfigFiles = torConfigFiles
+    ): File? {
+        return OnionAuthUtilities.addV3AuthenticationPrivateKey(name, onionAddress, privateKey, configFiles)
+    }
+
+    @Throws(AssertionError::class)
+    private fun checkAddAuthPrivateAssertions(file: File?) {
+        Assert.assertTrue(file?.exists() == true)
+        Assert.assertEquals(file?.parentFile, torConfigFiles.v3AuthPrivateDir)
+        Assert.assertEquals(expectedFileContent, file?.readText())
+    }
+}

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -82,6 +82,7 @@ import io.matthewnelson.topl_service.service.components.binding.TorServiceConnec
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
 import io.matthewnelson.topl_service.service.components.onionproxy.model.TorServiceEventBroadcaster
 import io.matthewnelson.topl_service.util.ServiceConsts
+import io.matthewnelson.topl_service.util.V3ClientAuthManager
 
 class TorServiceController private constructor(): ServiceConsts() {
 
@@ -394,6 +395,17 @@ class TorServiceController private constructor(): ServiceConsts() {
                 throw RuntimeException(e.message)
             }
         }
+
+        /**
+         * Returns an instance of [V3ClientAuthManager] for adding, querying, and removing
+         * v3 Client Authorization private key files.
+         *
+         * @throws [RuntimeException] if called before [Builder.build]
+         * */
+        @JvmStatic
+        @Throws(RuntimeException::class)
+        fun getV3ClientAuthManager(): V3ClientAuthManager =
+            V3ClientAuthManager(getTorConfigFiles())
 
         /**
          * Helper method for easily obtaining [ServiceTorSettings].

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -275,6 +275,7 @@ internal class TorService: BaseService() {
         onionProxyManager.getNewSettingsBuilder()
             .updateTorSettings()
             .setGeoIpFiles()
+            .setV3AuthPrivateDir()
             .finishAndWriteToTorrcFile()
     }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorInstaller.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorInstaller.kt
@@ -111,6 +111,8 @@ internal class ServiceTorInstaller(private val torService: BaseService): TorInst
             copyGeoIpv6Asset()
             geoIpv6FileCopied = true
         }
+        if (!torConfigFiles.v3AuthPrivateDir.exists())
+            torConfigFiles.v3AuthPrivateDir.mkdirs()
 
         // If the app version has been increased, or if this is a debug build, copy over
         // geoip assets then update SharedPreferences with the new version code. This

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceUtilities.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceUtilities.kt
@@ -78,6 +78,7 @@ object ServiceUtilities {
      * @param [download] Long value associated with download (bytesRead)
      * @param [upload] Long value associated with upload (bytesWritten)
      * */
+    @JvmStatic
     fun getFormattedBandwidthString(download: Long, upload: Long): String =
         "${formatBandwidth(download)} ↓ / ${formatBandwidth(upload)} ↑"
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/V3ClientAuthManager.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/V3ClientAuthManager.kt
@@ -5,6 +5,13 @@ import io.matthewnelson.topl_core.util.OnionAuthUtilities
 import io.matthewnelson.topl_core_base.TorConfigFiles
 import java.io.File
 
+/**
+ * This class provides methods necessary for adding, querying, deleting, and reading
+ * files regarding v3 Client Authentication.
+ *
+ * Use [io.matthewnelson.topl_service.TorServiceController.getV3ClientAuthManager] to
+ * instantiate an instance of the Manager.
+ * */
 class V3ClientAuthManager internal constructor(
     private val torConfigFiles: TorConfigFiles
 ) {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/V3ClientAuthManager.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/V3ClientAuthManager.kt
@@ -1,0 +1,116 @@
+package io.matthewnelson.topl_service.util
+
+import androidx.annotation.WorkerThread
+import io.matthewnelson.topl_core.util.OnionAuthUtilities
+import io.matthewnelson.topl_core_base.TorConfigFiles
+import java.io.File
+
+class V3ClientAuthManager internal constructor(
+    private val torConfigFiles: TorConfigFiles
+) {
+
+    ///////////////////////////////////
+    /// Add v3 Client Authorization ///
+    ///////////////////////////////////
+    /**
+     * Creates a file containing v3 Client Authorization for a Hidden Service in the format of:
+     *  - Filename: [nickname].auth_private
+     *  - File Contents:  <56-char-onion-addr-without-.onion-part>:descriptor:x25519:<x25519 private key in base32>
+     *
+     * Exceptions are thrown for you with adequate messages if the values passed
+     * are non-compliant.
+     *
+     * **Docs:** https://2019.www.torproject.org/docs/tor-onion-service.html.en#ClientAuthorization
+     *
+     * @param [nickname] The nickname for the file. Is appended with `.auth_private` and used as the File name
+     *   [nickname] requirements are:
+     *   - between 1 and 75 characters
+     *   - alpha-numeric values (0-9, a-z, A-Z) (capitalization does not matter)
+     *   - may contain periods (.), **but** cannot be fist/last character or be used consecutively (..)
+     *   - may contain underscores (_)
+     * @param [onionAddress] The .onion address for which this Private Key will exist for
+     *   - may or may not contain the `.onion` (it gets stripped off if it's present)
+     *   - 56 characters (not including the `.onion` appendage)
+     *   - Base32 encoded ed25519 (a-z, 2-7, **uncapitalized**)
+     * @param [base32EncodedPrivateKey] The private key for authenticating to the Hidden Service
+     *   - 52 characters
+     *   - Base32 encoded x25519 (A-Z, 2-7, **capitalized**)
+     *
+     * @return The File if it was created properly, `null` if it was not
+     * @throws [IllegalArgumentException] If passed arguments are not compliant with the spec
+     * @throws [IllegalStateException] If the file already exists (and must be deleted before overwriting)
+     * @throws [SecurityException] If access is not authorized
+     * */
+    @WorkerThread
+    @Throws(
+        IllegalArgumentException::class,
+        IllegalStateException::class,
+        SecurityException::class
+    )
+    fun addV3ClientAuthenticationPrivateKey(
+        nickname: String,
+        onionAddress: String,
+        base32EncodedPrivateKey: String
+    ): File? =
+        OnionAuthUtilities.addV3ClientAuthenticationPrivateKey(
+            nickname, onionAddress, base32EncodedPrivateKey, torConfigFiles
+        )
+
+    /////////////////
+    /// Retrieval ///
+    /////////////////
+    /**
+     * Retrieve a v3 client authentication file by the nickname, whether the file
+     * extension ".auth_private" is included or not.
+     *
+     * @param [nickname] The pre file extension name
+     * */
+    @WorkerThread
+    fun getFileByNickname(nickname: String): File? =
+        OnionAuthUtilities.getFileByNickname(nickname, torConfigFiles)
+
+    /**
+     * All files within the v3 Client Authentication directory are returned. If
+     * the directory is empty, returns `null`.
+     * */
+    @WorkerThread
+    fun getAllFiles(): Array<File>? =
+        OnionAuthUtilities.getAllFiles(torConfigFiles)
+
+    /**
+     * From the v3 Client Authentication directory, all files that contain the
+     * ".auth_private" extension will have their name w/o the extension returned
+     * in an array. If the directory is empty, returns `null`.
+     * */
+    @WorkerThread
+    fun getAllFileNicknames(): Array<String>? =
+        OnionAuthUtilities.getAllFileNicknames(torConfigFiles)
+
+    class V3ClientAuthContent internal constructor(val address: String, val privateKey: String)
+
+    @WorkerThread
+    fun getFileContent(nickname: String): V3ClientAuthContent? {
+        val v3ClientAuthFile = getFileByNickname(nickname) ?: return null
+        val content = v3ClientAuthFile.readText().split(':')
+        return V3ClientAuthContent(content[0], content[3])
+    }
+
+    @WorkerThread
+    fun getFileContent(file: File): V3ClientAuthContent? {
+        val v3ClientAuthFile = getFileByNickname(file.nameWithoutExtension) ?: return null
+        val content = v3ClientAuthFile.readText().split(':')
+        return V3ClientAuthContent(content[0], content[3])
+    }
+
+
+    ////////////////
+    /// Deletion ///
+    ////////////////
+    @WorkerThread
+    fun deleteFile(nickname: String): Boolean? =
+        OnionAuthUtilities.deleteFile(nickname, torConfigFiles)
+
+    @WorkerThread
+    fun deleteFile(file: File): Boolean? =
+        OnionAuthUtilities.deleteFile(file, torConfigFiles)
+}


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR adds to the 1.1.0-alpha01 release the capability of authenticating to a v3 Hidden Service via importing of a Base32 encoded x25519 generated private key pair.

For more information on about v3 Client Authorization, see <a href="https://community.torproject.org/onion-services/advanced/client-auth/" target="_blank">the documentation</a>


## Type of change
<!--    [x] = check mark on preview     -->
<!--    [ ] = empty box on preview      -->
<!---->
<!-- Please REMOVE unchecked selections -->

- [x] New feature (non-breaking change which adds functionality)

## Change Status
<!-- Please REMOVE unchecked selections -->

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?
<!-- Please REMOVE unchecked selections -->

- [x] Unit Tests

# Checklist
<!-- Please KEEP unchecked selections -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/ui tests pass locally with my changes
- [x] There are no merge conflicts
