### PR TITLE
Add Service execution hooks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=io.matthewnelson.topl-android
-VERSION_NAME=2.0.3-SNAPSHOT
+VERSION_NAME=2.0.3b-SNAPSHOT
 
 # The trailing 2 digits are for `alpha##` releases. For example:
 #     4.4.1-alpha02 = 441102 where `102` stands for alpha02

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -77,6 +77,7 @@ import android.content.Intent
 import android.os.Process
 import io.matthewnelson.encrypted_storage.Prefs
 import io.matthewnelson.sampleapp.topl_android.MyEventBroadcaster
+import io.matthewnelson.sampleapp.topl_android.MyServiceExecutionHooks
 import io.matthewnelson.sampleapp.topl_android.MyTorSettings
 import io.matthewnelson.sampleapp.ui.MainActivity
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
@@ -186,6 +187,7 @@ class App: Application() {
                 .disableStopServiceOnTaskRemoved(stopServiceOnTaskRemoved)
                 .setBuildConfigDebug(buildConfigDebug)
                 .setEventBroadcaster(eventBroadcaster = MyEventBroadcaster())
+                .setServiceExecutionHooks(executionHooks = MyServiceExecutionHooks())
         }
     }
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/CodeSamples.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/CodeSamples.kt
@@ -178,6 +178,7 @@ class CodeSamples {
             // TorServiceController.Companion?.appEventBroadcaster and cast what's returned
             // as MyEventBroadcaster
             .setEventBroadcaster(eventBroadcaster = MyEventBroadcaster())
+            .setServiceExecutionHooks(executionHooks = MyServiceExecutionHooks())
 
             // Only needed if you wish to customize the directories/files used by Tor if
             // the defaults aren't to your liking.

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyServiceExecutionHooks.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyServiceExecutionHooks.kt
@@ -1,0 +1,15 @@
+package io.matthewnelson.sampleapp.topl_android
+
+import android.content.Context
+import android.widget.Toast
+import io.matthewnelson.topl_service_base.ServiceExecutionHooks
+import kotlinx.coroutines.delay
+
+class MyServiceExecutionHooks: ServiceExecutionHooks() {
+
+    override suspend fun executeOnCreateTorService(context: Context) {}
+
+    override suspend fun executeBeforeStartTor(context: Context) {}
+
+    override suspend fun executeAfterStopTor(context: Context) {}
+}

--- a/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/ServiceExecutionHooks.kt
+++ b/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/ServiceExecutionHooks.kt
@@ -1,0 +1,24 @@
+package io.matthewnelson.topl_service_base
+
+import android.content.Context
+
+/**
+ * Set Hooks to be executed from TorService.
+ * */
+abstract class ServiceExecutionHooks {
+
+    /**
+     * Is executed from TorService.onCreate on Dispatchers.Main
+     * */
+    abstract suspend fun executeOnCreateTorService(context: Context)
+
+    /**
+     * Is executed from ServiceActionProcessor.processQueue on Dispatchers.Main
+     * */
+    abstract suspend fun executeBeforeStartTor(context: Context)
+
+    /**
+     * Is executed from ServiceActionProcessor.processQueue on Dispatchers.Main
+     * */
+    abstract suspend fun executeAfterStopTor(context: Context)
+}

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -253,8 +253,9 @@ class TorServiceController private constructor(): ServiceConsts() {
         }
 
         /**
-         * Implement and set hooks to be executed in [TorService.onCreate], and just
-         * prior to calling [TorService.stopSelf].
+         * Implement and set hooks to be executed in [TorService.onCreate], and
+         * [ServiceActionProcessor.processServiceAction] prior to starting of Tor, and
+         * post stopping of Tor.
          * */
         fun setServiceExecutionHooks(executionHooks: ServiceExecutionHooks): Builder {
             if (serviceExecutionHooks == null) {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -246,8 +246,19 @@ class TorServiceController private constructor(): ServiceConsts() {
          * class actually is.
          * */
         fun setEventBroadcaster(eventBroadcaster: TorServiceEventBroadcaster): Builder {
-            if (Companion.appEventBroadcaster == null) {
+            if (appEventBroadcaster == null) {
                 appEventBroadcaster = eventBroadcaster
+            }
+            return this
+        }
+
+        /**
+         * Implement and set hooks to be executed in [TorService.onCreate], and just
+         * prior to calling [TorService.stopSelf].
+         * */
+        fun setServiceExecutionHooks(executionHooks: ServiceExecutionHooks): Builder {
+            if (serviceExecutionHooks == null) {
+                serviceExecutionHooks = executionHooks
             }
             return this
         }
@@ -321,6 +332,10 @@ class TorServiceController private constructor(): ServiceConsts() {
 
         @JvmStatic
         var appEventBroadcaster: TorServiceEventBroadcaster? = null
+            private set
+
+        @JvmStatic
+        var serviceExecutionHooks: ServiceExecutionHooks? = null
             private set
 
         /**

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -80,6 +80,7 @@ import android.os.IBinder
 import androidx.annotation.WorkerThread
 import androidx.core.app.NotificationCompat
 import io.matthewnelson.topl_core.broadcaster.BroadcastLogger
+import io.matthewnelson.topl_core_base.BaseConsts.BroadcastType
 import io.matthewnelson.topl_core_base.TorConfigFiles
 import io.matthewnelson.topl_service.BuildConfig
 import io.matthewnelson.topl_service.TorServiceController
@@ -94,6 +95,7 @@ import io.matthewnelson.topl_service_base.ApplicationDefaultTorSettings
 import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceActionName
 import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceLifecycleEvent
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import java.io.File
 import java.io.IOException
 
@@ -407,6 +409,21 @@ internal abstract class BaseService: Service() {
         serviceNotification.buildNotification(this, setStartTime = true)
         registerPrefsListener()
         setIsDeviceLocked()
+
+        TorServiceController.serviceExecutionHooks?.let { hooks ->
+            getScopeMain().launch {
+                try {
+                    hooks.executeOnCreateTorService(context.applicationContext)
+                } catch (e: Exception) {
+                    TorServiceController.appEventBroadcaster?.broadcastException(
+                        "${BroadcastType.EXCEPTION}|" +
+                                "${hooks.javaClass.simpleName}|" +
+                                "${e.message}"
+                        , e
+                    )
+                }
+            }
+        }
     }
 
     override fun onDestroy() {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
@@ -71,7 +71,6 @@
 * */
 package io.matthewnelson.topl_service.service.components.actions
 
-import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.util.ServiceConsts
 import kotlinx.coroutines.*
@@ -288,22 +287,7 @@ internal class ServiceActionProcessor(private val torService: BaseService): Serv
                             }
                             ServiceActionCommand.START_TOR -> {
                                 if (!torService.hasControlConnection()) {
-
-                                    TorServiceController.serviceExecutionHooks?.let { hooks ->
-                                        withContext(Dispatchers.Main) {
-                                            try {
-                                                hooks.executeBeforeStartTor(torService.context.applicationContext)
-                                            } catch (e: Exception) {
-                                                TorServiceController.appEventBroadcaster?.broadcastException(
-                                                    "${BroadcastType.EXCEPTION}|" +
-                                                            "${hooks.javaClass.simpleName}|" +
-                                                            "${e.message}"
-                                                    , e
-                                                )
-                                            }
-                                        }
-                                    }
-
+                                    torService.executionHookPreStartTor()
                                     torService.startTor()
                                     delay(300L)
                                 }
@@ -314,24 +298,9 @@ internal class ServiceActionProcessor(private val torService: BaseService): Serv
                             }
                             ServiceActionCommand.STOP_TOR -> {
                                 if (torService.hasControlConnection()) {
-
                                     torService.stopTor()
                                     delay(300L)
-
-                                    TorServiceController.serviceExecutionHooks?.let { hooks ->
-                                        withContext(Dispatchers.Main) {
-                                            try {
-                                                hooks.executeAfterStopTor(torService.context.applicationContext)
-                                            } catch (e: Exception) {
-                                                TorServiceController.appEventBroadcaster?.broadcastException(
-                                                    "${BroadcastType.EXCEPTION}|" +
-                                                            "${hooks.javaClass.simpleName}|" +
-                                                            "${e.message}"
-                                                    , e
-                                                )
-                                            }
-                                        }
-                                    }
+                                    torService.executionHookPostStopTor()
                                 }
                             }
                         }


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR adds service execution hooks at key points of TorService, in:
 - `TorService.onCreate`
 - `ServiceActionProcessor.processQueue` prior to starting of Tor
 - `ServiceActionProcessor.processQueue` post stopping of Tor, prior to execution of `TorService.stopSelf`

SNAPSHOT available by:
 - In your Application module’s build.gradle file, add the following (outside the android block):
```groovy
repositories {
    maven {
        url 'https://oss.sonatype.org/content/repositories/snapshots/'
    }
}
```

- In your Application module’s build.gradle file, add (or modify) the following in the dependencies block:
```groovy
def topl_android_version = "2.0.3b-SNAPSHOT"
implementation 'io.matthewnelson.topl-android:topl-service:$topl_android_version'
```