### PR TITLE
Use Package Manager's Launch Intent for notification content intent

### DIFF
--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -76,7 +76,6 @@ import android.os.Process
 import io.matthewnelson.encrypted_storage.Prefs
 import io.matthewnelson.sampleapp.topl_android.MyEventBroadcaster
 import io.matthewnelson.sampleapp.topl_android.MyTorSettings
-import io.matthewnelson.sampleapp.ui.MainActivity
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashboardFragment
 import io.matthewnelson.sampleapp.ui.fragments.settings.library.components.LibraryPrefs
@@ -114,13 +113,7 @@ class App: Application() {
                 channelID = "TOPL-Android Demo",
                 notificationID = 615
             )
-                .setActivityToBeOpenedOnTap(
-                    clazz = MainActivity::class.java,
-                    intentExtrasKey = null,
-                    intentExtras = null,
-                    intentRequestCode = null
-                )
-
+                .setContentIntentData(bundle = null, requestCode = 8)
                 .setVisibility(visibility)
                 .setCustomColor(iconColorRes)
                 .enableTorRestartButton(enableRestart)

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/CodeSamples.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/CodeSamples.kt
@@ -76,7 +76,6 @@ import android.content.Context
 import androidx.core.app.NotificationCompat
 import io.matthewnelson.sampleapp.BuildConfig
 import io.matthewnelson.sampleapp.R
-import io.matthewnelson.sampleapp.ui.MainActivity
 import io.matthewnelson.topl_core_base.TorConfigFiles
 import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.lifecycle.BackgroundManager
@@ -97,12 +96,9 @@ class CodeSamples {
             channelID = "TOPL-Android Demo",
             notificationID = 615
         )
