### PR TITLE
move ServiceActionName annotation class to BaseServiceConsts

### DIFF
--- a/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/BaseServiceConsts.kt
+++ b/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/BaseServiceConsts.kt
@@ -100,6 +100,37 @@ abstract class BaseServiceConsts: BaseConsts() {
     }
 
 
+    /////////////////////
+    /// ServiceAction ///
+    /////////////////////
+    @Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.TYPE,
+        AnnotationTarget.PROPERTY
+    )
+    @StringDef(
+        ServiceActionName.DISABLE_NETWORK,
+        ServiceActionName.ENABLE_NETWORK,
+        ServiceActionName.NEW_ID,
+        ServiceActionName.RESTART_TOR,
+        ServiceActionName.START,
+        ServiceActionName.STOP
+    )
+    @Retention(AnnotationRetention.SOURCE)
+    annotation class ServiceActionName {
+        companion object {
+            private const val ACTION_NAME = "Action_"
+            const val DISABLE_NETWORK = "${ACTION_NAME}DISABLE_NETWORK"
+            const val ENABLE_NETWORK = "${ACTION_NAME}ENABLE_NETWORK"
+            const val NEW_ID = "${ACTION_NAME}NEW_ID"
+            const val RESTART_TOR = "${ACTION_NAME}RESTART_TOR"
+            const val START = "${ACTION_NAME}START"
+            const val STOP = "${ACTION_NAME}STOP"
+        }
+    }
+
+
     ////////////////////////////////
     /// Service Lifecycle Events ///
     ////////////////////////////////

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -89,9 +89,9 @@ import io.matthewnelson.topl_service.prefs.TorServicePrefsListener
 import io.matthewnelson.topl_service.service.components.actions.ServiceActionProcessor
 import io.matthewnelson.topl_service.service.components.actions.ServiceAction
 import io.matthewnelson.topl_service.service.components.binding.TorServiceConnection
-import io.matthewnelson.topl_service.util.ServiceConsts.ServiceActionName
 import io.matthewnelson.topl_service.util.ServiceConsts.NotificationImage
 import io.matthewnelson.topl_service_base.ApplicationDefaultTorSettings
+import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceActionName
 import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceLifecycleEvent
 import kotlinx.coroutines.CoroutineScope
 import java.io.File

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceAction.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceAction.kt
@@ -72,7 +72,7 @@
 package io.matthewnelson.topl_service.service.components.actions
 
 import io.matthewnelson.topl_service.util.ServiceConsts.ServiceActionCommand
-import io.matthewnelson.topl_service.util.ServiceConsts.ServiceActionName
+import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceActionName
 
 /**
  * There are multiple avenues to interacting with a Service (BroadcastReceiver, Binder,

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
@@ -78,8 +78,8 @@ import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.service.components.actions.ServiceActionProcessor
 import io.matthewnelson.topl_service.service.TorService
 import io.matthewnelson.topl_service_base.TorPortInfo
-import io.matthewnelson.topl_service.util.ServiceConsts.ServiceActionName
 import io.matthewnelson.topl_service.util.ServiceConsts.NotificationImage
+import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceActionName
 import io.matthewnelson.topl_service_base.ServiceUtilities
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
@@ -80,7 +80,7 @@ import android.net.ConnectivityManager
 import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.service.TorService
 import io.matthewnelson.topl_service.service.components.actions.ServiceAction
-import io.matthewnelson.topl_service.util.ServiceConsts.ServiceActionName
+import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceActionName
 import java.math.BigInteger
 import java.security.SecureRandom
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
@@ -77,6 +77,7 @@ import io.matthewnelson.topl_service_base.BaseServiceConsts
 
 abstract class ServiceConsts: BaseServiceConsts() {
 
+
     //////////////////////////
     /// NotificationImages ///
     //////////////////////////
@@ -97,9 +98,9 @@ abstract class ServiceConsts: BaseServiceConsts() {
     }
 
 
-    //////////////////////
+    /////////////////////
     /// ServiceAction ///
-    //////////////////////
+    /////////////////////
     @Target(
         AnnotationTarget.TYPE,
         AnnotationTarget.CLASS,
@@ -123,33 +124,6 @@ abstract class ServiceConsts: BaseServiceConsts() {
             const val START_TOR = "${ACTION_COMMAND}START_TOR"
             const val STOP_SERVICE = "${ACTION_COMMAND}STOP_SERVICE"
             const val STOP_TOR = "${ACTION_COMMAND}STOP_TOR"
-        }
-    }
-
-    @Target(
-        AnnotationTarget.CLASS,
-        AnnotationTarget.VALUE_PARAMETER,
-        AnnotationTarget.TYPE,
-        AnnotationTarget.PROPERTY
-    )
-    @StringDef(
-        ServiceActionName.DISABLE_NETWORK,
-        ServiceActionName.ENABLE_NETWORK,
-        ServiceActionName.NEW_ID,
-        ServiceActionName.RESTART_TOR,
-        ServiceActionName.START,
-        ServiceActionName.STOP
-    )
-    @Retention(AnnotationRetention.SOURCE)
-    internal annotation class ServiceActionName {
-        companion object {
-            private const val ACTION_NAME = "Action_"
-            const val DISABLE_NETWORK = "${ACTION_NAME}DISABLE_NETWORK"
-            const val ENABLE_NETWORK = "${ACTION_NAME}ENABLE_NETWORK"
-            const val NEW_ID = "${ACTION_NAME}NEW_ID"
-            const val RESTART_TOR = "${ACTION_NAME}RESTART_TOR"
-            const val START = "${ACTION_NAME}START"
-            const val STOP = "${ACTION_NAME}STOP"
         }
     }
 }


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR exposes the `ServiceActionName` annotation class by moving it to `topl-service-base::BaseServiceConsts`.

Will enable library users to listen for Service Action execution more easily.