### PR TITLE
Performance enhancements

### DIFF
--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashMessage.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashMessage.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.sampleapp.ui.fragments.dashboard
 
 import androidx.annotation.ColorRes

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashboardFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/dashboard/DashboardFragment.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.sampleapp.ui.fragments.dashboard
 
 import android.app.NotificationChannel

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/home/HomeFragment.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/ui/fragments/home/HomeFragment.kt
@@ -72,12 +72,17 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import androidx.lifecycle.lifecycleScope
 import io.matthewnelson.sampleapp.R
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
 import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.prefs.TorServicePrefs
 import io.matthewnelson.topl_service.util.ServiceConsts
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class HomeFragment : Fragment() {
 
@@ -97,6 +102,7 @@ class HomeFragment : Fragment() {
 
     private lateinit var torServicePrefs: TorServicePrefs
     private lateinit var logMessageAdapter: LogMessageAdapter
+    private var getDebugLogsJob: Job? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -104,10 +110,12 @@ class HomeFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         torServicePrefs = TorServicePrefs(inflater.context)
-        hasDebugLogs = torServicePrefs.getBoolean(
-            ServiceConsts.PrefKeyBoolean.HAS_DEBUG_LOGS,
-            TorServiceController.getTorSettings().hasDebugLogs
-        )
+        getDebugLogsJob = lifecycleScope.launch(Dispatchers.IO) {
+            hasDebugLogs = torServicePrefs.getBoolean(
+                ServiceConsts.PrefKeyBoolean.HAS_DEBUG_LOGS,
+                TorServiceController.getTorSettings().hasDebugLogs
+            )
+        }
         return inflater.inflate(R.layout.fragment_home, container, false)
     }
 
@@ -172,10 +180,22 @@ class HomeFragment : Fragment() {
     }
 
     private fun setButtonDebugText() {
-        buttonDebug.text = if (hasDebugLogs) {
-            getString(R.string.home_button_debugging_disable)
-        } else {
-            getString(R.string.home_button_debugging_enable)
-        }
+        if (getDebugLogsJob?.isActive == true)
+            lifecycleScope.launch {
+                getDebugLogsJob?.join()
+                delay(50L)
+
+                buttonDebug.text = if (hasDebugLogs) {
+                    getString(R.string.home_button_debugging_disable)
+                } else {
+                    getString(R.string.home_button_debugging_enable)
+                }
+            }
+        else
+            buttonDebug.text = if (hasDebugLogs) {
+                getString(R.string.home_button_debugging_disable)
+            } else {
+                getString(R.string.home_button_debugging_enable)
+            }
     }
 }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
@@ -106,44 +106,47 @@ object OnionAuthUtilities {
         }
     }
 
-    private val FILE_NAME_CHARS = charArrayOf(
-        '0', '1', '2', '3', '4', '5',
-        '6', '7', '8', '9', '_', '.',
-        'a', 'b', 'c', 'd', 'e', 'f',
-        'g', 'h', 'i', 'j', 'k', 'l',
-        'm', 'n', 'o', 'p', 'q', 'r',
-        's', 't', 'u', 'v', 'w', 'x',
-        'y', 'z', 'A', 'B', 'C', 'D',
-        'E', 'F', 'G', 'H', 'I', 'J',
-        'K', 'L', 'M', 'N', 'O', 'P',
-        'Q', 'R', 'S', 'T', 'U', 'V',
-        'W', 'X', 'Y', 'Z'
-    )
+    private val FILE_NAME_CHARS: CharArray
+        get() = charArrayOf(
+            '0', '1', '2', '3', '4', '5',
+            '6', '7', '8', '9', '_', '.',
+            'a', 'b', 'c', 'd', 'e', 'f',
+            'g', 'h', 'i', 'j', 'k', 'l',
+            'm', 'n', 'o', 'p', 'q', 'r',
+            's', 't', 'u', 'v', 'w', 'x',
+            'y', 'z', 'A', 'B', 'C', 'D',
+            'E', 'F', 'G', 'H', 'I', 'J',
+            'K', 'L', 'M', 'N', 'O', 'P',
+            'Q', 'R', 'S', 'T', 'U', 'V',
+            'W', 'X', 'Y', 'Z'
+        )
 
     private fun isV3ClientAuthNicknameCompliant(nickname: String): String =
         checkStringCompliance(nickname, FILE_NAME_CHARS, 1, 75)
 
-    private val BASE32_ED25519_CHARS = charArrayOf(
-        '2', '3', '4', '5', '6', '7',
-        'a', 'b', 'c', 'd', 'e', 'f',
-        'g', 'h', 'i', 'j', 'k', 'l',
-        'm', 'n', 'o', 'p', 'q', 'r',
-        's', 't', 'u', 'v', 'w', 'x',
-        'y', 'z'
-    )
+    private val BASE32_ED25519_CHARS: CharArray
+        get() = charArrayOf(
+            '2', '3', '4', '5', '6', '7',
+            'a', 'b', 'c', 'd', 'e', 'f',
+            'g', 'h', 'i', 'j', 'k', 'l',
+            'm', 'n', 'o', 'p', 'q', 'r',
+            's', 't', 'u', 'v', 'w', 'x',
+            'y', 'z'
+        )
 
     @Throws(IllegalArgumentException::class)
     private fun isV3OnionAddressBase32ed25519Compliant(onionAddress: String): String =
         checkStringCompliance(onionAddress, BASE32_ED25519_CHARS, 56, 56)
 