-            .setActivityToBeOpenedOnTap(
-                clazz = MainActivity::class.java,
-                intentExtrasKey = null,
-                intentExtras = null,
-                intentRequestCode = null
-            )
+            // Only needed if you are passing a bundle, or changing request code to something other than 0
+            .setContentIntentData(bundle = null, requestCode = 21)
+
             .setImageTorNetworkingEnabled(drawableRes = R.drawable.tor_stat_network_enabled)
             .setImageTorNetworkingDisabled(drawableRes = R.drawable.tor_stat_network_disabled)
             .setImageTorDataTransfer(drawableRes = R.drawable.tor_stat_network_dataxfer)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -597,14 +597,14 @@ class ServiceNotification internal constructor(
         builder.addAction(
             imageNetworkEnabled,
             "New Identity",
-            getActionPendingIntent(torService, ServiceConsts.ServiceActionName.NEW_ID, 1)
+            getActionPendingIntent(torService, ServiceActionName.NEW_ID, 1)
         )
 
         if (enableRestartButton && TorServiceReceiver.deviceIsLocked != true)
             builder.addAction(
                 imageNetworkEnabled,
                 "Restart Tor",
-                getActionPendingIntent(torService, ServiceConsts.ServiceActionName.RESTART_TOR, 2)
+                getActionPendingIntent(torService, ServiceActionName.RESTART_TOR, 2)
             )
 
         if (enableStopButton && TorServiceReceiver.deviceIsLocked != true)

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/notification/ServiceNotification.kt
@@ -77,6 +77,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.os.Bundle
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.core.app.NotificationCompat
@@ -105,6 +106,7 @@ class ServiceNotification internal constructor(
     var activityWhenTapped: Class<*>? = null,
     var activityIntentKey: String? = null,
     var activityIntentExtras: String? = null,
+    var activityIntentBundle: Bundle? = null,
     var activityIntentRequestCode: Int = 0,
 
     @DrawableRes var imageNetworkEnabled: Int = R.drawable.tor_stat_network_enabled,
@@ -171,12 +173,12 @@ class ServiceNotification internal constructor(
          * @param [intentExtrasKey]? The key for if you with to add extras in the PendingIntent.
          * @param [intentExtras]? The extras that will be sent in the PendingIntent.
          * @param [intentRequestCode]? The request code - Defaults to 0 if not set.
-         *
-         * TODO:
-         *  + Include an optional Bundle? to be set for creating the pending intent.
-         *  + Think about overriding and providing another option to rotate the ContentIntent
-         *  to open up/resume current activity?
          * */
+        @Deprecated(
+            message = "Default behavior of user tapping notification now uses your application's " +
+                    "launcher intent from package manager to mitigate launching of multiple activities.",
+            replaceWith = ReplaceWith("setContentIntentData(bundle = null, requestCode = intentRequestCode)")
+        )
         fun setActivityToBeOpenedOnTap(
             clazz: Class<*>,
             intentExtrasKey: String?,
@@ -187,6 +189,31 @@ class ServiceNotification internal constructor(
             this.serviceNotification.activityIntentKey = intentExtrasKey
             this.serviceNotification.activityIntentExtras = intentExtras
             intentRequestCode?.let { serviceNotification.activityIntentRequestCode = it }
+            return this
+        }
+
+
+        /**
+         * Default notification behaviour is to use the launch intent for your application
+         * from Package Manager when a user taps the notification. Electing this method allows
+         * for adding a request code and bundle to the PendingIntent.
+         *
+         * **NOTE:** electing [setActivityToBeOpenedOnTap] method behaviour takes precedent until
+         * it is removed in a future release.
+         *
+         * **NOTE:** If you do not elect this method or [setActivityToBeOpenedOnTap] in your
+         * [Builder], the notification's content intent is still set with a default [requestCode]
+         * value of 0 and null bundle.
+         *
+         * @param [bundle] Bundle to be sent to the Launch Activity
+         * @param [requestCode] Request Code to be used when launching the Activity
+         * */
+        fun setContentIntentData(
+            bundle: Bundle?,
+            requestCode: Int?
+        ): Builder {
+            this.serviceNotification.activityIntentBundle = bundle
+            requestCode?.let { serviceNotification.activityIntentRequestCode = it }
             return this
         }
 
@@ -408,8 +435,22 @@ class ServiceNotification internal constructor(
                 builder.setProgress(100, 0, true)
         }
 
-        if (activityWhenTapped != null)
+        if (activityWhenTapped != null) {
             builder.setContentIntent(getContentPendingIntent(torService))
+        } else {
+            torService.packageManager.getLaunchIntentForPackage(torService.packageName)
+                ?.let { intent ->
+                    builder.setContentIntent(
+                        PendingIntent.getActivity(
+                            torService.context,
+                            activityIntentRequestCode,
+                            intent,
+                            PendingIntent.FLAG_UPDATE_CURRENT,
+                            activityIntentBundle
+                        )
+                    )
+                }
+        }
 
         notificationBuilder = builder
         return builder
@@ -556,14 +597,14 @@ class ServiceNotification internal constructor(
         builder.addAction(
             imageNetworkEnabled,
             "New Identity",
-            getActionPendingIntent(torService, ServiceActionName.NEW_ID, 1)
+            getActionPendingIntent(torService, ServiceConsts.ServiceActionName.NEW_ID, 1)
         )
 
         if (enableRestartButton && TorServiceReceiver.deviceIsLocked != true)
             builder.addAction(
                 imageNetworkEnabled,
                 "Restart Tor",
-                getActionPendingIntent(torService, ServiceActionName.RESTART_TOR, 2)
+                getActionPendingIntent(torService, ServiceConsts.ServiceActionName.RESTART_TOR, 2)
             )
 
         if (enableStopButton && TorServiceReceiver.deviceIsLocked != true)


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR changes the notification's default behavior such that upon the user clicking it, the application's launch intent is used. It deprecates the Builder method for `setActivityToBeOpenedOnTap`, as that functionality opens multiple Activities. A bundle and request code can now be set by utilizing the new Builder method `setContentIntentData`.

Resolves #91 


## Type of change
<!--    [x] = check mark on preview     -->
<!--    [ ] = empty box on preview      -->
<!---->
<!-- Please REMOVE unchecked selections -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update