-    private val BASE32_X25519_CHARS = charArrayOf(
-        '2', '3', '4', '5', '6', '7',
-        'A', 'B', 'C', 'D', 'E', 'F',
-        'G', 'H', 'I', 'J', 'K', 'L',
-        'M', 'N', 'O', 'P', 'Q', 'R',
-        'S', 'T', 'U', 'V', 'W', 'X',
-        'Y', 'Z'
-    )
+    private val BASE32_X25519_CHARS: CharArray
+        get() = charArrayOf(
+            '2', '3', '4', '5', '6', '7',
+            'A', 'B', 'C', 'D', 'E', 'F',
+            'G', 'H', 'I', 'J', 'K', 'L',
+            'M', 'N', 'O', 'P', 'Q', 'R',
+            'S', 'T', 'U', 'V', 'W', 'X',
+            'Y', 'Z'
+        )
 
     @Throws(IllegalArgumentException::class)
     private fun isV3ClientAuthKeyBase32x25519Compliant(v3ClientAuthorizationKey: String): String =

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.topl_core.util
 
 import androidx.annotation.WorkerThread

--- a/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
+++ b/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.topl_core.util
 
 import io.matthewnelson.topl_core_base.TorConfigFiles

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefs.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefs.kt
@@ -68,6 +68,7 @@ package io.matthewnelson.topl_service.prefs
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.annotation.WorkerThread
 import io.matthewnelson.topl_service.util.ServiceConsts
 
 /**
@@ -126,9 +127,11 @@ class TorServicePrefs(context: Context): ServiceConsts() {
      *  @return True if the SharedPreference contains a value for the associated
      *   [prefsKey], false if not
      *  * */
+    @WorkerThread
     fun contains(prefsKey: String): Boolean =
         prefs.contains(prefsKey)
 
+    @WorkerThread
     @Throws(NullPointerException::class)
     fun getAll(): Map<String, *> =
         prefs.all
@@ -142,6 +145,7 @@ class TorServicePrefs(context: Context): ServiceConsts() {
      *  associated with the [booleanKey].
      * @return The Boolean value associated with the [booleanKey], otherwise [defValue]
      * */
+    @WorkerThread
     fun getBoolean(@PrefKeyBoolean booleanKey: String, defValue: Boolean): Boolean =
         prefs.getBoolean(booleanKey, defValue)
 
@@ -154,6 +158,7 @@ class TorServicePrefs(context: Context): ServiceConsts() {
      *  associated with the [intKey].
      * @return The Int value associated with [intKey], otherwise [defValue]
      * */
+    @WorkerThread
     fun getInt(@PrefKeyInt intKey: String, defValue: Int?): Int? {
         val value = prefs.getInt(intKey, defValue ?: NULL_INT_VALUE)
         return if (value == NULL_INT_VALUE) {
@@ -172,6 +177,7 @@ class TorServicePrefs(context: Context): ServiceConsts() {
      *  associated with the [listKey].
      * @return The List of Strings associated with the [listKey], otherwise [defValue]
      * */
+    @WorkerThread
     fun getList(@PrefKeyList listKey: String, defValue: List<String>): List<String> {
         val csv: String = prefs.getString(listKey, defValue.joinToString()) ?: defValue.joinToString()
         return if (csv.trim().isEmpty()) {
@@ -190,6 +196,7 @@ class TorServicePrefs(context: Context): ServiceConsts() {
      *  associated with the [stringKey].
      * @return The String value associated with [stringKey], otherwise [defValue]
      * */
+    @WorkerThread
     fun getString(@PrefKeyString stringKey: String, defValue: String?): String? {
         val value = prefs.getString(stringKey, defValue ?: NULL_STRING_VALUE)
         return if (value == NULL_STRING_VALUE) {
@@ -204,6 +211,7 @@ class TorServicePrefs(context: Context): ServiceConsts() {
     /// Modify ///
     //////////////
 
+    @WorkerThread
     fun clear() {
         val editor = prefs.edit().clear()
         if (!editor.commit())
@@ -220,6 +228,7 @@ class TorServicePrefs(context: Context): ServiceConsts() {
      *
      *  @param [prefsKey] String of type ServiceConsts.PrefKey*
      *  * */
+    @WorkerThread
     fun remove(prefsKey: String) {
         val editor = prefs.edit().remove(prefsKey)
         if (!editor.commit())
@@ -232,6 +241,7 @@ class TorServicePrefs(context: Context): ServiceConsts() {
      * @param [booleanKey] String of type [ServiceConsts.PrefKeyBoolean]
      * @param [value] Your Boolean value
      * */
+    @WorkerThread
     fun putBoolean(@PrefKeyBoolean booleanKey: String, value: Boolean) {
         val editor = prefs.edit().putBoolean(booleanKey, value)
         if (!editor.commit())
@@ -244,6 +254,7 @@ class TorServicePrefs(context: Context): ServiceConsts() {
      * @param [intKey] String of type [ServiceConsts.PrefKeyInt]
      * @param [value] Your Int? value
      * */
+    @WorkerThread
     fun putInt(@PrefKeyInt intKey: String, value: Int?) {
         val editor = prefs.edit().putInt(intKey, value ?: NULL_INT_VALUE)
         if (!editor.commit())
@@ -257,6 +268,7 @@ class TorServicePrefs(context: Context): ServiceConsts() {
      * @param [listKey] String of type [ServiceConsts.PrefKeyList]
      * @param [value] Your List<String> value
      * */
+    @WorkerThread
     fun putList(@PrefKeyList listKey: String, value: List<String>) {
         val editor = prefs.edit().putString(listKey, value.joinToString())
         if (!editor.commit())
@@ -269,6 +281,7 @@ class TorServicePrefs(context: Context): ServiceConsts() {
      * @param [stringKey] String of type [ServiceConsts.PrefKeyString]
      * @param [value] Your String value
      * */
+    @WorkerThread
     fun putString(@PrefKeyString stringKey: String, value: String?) {
         val editor = prefs.edit().putString(stringKey, value ?: NULL_STRING_VALUE)
         if (!editor.commit())

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -302,7 +302,7 @@ internal class TorService: BaseService() {
     override fun onTaskRemoved(rootIntent: Intent?) {
         // Cancel the BackgroundManager's coroutine if it's active so it doesn't execute
         torServiceBinder.cancelExecuteBackgroundPolicyJob()
-        broadcastLogger.debug("Task has been removed")
+        broadcastLogger.notice("Task has been removed")
         super.onTaskRemoved(rootIntent)
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/BaseServiceBinder.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/BaseServiceBinder.kt
@@ -66,10 +66,7 @@
 * */
 package io.matthewnelson.topl_service.service.components.binding
 
-import android.app.Activity
-import android.app.Application
 import android.os.Binder
-import android.os.Bundle
 import io.matthewnelson.topl_core.broadcaster.BroadcastLogger
 import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.lifecycle.BackgroundManager
@@ -78,9 +75,7 @@ import io.matthewnelson.topl_service.service.components.actions.ServiceActions.S
 import io.matthewnelson.topl_service.util.ServiceConsts.BackgroundPolicy
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import net.freehaven.tor.control.TorControlCommands
 
 
 internal abstract class BaseServiceBinder(private val torService: BaseService): Binder() {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorSettings.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorSettings.kt
@@ -66,6 +66,7 @@
 * */
 package io.matthewnelson.topl_service.service.components.onionproxy
 
+import androidx.annotation.WorkerThread
 import io.matthewnelson.topl_core_base.TorSettings
 import io.matthewnelson.topl_service.util.ServiceConsts.PrefKeyString
 import io.matthewnelson.topl_service.util.ServiceConsts.PrefKeyList
@@ -99,8 +100,10 @@ class ServiceTorSettings internal constructor(
 ): TorSettings() {
 
     override val dormantClientTimeout: Int?
+        @WorkerThread
         get() = servicePrefs.getInt(PrefKeyInt.DORMANT_CLIENT_TIMEOUT, defaultTorSettings.dormantClientTimeout)
 
+    @WorkerThread
     fun dormantClientTimeoutSave(minutes: Int?) {
         if (minutes == defaultTorSettings.dormantClientTimeout)
             servicePrefs.remove(PrefKeyInt.DORMANT_CLIENT_TIMEOUT)
@@ -109,6 +112,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val disableNetwork: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.DISABLE_NETWORK, defaultTorSettings.disableNetwork)
 
     /**
@@ -119,6 +123,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean]
      * @see [TorSettings.disableNetwork]
      * */
+    @WorkerThread
     fun disableNetworkSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.disableNetwork)
             servicePrefs.remove(PrefKeyBoolean.DISABLE_NETWORK)
@@ -127,6 +132,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val dnsPort: String
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.DNS_PORT, defaultTorSettings.dnsPort)
             ?: defaultTorSettings.dnsPort
 
@@ -140,6 +146,7 @@ class ServiceTorSettings internal constructor(
      * @see [TorSettings.dnsPort]
      * @throws [IllegalArgumentException] if the value is not 0, auto, or between 1024 and 65535
      * */
+    @WorkerThread
     @Throws(IllegalArgumentException::class)
     fun dnsPortSave(dnsPort: String) {
         when {
@@ -158,6 +165,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val dnsPortIsolationFlags: List<@IsolationFlag String>?
+        @WorkerThread
         get() = servicePrefs.getList(
             PrefKeyList.DNS_PORT_ISOLATION_FLAGS,
             defaultTorSettings.dnsPortIsolationFlags ?: arrayListOf()
@@ -173,6 +181,7 @@ class ServiceTorSettings internal constructor(
      * @see [io.matthewnelson.topl_core_base.BaseConsts.IsolationFlag]
      * @see [TorSettings.dnsPortIsolationFlags]
      * */
+    @WorkerThread
     fun dnsPortIsolationFlagsSave(isolationFlags: List<@IsolationFlag String>) {
         if (isolationFlags == defaultTorSettings.dnsPortIsolationFlags) {
             servicePrefs.remove(PrefKeyList.DNS_PORT_ISOLATION_FLAGS)
@@ -182,6 +191,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val customTorrc: String?
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.CUSTOM_TORRC, defaultTorSettings.customTorrc)
 
     /**
@@ -192,6 +202,7 @@ class ServiceTorSettings internal constructor(
      * @param [customTorrc] A String of values to be added to the torrc file
      * @see [TorSettings.customTorrc]
      * */
+    @WorkerThread
     fun customTorrcSave(customTorrc: String?) {
         if (customTorrc == defaultTorSettings.customTorrc)
             servicePrefs.remove(PrefKeyString.CUSTOM_TORRC)
@@ -200,6 +211,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val entryNodes: String?
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.ENTRY_NODES, defaultTorSettings.entryNodes)
 
     /**
@@ -210,6 +222,7 @@ class ServiceTorSettings internal constructor(
      * @param [entryNodes] A comma separated list of nodes
      * @see [TorSettings.entryNodes]
      * */
+    @WorkerThread
     fun entryNodesSave(entryNodes: String?) {
         if (entryNodes == defaultTorSettings.entryNodes)
             servicePrefs.remove(PrefKeyString.ENTRY_NODES)
@@ -218,6 +231,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val excludeNodes: String?
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.EXCLUDED_NODES, defaultTorSettings.excludeNodes)
 
     /**
@@ -228,6 +242,7 @@ class ServiceTorSettings internal constructor(
      * @param [excludeNodes] A comma separated list of nodes
      * @see [TorSettings.excludeNodes]
      * */
+    @WorkerThread
     fun excludeNodesSave(excludeNodes: String?) {
         if (excludeNodes == defaultTorSettings.excludeNodes)
             servicePrefs.remove(PrefKeyString.EXCLUDED_NODES)
@@ -236,6 +251,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val exitNodes: String?
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.EXIT_NODES, defaultTorSettings.exitNodes)
 
     /**
@@ -246,6 +262,7 @@ class ServiceTorSettings internal constructor(
      * @param [exitNodes] A comma separated list of nodes
      * @see [TorSettings.exitNodes]
      * */
+    @WorkerThread
     fun exitNodesSave(exitNodes: String?) {
         if (exitNodes == defaultTorSettings.exitNodes)
             servicePrefs.remove(PrefKeyString.EXIT_NODES)
@@ -254,6 +271,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val httpTunnelPort: String
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.HTTP_TUNNEL_PORT, defaultTorSettings.httpTunnelPort)
             ?: defaultTorSettings.httpTunnelPort
 
@@ -267,6 +285,7 @@ class ServiceTorSettings internal constructor(
      * @see [TorSettings.httpTunnelPort]
      * @throws [IllegalArgumentException] if the value is not 0, auto, or between 1024 and 65535
      * */
+    @WorkerThread
     @Throws(IllegalArgumentException::class)
     fun httpTunnelPortSave(httpPort: String) {
         when {
@@ -285,6 +304,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val httpTunnelPortIsolationFlags: List<@IsolationFlag String>?
+        @WorkerThread
         get() = servicePrefs.getList(
             PrefKeyList.HTTP_TUNNEL_PORT_ISOLATION_FLAGS,
             defaultTorSettings.httpTunnelPortIsolationFlags ?: arrayListOf()
@@ -300,6 +320,7 @@ class ServiceTorSettings internal constructor(
      * @see [io.matthewnelson.topl_core_base.BaseConsts.IsolationFlag]
      * @see [TorSettings.httpTunnelPortIsolationFlags]
      * */
+    @WorkerThread
     fun httpPortIsolationFlagsSave(isolationFlags: List<@IsolationFlag String>) {
         if (isolationFlags == defaultTorSettings.httpTunnelPortIsolationFlags) {
             servicePrefs.remove(PrefKeyList.HTTP_TUNNEL_PORT_ISOLATION_FLAGS)
@@ -314,6 +335,7 @@ class ServiceTorSettings internal constructor(
     // TODO: write a save method after refactor
 
     override val proxyHost: String?
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.PROXY_HOST, defaultTorSettings.proxyHost)
 
     /**
@@ -324,6 +346,7 @@ class ServiceTorSettings internal constructor(
      * @param [proxyHost]
      * @see [TorSettings.proxyHost]
      * */
+    @WorkerThread
     fun proxyHostSave(proxyHost: String?) {
         if (proxyHost == defaultTorSettings.proxyHost)
             servicePrefs.remove(PrefKeyString.PROXY_HOST)
@@ -332,6 +355,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val proxyPassword: String?
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.PROXY_PASSWORD, defaultTorSettings.proxyPassword)
 
     /**
@@ -342,6 +366,7 @@ class ServiceTorSettings internal constructor(
      * @param [proxyPassword]
      * @see [TorSettings.proxyPassword]
      * */
+    @WorkerThread
     fun proxyPasswordSave(proxyPassword: String?) {
         if (proxyPassword == defaultTorSettings.proxyPassword)
             servicePrefs.remove(PrefKeyString.PROXY_PASSWORD)
@@ -350,6 +375,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val proxyPort: Int?
+        @WorkerThread
         get() = servicePrefs.getInt(PrefKeyInt.PROXY_PORT, defaultTorSettings.proxyPort)
 
     /**
@@ -362,6 +388,7 @@ class ServiceTorSettings internal constructor(
      * @see [TorSettings.proxyPort]
      * @throws [IllegalArgumentException] if the value is not `null`, or between 1024 and 65535
      * */
+    @WorkerThread
     @Throws(IllegalArgumentException::class)
     fun proxyPortSave(proxyPort: Int?) {
         when {
@@ -381,6 +408,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val proxySocks5Host: String?
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.PROXY_SOCKS5_HOST, defaultTorSettings.proxySocks5Host)
 
     /**
@@ -391,6 +419,7 @@ class ServiceTorSettings internal constructor(
      * @param [proxySocks5Host]
      * @see [TorSettings.proxySocks5Host]
      * */
+    @WorkerThread
     fun proxySocks5HostSave(proxySocks5Host: String?) {
         if (proxySocks5Host == defaultTorSettings.proxySocks5Host)
             servicePrefs.remove(PrefKeyString.PROXY_SOCKS5_HOST)
@@ -399,6 +428,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val proxySocks5ServerPort: Int?
+        @WorkerThread
         get() = servicePrefs.getInt(PrefKeyInt.PROXY_SOCKS5_SERVER_PORT, defaultTorSettings.proxySocks5ServerPort)
 
     /**
@@ -411,6 +441,7 @@ class ServiceTorSettings internal constructor(
      * @see [TorSettings.proxySocks5ServerPort]
      * @throws [IllegalArgumentException] if the value is not `null`, or between 1024 and 65535
      * */
+    @WorkerThread
     @Throws(IllegalArgumentException::class)
     fun proxySocks5ServerPortSave(proxySocks5ServerPort: Int?) {
         when {
@@ -430,6 +461,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val proxyType: @ProxyType String
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.PROXY_TYPE, defaultTorSettings.proxyType) ?: defaultTorSettings.proxyType
 
     /**
@@ -442,6 +474,7 @@ class ServiceTorSettings internal constructor(
      * @see [TorSettings.proxyType]
      * @throws [IllegalArgumentException] if the value is not empty (disabled), HTTPS, or Socks5
      * */
+    @WorkerThread
     @Throws(IllegalArgumentException::class)
     fun proxyTypeSave(@ProxyType proxyType: String) {
         when (proxyType) {
@@ -462,6 +495,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val proxyUser: String?
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.PROXY_USER, defaultTorSettings.proxyUser)
 
     /**
@@ -472,6 +506,7 @@ class ServiceTorSettings internal constructor(
      * @param [proxyUser]
      * @see [TorSettings.proxyUser]
      * */
+    @WorkerThread
     fun proxyUserSave(proxyUser: String?) {
         if (proxyUser == defaultTorSettings.proxyUser)
             servicePrefs.remove(PrefKeyString.PROXY_USER)
@@ -480,6 +515,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val reachableAddressPorts: String
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.REACHABLE_ADDRESS_PORTS, defaultTorSettings.reachableAddressPorts)
             ?: defaultTorSettings.reachableAddressPorts
 
@@ -491,6 +527,7 @@ class ServiceTorSettings internal constructor(
      * @param [reachableAddressPorts]
      * @see [TorSettings.reachableAddressPorts]
      * */
+    @WorkerThread
     fun reachableAddressPortsSave(reachableAddressPorts: String) {
         if (reachableAddressPorts == defaultTorSettings.reachableAddressPorts)
             servicePrefs.remove(PrefKeyString.REACHABLE_ADDRESS_PORTS)
@@ -499,6 +536,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val relayNickname: String?
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.RELAY_NICKNAME, defaultTorSettings.relayNickname)
 
     /**
@@ -509,6 +547,7 @@ class ServiceTorSettings internal constructor(
      * @param [relayNickname]
      * @see [TorSettings.relayNickname]
      * */
+    @WorkerThread
     fun relayNicknameSave(relayNickname: String) {
         if (relayNickname == defaultTorSettings.relayNickname)
             servicePrefs.remove(PrefKeyString.RELAY_NICKNAME)
@@ -517,6 +556,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val relayPort: String
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.RELAY_PORT, defaultTorSettings.relayPort)
             ?: defaultTorSettings.relayPort
 
@@ -530,6 +570,7 @@ class ServiceTorSettings internal constructor(
      * @see [TorSettings.relayPort]
      * @throws [IllegalArgumentException] if the value is not 0, auto, or between 1024 and 65535
      * */
+    @WorkerThread
     @Throws(IllegalArgumentException::class)
     fun relayPortSave(relayPort: String) {
         when {
@@ -548,6 +589,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val socksPort: String
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.SOCKS_PORT, defaultTorSettings.socksPort)
             ?: defaultTorSettings.socksPort
 
@@ -561,6 +603,7 @@ class ServiceTorSettings internal constructor(
      * @see [TorSettings.socksPort]
      * @throws [IllegalArgumentException] if the value is not 0, auto, or between 1024 and 65535
      * */
+    @WorkerThread
     @Throws(IllegalArgumentException::class)
     fun socksPortSave(socksPort: String) {
         when {
@@ -579,6 +622,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val socksPortIsolationFlags: List<@IsolationFlag String>?
+        @WorkerThread
         get() = servicePrefs.getList(
             PrefKeyList.SOCKS_PORT_ISOLATION_FLAGS,
             defaultTorSettings.socksPortIsolationFlags ?: arrayListOf()
@@ -594,6 +638,7 @@ class ServiceTorSettings internal constructor(
      * @see [io.matthewnelson.topl_core_base.BaseConsts.IsolationFlag]
      * @see [TorSettings.socksPortIsolationFlags]
      * */
+    @WorkerThread
     fun socksPortIsolationFlagsSave(isolationFlags: List<@IsolationFlag String>) {
         if (isolationFlags == defaultTorSettings.socksPortIsolationFlags) {
             servicePrefs.remove(PrefKeyList.SOCKS_PORT_ISOLATION_FLAGS)
@@ -603,6 +648,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val virtualAddressNetwork: String?
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.VIRTUAL_ADDRESS_NETWORK, defaultTorSettings.virtualAddressNetwork)
 
     /**
@@ -613,6 +659,7 @@ class ServiceTorSettings internal constructor(
      * @param [virtualAddressNetwork]
      * @see [TorSettings.virtualAddressNetwork]
      * */
+    @WorkerThread
     fun virtualAddressNetworkSave(virtualAddressNetwork: String) {
         if (virtualAddressNetwork == defaultTorSettings.virtualAddressNetwork)
             servicePrefs.remove(PrefKeyString.VIRTUAL_ADDRESS_NETWORK)
@@ -621,6 +668,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val hasBridges: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_BRIDGES, defaultTorSettings.hasBridges)
 
     /**
@@ -631,6 +679,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean] to enable/disable
      * @see [TorSettings.hasBridges]
      * */
+    @WorkerThread
     fun hasBridgesSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasBridges)
             servicePrefs.remove(PrefKeyBoolean.HAS_BRIDGES)
@@ -639,6 +688,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val connectionPadding: String
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.HAS_CONNECTION_PADDING, defaultTorSettings.connectionPadding)
             ?: defaultTorSettings.connectionPadding
 
@@ -652,6 +702,7 @@ class ServiceTorSettings internal constructor(
      * @see [TorSettings.connectionPadding]
      * @throws [IllegalArgumentException] if the value is not 0 (Off), 1 (On), or auto
      * */
+    @WorkerThread
     @Throws(IllegalArgumentException::class)
     fun connectionPaddingSave(@ConnectionPadding connectionPadding: String) {
         when (connectionPadding) {
@@ -672,6 +723,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val hasCookieAuthentication: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_COOKIE_AUTHENTICATION, defaultTorSettings.hasCookieAuthentication)
 
     /**
@@ -682,6 +734,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean] to enable/disable
      * @see [TorSettings.hasCookieAuthentication]
      * */
+    @WorkerThread
     fun hasCookieAuthenticationSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasCookieAuthentication)
             servicePrefs.remove(PrefKeyBoolean.HAS_COOKIE_AUTHENTICATION)
@@ -690,6 +743,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val hasDebugLogs: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_DEBUG_LOGS, defaultTorSettings.hasDebugLogs)
 
     /**
@@ -700,6 +754,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean] to enable/disable
      * @see [TorSettings.hasDebugLogs]
      * */
+    @WorkerThread
     fun hasDebugLogsSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasDebugLogs)
             servicePrefs.remove(PrefKeyBoolean.HAS_DEBUG_LOGS)
@@ -708,6 +763,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val hasDormantCanceledByStartup: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_DORMANT_CANCELED_BY_STARTUP, defaultTorSettings.hasDormantCanceledByStartup)
 
     /**
@@ -718,6 +774,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean] to enable/disable
      * @see [TorSettings.hasDormantCanceledByStartup]
      * */
+    @WorkerThread
     fun hasDormantCanceledByStartupSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasDormantCanceledByStartup)
             servicePrefs.remove(PrefKeyBoolean.HAS_DORMANT_CANCELED_BY_STARTUP)
@@ -726,6 +783,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val hasOpenProxyOnAllInterfaces: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_OPEN_PROXY_ON_ALL_INTERFACES, defaultTorSettings.hasOpenProxyOnAllInterfaces)
 
     /**
@@ -736,6 +794,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean] to enable/disable
      * @see [TorSettings.hasOpenProxyOnAllInterfaces]
      * */
+    @WorkerThread
     fun hasOpenProxyOnAllInterfacesSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasOpenProxyOnAllInterfaces)
             servicePrefs.remove(PrefKeyBoolean.HAS_OPEN_PROXY_ON_ALL_INTERFACES)
@@ -744,6 +803,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val hasReachableAddress: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_REACHABLE_ADDRESS, defaultTorSettings.hasReachableAddress)
 
     /**
@@ -754,6 +814,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean] to enable/disable
      * @see [TorSettings.hasReachableAddress]
      * */
+    @WorkerThread
     fun hasReachableAddressSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasReachableAddress)
             servicePrefs.remove(PrefKeyBoolean.HAS_REACHABLE_ADDRESS)
@@ -762,6 +823,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val hasReducedConnectionPadding: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_REDUCED_CONNECTION_PADDING, defaultTorSettings.hasReducedConnectionPadding)
 
     /**
@@ -772,6 +834,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean] to enable/disable
      * @see [TorSettings.hasReducedConnectionPadding]
      * */
+    @WorkerThread
     fun hasReducedConnectionPaddingSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasReducedConnectionPadding)
             servicePrefs.remove(PrefKeyBoolean.HAS_REDUCED_CONNECTION_PADDING)
@@ -780,6 +843,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val hasSafeSocks: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_SAFE_SOCKS, defaultTorSettings.hasSafeSocks)
 
     /**
@@ -790,6 +854,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean] to enable/disable
      * @see [TorSettings.hasSafeSocks]
      * */
+    @WorkerThread
     fun hasSafeSocksSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasSafeSocks)
             servicePrefs.remove(PrefKeyBoolean.HAS_SAFE_SOCKS)
@@ -798,6 +863,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val hasStrictNodes: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_STRICT_NODES, defaultTorSettings.hasStrictNodes)
 
     /**
@@ -808,6 +874,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean] to enable/disable
      * @see [TorSettings.hasStrictNodes]
      * */
+    @WorkerThread
     fun hasStrictNodesSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasStrictNodes)
             servicePrefs.remove(PrefKeyBoolean.HAS_STRICT_NODES)
@@ -816,6 +883,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val hasTestSocks: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.HAS_TEST_SOCKS, defaultTorSettings.hasTestSocks)
 
     /**
@@ -826,6 +894,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean] to enable/disable
      * @see [TorSettings.hasTestSocks]
      * */
+    @WorkerThread
     fun hasTestSocksSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.hasTestSocks)
             servicePrefs.remove(PrefKeyBoolean.HAS_TEST_SOCKS)
@@ -834,6 +903,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val isAutoMapHostsOnResolve: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.IS_AUTO_MAP_HOSTS_ON_RESOLVE, defaultTorSettings.isAutoMapHostsOnResolve)
 
     /**
@@ -844,6 +914,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean] to enable/disable
      * @see [TorSettings.isAutoMapHostsOnResolve]
      * */
+    @WorkerThread
     fun isAutoMapHostsOnResolveSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.isAutoMapHostsOnResolve)
             servicePrefs.remove(PrefKeyBoolean.IS_AUTO_MAP_HOSTS_ON_RESOLVE)
@@ -852,6 +923,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val isRelay: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.IS_RELAY, defaultTorSettings.isRelay)
 
     /**
@@ -862,6 +934,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean] to enable/disable
      * @see [TorSettings.isRelay]
      * */
+    @WorkerThread
     fun isRelaySave(boolean: Boolean) {
         if (boolean == defaultTorSettings.isRelay)
             servicePrefs.remove(PrefKeyBoolean.IS_RELAY)
@@ -870,6 +943,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val runAsDaemon: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.RUN_AS_DAEMON, defaultTorSettings.runAsDaemon)
 
     /**
@@ -880,6 +954,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean] to enable/disable
      * @see [TorSettings.runAsDaemon]
      * */
+    @WorkerThread
     fun runAsDaemonSave(boolean: Boolean) {
         if (boolean == defaultTorSettings.runAsDaemon)
             servicePrefs.remove(PrefKeyBoolean.RUN_AS_DAEMON)
@@ -888,6 +963,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val transPort: String
+        @WorkerThread
         get() = servicePrefs.getString(PrefKeyString.TRANS_PORT, defaultTorSettings.transPort) ?: defaultTorSettings.transPort
 
     /**
@@ -900,6 +976,7 @@ class ServiceTorSettings internal constructor(
      * @see [TorSettings.transPort]
      * @throws [IllegalArgumentException] if the value is not 0, auto, or between 1024 and 65535
      * */
+    @WorkerThread
     @Throws(IllegalArgumentException::class)
     fun transPortSave(transPort: String) {
         when {
@@ -918,6 +995,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val transPortIsolationFlags: List<@IsolationFlag String>?
+        @WorkerThread
         get() = servicePrefs.getList(
             PrefKeyList.TRANS_PORT_ISOLATION_FLAGS,
             defaultTorSettings.transPortIsolationFlags ?: arrayListOf()
@@ -933,6 +1011,7 @@ class ServiceTorSettings internal constructor(
      * @see [io.matthewnelson.topl_core_base.BaseConsts.IsolationFlag]
      * @see [TorSettings.transPortIsolationFlags]
      * */
+    @WorkerThread
     fun transPortIsolationFlagsSave(isolationFlags: List<@IsolationFlag String>) {
         if (isolationFlags == defaultTorSettings.transPortIsolationFlags) {
             servicePrefs.remove(PrefKeyList.TRANS_PORT_ISOLATION_FLAGS)
@@ -942,6 +1021,7 @@ class ServiceTorSettings internal constructor(
     }
 
     override val useSocks5: Boolean
+        @WorkerThread
         get() = servicePrefs.getBoolean(PrefKeyBoolean.USE_SOCKS5, defaultTorSettings.useSocks5)
 
     /**
@@ -952,6 +1032,7 @@ class ServiceTorSettings internal constructor(
      * @param [boolean] to enable/disable
      * @see [TorSettings.useSocks5]
      * */
+    @WorkerThread
     fun useSocks5Save(boolean: Boolean) {
         if (boolean == defaultTorSettings.useSocks5)
             servicePrefs.remove(PrefKeyBoolean.USE_SOCKS5)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/model/TorPortInfo.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/model/TorPortInfo.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.topl_service.service.components.onionproxy.model
 
 /**

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
@@ -149,7 +149,7 @@ internal class TorServiceReceiver(private val torService: BaseService): Broadcas
 
     override fun onReceive(context: Context?, intent: Intent?) {
         if (context != null && intent != null) {
-            when (val action = intent.action) {
+            when (intent.action) {
                 @Suppress("DEPRECATION")
                 ConnectivityManager.CONNECTIVITY_ACTION -> {
                     if (!torService.isTorOn()) return

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
@@ -69,7 +69,6 @@ package io.matthewnelson.topl_service.util
 import androidx.annotation.IntDef
 import androidx.annotation.StringDef
 import io.matthewnelson.topl_core_base.BaseConsts
-import io.matthewnelson.topl_service.service.components.actions.ServiceActions
 
 abstract class ServiceConsts: BaseConsts() {
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/V3ClientAuthManager.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/V3ClientAuthManager.kt
@@ -99,15 +99,15 @@ class V3ClientAuthManager internal constructor(
     fun getFileContent(nickname: String): V3ClientAuthContent? {
         val v3ClientAuthFile = getFileByNickname(nickname) ?: return null
         val content = v3ClientAuthFile.readText().split(':')
-        return V3ClientAuthContent(content[0], content[3])
+        return if (content.size != 4)
+            null
+        else
+            V3ClientAuthContent(content[0], content[3])
     }
 
     @WorkerThread
-    fun getFileContent(file: File): V3ClientAuthContent? {
-        val v3ClientAuthFile = getFileByNickname(file.nameWithoutExtension) ?: return null
-        val content = v3ClientAuthFile.readText().split(':')
-        return V3ClientAuthContent(content[0], content[3])
-    }
+    fun getFileContent(file: File): V3ClientAuthContent? =
+        getFileContent(file.nameWithoutExtension)
 
 
     ////////////////

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/V3ClientAuthManager.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/V3ClientAuthManager.kt
@@ -1,3 +1,69 @@
+/*
+* TorOnionProxyLibrary-Android (a.k.a. topl-android) is a derivation of
+* work from the Tor_Onion_Proxy_Library project that started at commit
+* hash `74407114cbfa8ea6f2ac51417dda8be98d8aba86`. Contributions made after
+* said commit hash are:
+*
+*     Copyright (C) 2020 Matthew Nelson
+*
+*     This program is free software: you can redistribute it and/or modify it
+*     under the terms of the GNU General Public License as published by the
+*     Free Software Foundation, either version 3 of the License, or (at your
+*     option) any later version.
+*
+*     This program is distributed in the hope that it will be useful, but
+*     WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+*     or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+*     for more details.
+*
+*     You should have received a copy of the GNU General Public License
+*     along with this program. If not, see <https://www.gnu.org/licenses/>.
+*
+* `===========================================================================`
+* `+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++`
+* `===========================================================================`
+*
+* The following exception is an additional permission under section 7 of the
+* GNU General Public License, version 3 (“GPLv3”).
+*
+*     "The Interfaces" is henceforth defined as Application Programming Interfaces
+*     that are publicly available classes/functions/etc (ie: do not contain the
+*     visibility modifiers `internal`, `private`, `protected`, or are within
+*     classes/functions/etc that contain the aforementioned visibility modifiers)
+*     to TorOnionProxyLibrary-Android users that are needed to implement
+*     TorOnionProxyLibrary-Android and reside in ONLY the following modules:
+*
+*      - topl-core-base
+*      - topl-service
+*
+*     The following are excluded from "The Interfaces":
+*
+*       - All other code
+*
+*     Linking TorOnionProxyLibrary-Android statically or dynamically with other
+*     modules is making a combined work based on TorOnionProxyLibrary-Android.
+*     Thus, the terms and conditions of the GNU General Public License cover the
+*     whole combination.
+*
+*     As a special exception, the copyright holder of TorOnionProxyLibrary-Android
+*     gives you permission to combine TorOnionProxyLibrary-Android program with free
+*     software programs or libraries that are released under the GNU LGPL and with
+*     independent modules that communicate with TorOnionProxyLibrary-Android solely
+*     through "The Interfaces". You may copy and distribute such a system following
+*     the terms of the GNU GPL for TorOnionProxyLibrary-Android and the licenses of
+*     the other code concerned, provided that you include the source code of that
+*     other code when and as the GNU GPL requires distribution of source code and
+*     provided that you do not modify "The Interfaces".
+*
+*     Note that people who make modified versions of TorOnionProxyLibrary-Android
+*     are not obligated to grant this special exception for their modified versions;
+*     it is their choice whether to do so. The GNU General Public License gives
+*     permission to release a modified version without this exception; this exception
+*     also makes it possible to release a modified version which carries forward this
+*     exception. If you modify "The Interfaces", this exception does not apply to your
+*     modified version of TorOnionProxyLibrary-Android, and you must remove this
+*     exception when you distribute your modified version.
+* */
 package io.matthewnelson.topl_service.util
 
 import androidx.annotation.WorkerThread


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR:
 - Adds annotation to methods/getters denoting they should be called from a WorkerThread
 - Changes the broadcasting of onTaskRemoved from debug to notice so it can be watched for
 from the implementing application's EventBroadcaster.
 - Updates methods in `topl-service::V3ClientAuthManager` class to be DRY
 - Updates character arrays in `topl-core::OnionAuthUtilities` class to work as getters instead of being setup at runtime.
 - Adds missing license headers to files & cleans up unused imports.

SNAPSHOT available by:
 - In your Application module’s build.gradle file, add the following (outside the android block):
```groovy
repositories {
    maven {
        url 'https://oss.sonatype.org/content/repositories/snapshots/'
    }
}
```

- In your Application module’s build.gradle file, add (or modify) the following in the dependencies block:
```groovy
def topl_android_version = "1.1.0-alpha01a-SNAPSHOT"
implementation 'io.matthewnelson.topl-android:topl-core-base:$topl_android_version'
implementation 'io.matthewnelson.topl-android:topl-service:$topl_android_version'
```

## Type of change
<!--    [x] = check mark on preview     -->
<!--    [ ] = empty box on preview      -->
<!---->
<!-- Please REMOVE unchecked selections -->

- [x] New feature (non-breaking change which adds functionality)

## Change Status
<!-- Please REMOVE unchecked selections -->

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?
<!-- Please REMOVE unchecked selections -->

- [x] Unit Tests

# Checklist
<!-- Please KEEP unchecked selections -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/ui tests pass locally with my changes
- [x] There are no merge conflicts
