### PR TITLE
Mn/fix/internal visibility modifiers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=io.matthewnelson.topl-android
-VERSION_NAME=2.0.3b-SNAPSHOT
+VERSION_NAME=2.0.3c-SNAPSHOT
 
 # The trailing 2 digits are for `alpha##` releases. For example:
 #     4.4.1-alpha02 = 441102 where `102` stands for alpha02

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=io.matthewnelson.topl-android
-VERSION_NAME=2.0.3c-SNAPSHOT
+VERSION_NAME=2.0.3e-SNAPSHOT
 
 # The trailing 2 digits are for `alpha##` releases. For example:
 #     4.4.1-alpha02 = 441102 where `102` stands for alpha02

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
@@ -123,15 +123,27 @@ import java.io.*
  * @param [torInstaller] [TorInstaller]
  * @param [torSettings] [TorSettings] Basically your torrc file
  */
-internal class OnionProxyContext(
+internal class OnionProxyContext private constructor(
     val torConfigFiles: TorConfigFiles,
     val torInstaller: TorInstaller,
     val torSettings: TorSettings
 ): CoreConsts() {
 
+    companion object {
+        @JvmSynthetic
+        internal fun instantiate(
+            torConfigFiles: TorConfigFiles,
+            torInstaller: TorInstaller,
+            torSettings: TorSettings
+        ): OnionProxyContext =
+            OnionProxyContext(torConfigFiles, torInstaller, torSettings)
+    }
+
     // Gets initialized in OnionProxyManager _immediately_ after
     // OnionProxyContext is instantiated.
     private lateinit var broadcastLogger: BroadcastLogger
+
+    @JvmSynthetic
     fun initBroadcastLogger(onionProxyBroadcastLogger: BroadcastLogger) {
         if (!::broadcastLogger.isInitialized)
             broadcastLogger = onionProxyBroadcastLogger
@@ -157,6 +169,7 @@ internal class OnionProxyContext(
      * @throws [IllegalArgumentException] If [configFileReference] is an invalid argument, or null file.
      * @throws [SecurityException] See [WriteObserver.checkExists]
      */
+    @JvmSynthetic
     @Throws(IllegalArgumentException::class, SecurityException::class)
     fun createFileObserver(@ConfigFile configFileReference: String): WriteObserver {
         broadcastLogger.debug("Creating FileObserver for $configFileReference")
@@ -190,6 +203,7 @@ internal class OnionProxyContext(
      * @return True if file exists or is created successfully, otherwise false.
      * @throws [SecurityException] Unauthorized access to file/directory.
      * */
+    @JvmSynthetic
     @Throws(IllegalArgumentException::class, SecurityException::class)
     fun createNewFileIfDoesNotExist(@ConfigFile configFileReference: String): Boolean {
         broadcastLogger.debug("Creating $configFileReference if DNE")
@@ -238,6 +252,7 @@ internal class OnionProxyContext(
      * @throws [SecurityException] Unauthorized access to file/directory.
      * @throws [IllegalArgumentException]
      * */
+    @JvmSynthetic
     @Throws(SecurityException::class, IllegalArgumentException::class)
     fun deleteFile(@ConfigFile configFileReference: String): Boolean {
         broadcastLogger.debug("Deleting $configFileReference")
@@ -273,6 +288,7 @@ internal class OnionProxyContext(
      * @throws [EOFException] Errors while reading file.
      * @throws [SecurityException] Unauthorized access to file/directory.
      * */
+    @JvmSynthetic
     @Throws(IOException::class, EOFException::class, SecurityException::class)
     fun readFile(@ConfigFile configFileReference: String): ByteArray {
         broadcastLogger.debug("Reading $configFileReference")
@@ -307,6 +323,7 @@ internal class OnionProxyContext(
      * @return True if directory exists or is created successfully, otherwise false.
      * @throws [SecurityException] Unauthorized access to file/directory.
      */
+    @JvmSynthetic
     @Throws(SecurityException::class)
     fun createDataDir(): Boolean =
         synchronized(dataDirLock) {
@@ -319,6 +336,7 @@ internal class OnionProxyContext(
      * @throws [RuntimeException] Was unable to delete a file.
      * @throws [SecurityException] Unauthorized access to file/directory.
      */
+    @JvmSynthetic
     @Throws(RuntimeException::class, SecurityException::class)
     fun deleteDataDirExceptHiddenServiceAndAuthPrivate() {
         synchronized(dataDirLock) {
@@ -337,6 +355,7 @@ internal class OnionProxyContext(
     ////////////////////
     /// HostnameFile ///
     ////////////////////
+    @JvmSynthetic
     @Throws(SecurityException::class)
     fun setHostnameDirPermissionsToReadOnly(): Boolean =
         synchronized(hostnameFileLock) {
@@ -354,6 +373,7 @@ internal class OnionProxyContext(
      * @return The resolveConf file with newly added ip addresses for Quad9
      * @throws [IOException] from FileWriter
      */
+    @JvmSynthetic
     @Throws(IOException::class)
     fun createQuad9NameserverFile(): File =
         synchronized(resolvConfFileLock) {
@@ -370,6 +390,7 @@ internal class OnionProxyContext(
      *
      * @return process id
      */
-    val processId: String
-        get() = Process.myPid().toString()
+    @JvmSynthetic
+    fun getProcessId(): String =
+        Process.myPid().toString()
 }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
@@ -131,7 +131,7 @@ internal class OnionProxyContext private constructor(
 
     companion object {
         @JvmSynthetic
-        internal fun instantiate(
+        fun instantiate(
             torConfigFiles: TorConfigFiles,
             torInstaller: TorInstaller,
             torSettings: TorSettings

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/BroadcastLogger.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/BroadcastLogger.kt
@@ -95,20 +95,33 @@ import io.matthewnelson.topl_core_base.TorSettings
  * @param [buildConfigDebug] To enable/disable Logcat messages
  * @param [hasDebugLogs] To switch debug logs on/off, as well as Logcat messages on Debug builds.
  * */
-class BroadcastLogger internal constructor(
+class BroadcastLogger private constructor(
     val TAG: String,
     val eventBroadcaster: EventBroadcaster,
     private val buildConfigDebug: Boolean,
     hasDebugLogs: Boolean
 ): CoreConsts() {
 
+    companion object {
+        @JvmSynthetic
+        internal fun instantiate(
+            tag: String,
+            eventBroadcaster: EventBroadcaster,
+            buildConfigDebug: Boolean,
+            hasDebugLogs: Boolean
+        ): BroadcastLogger =
+            BroadcastLogger(tag, eventBroadcaster, buildConfigDebug, hasDebugLogs)
+    }
+
     @Volatile
+    @JvmSynthetic
     internal var hasDebugLogs: Boolean = hasDebugLogs
         private set
 
     /**
      * See [io.matthewnelson.topl_core.broadcaster.BroadcastLoggerHelper.refreshBroadcastLoggersHasDebugLogsVar]
      * */
+    @JvmSynthetic
     internal fun updateHasDebugLogs(hasDebugLogs: Boolean) {
         this.hasDebugLogs = hasDebugLogs
     }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/BroadcastLogger.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/BroadcastLogger.kt
@@ -99,7 +99,8 @@ class BroadcastLogger private constructor(
     val TAG: String,
     val eventBroadcaster: EventBroadcaster,
     private val buildConfigDebug: Boolean,
-    hasDebugLogs: Boolean
+    @Volatile
+    private var hasDebugLogs: Boolean
 ): CoreConsts() {
 
     companion object {
@@ -112,11 +113,6 @@ class BroadcastLogger private constructor(
         ): BroadcastLogger =
             BroadcastLogger(tag, eventBroadcaster, buildConfigDebug, hasDebugLogs)
     }
-
-    @Volatile
-    @JvmSynthetic
-    internal var hasDebugLogs: Boolean = hasDebugLogs
-        private set
 
     /**
      * See [io.matthewnelson.topl_core.broadcaster.BroadcastLoggerHelper.refreshBroadcastLoggersHasDebugLogsVar]
@@ -167,5 +163,4 @@ class BroadcastLogger private constructor(
     fun torState(@TorState state: String, @TorNetworkState networkState: String) {
         eventBroadcaster.broadcastTorState(state, networkState)
     }
-
 }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/BroadcastLoggerHelper.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/BroadcastLoggerHelper.kt
@@ -82,16 +82,26 @@ import io.matthewnelson.topl_core_base.EventBroadcaster
  * can be controlled in a more efficient/effective manner. It also handles initialization of
  * several other classes [BroadcastLogger]'s upon instantiation.
  * */
-internal class BroadcastLoggerHelper(
+internal class BroadcastLoggerHelper private constructor(
     private val onionProxyManager: OnionProxyManager,
     private val eventBroadcaster: EventBroadcaster,
     private val buildConfigDebug: Boolean
 ) {
 
+    companion object {
+        @JvmSynthetic
+        internal fun instantiate(
+            onionProxyManager: OnionProxyManager,
+            eventBroadcaster: EventBroadcaster,
+            buildConfigDebug: Boolean
+        ): BroadcastLoggerHelper =
+            BroadcastLoggerHelper(onionProxyManager, eventBroadcaster, buildConfigDebug)
+    }
+
     private val broadcastLoggerList = mutableListOf<BroadcastLogger>()
 
     init {
-        onionProxyManager.onionProxyContext.initBroadcastLogger(
+        onionProxyManager.initOnionProxyContextBroadcastLogger(
             getBroadcastLogger(OnionProxyContext::class.java)
         )
         onionProxyManager.torInstaller.initBroadcastLogger(
@@ -107,6 +117,7 @@ internal class BroadcastLoggerHelper(
      * This gets called automatically at every [OnionProxyManager.start]. Can be called at
      * any time whether Tor's State is ON or OFF.
      * */
+    @JvmSynthetic
     fun refreshBroadcastLoggersHasDebugLogsVar() {
         if (broadcastLoggerList.size < 1) return
         val hasDebugLogs = onionProxyManager.torSettings.hasDebugLogs
@@ -124,6 +135,7 @@ internal class BroadcastLoggerHelper(
      *
      * @param [clazz] Class<*> - For initializing [BroadcastLogger.TAG] with your class' name.
      * */
+    @JvmSynthetic
     fun getBroadcastLogger(clazz: Class<*>): BroadcastLogger =
         getBroadcastLogger(clazz.simpleName)
 
@@ -134,10 +146,11 @@ internal class BroadcastLoggerHelper(
      *
      * @param [tagName] String - For initialize [BroadcastLogger.TAG].
      * */
+    @JvmSynthetic
     fun getBroadcastLogger(tagName: String): BroadcastLogger {
         var bl: BroadcastLogger? = checkIfBroadcastLoggerExists(tagName)
         if (bl == null) {
-            bl = BroadcastLogger(
+            bl = BroadcastLogger.instantiate(
                 tagName,
                 eventBroadcaster,
                 buildConfigDebug,

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/TorStateMachine.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/TorStateMachine.kt
@@ -99,7 +99,15 @@ import io.matthewnelson.topl_core.util.CoreConsts
 /**
  * Current State of Tor
  */
-class TorStateMachine(private val broadcastLogger: BroadcastLogger): CoreConsts() {
+class TorStateMachine private constructor(
+    private val broadcastLogger: BroadcastLogger
+): CoreConsts() {
+
+    companion object {
+        @JvmSynthetic
+        internal fun instantiate(broadcastLogger: BroadcastLogger): TorStateMachine =
+            TorStateMachine(broadcastLogger)
+    }
 
     private var currentTorState: @TorState String = TorState.OFF
     private var currentTorNetworkState: @TorNetworkState String = TorNetworkState.DISABLED
@@ -125,6 +133,7 @@ class TorStateMachine(private val broadcastLogger: BroadcastLogger): CoreConsts(
      * @param [state] [io.matthewnelson.topl_core_base.BaseConsts.TorState]
      * @return Previous [io.matthewnelson.topl_core_base.BaseConsts.TorState]
      * */
+    @JvmSynthetic
     @Synchronized
     internal fun setTorState(@TorState state: String): @TorState String {
         val currentState = currentTorState
@@ -144,6 +153,7 @@ class TorStateMachine(private val broadcastLogger: BroadcastLogger): CoreConsts(
      * @param [networkState] [io.matthewnelson.topl_core_base.BaseConsts.TorNetworkState]
      * @return Previous [io.matthewnelson.topl_core_base.BaseConsts.TorNetworkState]
      * */
+    @JvmSynthetic
     @Synchronized
     internal fun setTorNetworkState(@TorNetworkState networkState: String): @TorNetworkState String {
         val currentNetworkState = currentTorNetworkState

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/listener/BaseEventListener.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/listener/BaseEventListener.kt
@@ -88,6 +88,8 @@ abstract class BaseEventListener: EventListener() {
      * */
     var broadcastLogger: BroadcastLogger? = null
         private set
+
+    @JvmSynthetic
     internal fun initBroadcastLogger(torInstallerBroadcastLogger: BroadcastLogger) {
         if (broadcastLogger == null)
             broadcastLogger = torInstallerBroadcastLogger
@@ -111,6 +113,7 @@ abstract class BaseEventListener: EventListener() {
      *
      * TODO: find a less hacky way to do this...
      * */
+    @JvmSynthetic
     internal suspend fun beginWatchingNoticeMsgs() {
         noticeMsgBuffer = StringBuffer()
         delay(50)
@@ -123,6 +126,7 @@ abstract class BaseEventListener: EventListener() {
      * @param [delayMilliseconds] Length of time you wish to delay the coroutine for before executing
      * @return True if it contains the string, false if not.
      * */
+    @JvmSynthetic
     internal suspend fun doesNoticeMsgBufferContain(string: String, delayMilliseconds: Long): Boolean {
         delay(delayMilliseconds)
         val boolean = noticeMsgBuffer.toString().contains(string)

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/listener/BaseEventListener.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/listener/BaseEventListener.kt
@@ -86,7 +86,7 @@ abstract class BaseEventListener: EventListener() {
      * This gets set as soon as [io.matthewnelson.topl_core.OnionProxyManager] is instantiated,
      * and can be used to broadcast messages in your class which extends [TorInstaller].
      * */
-    var broadcastLogger: BroadcastLogger? = null
+    protected var broadcastLogger: BroadcastLogger? = null
         private set
 
     @JvmSynthetic

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/settings/TorSettingsBuilder.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/settings/TorSettingsBuilder.kt
@@ -127,10 +127,19 @@ import java.util.*
  * @param [broadcastLogger] for broadcasting/logging
  * @sample [io.matthewnelson.topl_service.service.TorService.generateTorrcFile]
  * */
-class TorSettingsBuilder internal constructor(
+class TorSettingsBuilder private constructor(
     private val onionProxyContext: OnionProxyContext,
     private val broadcastLogger: BroadcastLogger
 ): CoreConsts() {
+
+    companion object {
+        @JvmSynthetic
+        internal fun instantiate(
+            onionProxyContext: OnionProxyContext,
+            broadcastLogger: BroadcastLogger
+        ): TorSettingsBuilder =
+            TorSettingsBuilder(onionProxyContext, broadcastLogger)
+    }
 
     private var buffer = StringBuffer()
     private val torConfigFiles: TorConfigFiles

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/CoreConsts.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/CoreConsts.kt
@@ -84,8 +84,11 @@ abstract class CoreConsts: BaseConsts() {
     @Retention(AnnotationRetention.SOURCE)
     internal annotation class ConfigFile {
         companion object {
+            @JvmSynthetic
             const val CONTROL_PORT_FILE = "ControlPort file"
+            @JvmSynthetic
             const val COOKIE_AUTH_FILE = "CookieAuth file"
+            @JvmSynthetic
             const val HOSTNAME_FILE = "Hostname file"
         }
     }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/CoreConsts.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/CoreConsts.kt
@@ -84,11 +84,8 @@ abstract class CoreConsts: BaseConsts() {
     @Retention(AnnotationRetention.SOURCE)
     internal annotation class ConfigFile {
         companion object {
-            @JvmSynthetic
             const val CONTROL_PORT_FILE = "ControlPort file"
-            @JvmSynthetic
             const val COOKIE_AUTH_FILE = "CookieAuth file"
-            @JvmSynthetic
             const val HOSTNAME_FILE = "Hostname file"
         }
     }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/TorInstaller.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/TorInstaller.kt
@@ -113,7 +113,7 @@ abstract class TorInstaller: CoreConsts() {
      * This gets set as soon as [io.matthewnelson.topl_core.OnionProxyManager] is instantiated,
      * and can be used to broadcast messages in your class which extends [TorInstaller].
      * */
-    var broadcastLogger: BroadcastLogger? = null
+    protected var broadcastLogger: BroadcastLogger? = null
         private set
 
     @JvmSynthetic

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/TorInstaller.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/TorInstaller.kt
@@ -115,6 +115,8 @@ abstract class TorInstaller: CoreConsts() {
      * */
     var broadcastLogger: BroadcastLogger? = null
         private set
+
+    @JvmSynthetic
     internal fun initBroadcastLogger(torInstallerBroadcastLogger: BroadcastLogger) {
         if (broadcastLogger == null)
             broadcastLogger = torInstallerBroadcastLogger

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -123,14 +123,14 @@ class TorServiceController private constructor(): ServiceConsts() {
     ) {
 
 //        private var heartbeatTime = BackgroundManager.heartbeatTime
-        private var disableNetworkDelay = ServiceActionProcessor.disableNetworkDelay
-        private var restartTorDelayTime = ServiceActionProcessor.restartTorDelayTime
-        private var stopServiceDelayTime = ServiceActionProcessor.stopServiceDelayTime
+        private var disableNetworkDelay = ServiceActionProcessor.getDisableNetworkDelay()
+        private var restartTorDelayTime = ServiceActionProcessor.getRestartTorDelayTime()
+        private var stopServiceDelayTime = ServiceActionProcessor.getStopServiceDelayTime()
         private var stopServiceOnTaskRemoved = true
         private var torConfigFiles: TorConfigFiles? = null
 
         // On published releases of this Library, this value will **always** be `false`.
-        private var buildConfigDebug = BaseService.buildConfigDebug
+        private var buildConfigDebug = BaseService.getBuildConfigDebug()
 
         /**
          * Default is set to 6_000ms, (what this method adds time to).
@@ -352,7 +352,7 @@ class TorServiceController private constructor(): ServiceConsts() {
         @Throws(RuntimeException::class)
         fun getTorConfigFiles(): TorConfigFiles {
             return try {
-                BaseService.torConfigFiles
+                BaseService.getTorConfigFiles()
             } catch (e: UninitializedPropertyAccessException) {
                 throw RuntimeException(e.message)
             }
@@ -370,7 +370,7 @@ class TorServiceController private constructor(): ServiceConsts() {
         @Throws(RuntimeException::class)
         fun getDefaultTorSettings(): ApplicationDefaultTorSettings {
             return try {
-                BaseService.defaultTorSettings
+                BaseService.getApplicationDefaultTorSettings()
             } catch (e: UninitializedPropertyAccessException) {
                 throw RuntimeException(e.message)
             }
@@ -387,7 +387,7 @@ class TorServiceController private constructor(): ServiceConsts() {
         @JvmStatic
         @Throws(RuntimeException::class)
         fun getV3ClientAuthManager(): BaseV3ClientAuthManager =
-            V3ClientAuthManager(getTorConfigFiles())
+            V3ClientAuthManager.instantiate(getTorConfigFiles())
 
         /**
          * This method will *never* throw the [RuntimeException] if you call it after
@@ -399,7 +399,7 @@ class TorServiceController private constructor(): ServiceConsts() {
         @JvmStatic
         @Throws(RuntimeException::class)
         fun getServiceTorSettings(): BaseServiceTorSettings =
-            ServiceTorSettings(
+            ServiceTorSettings.instantiate(
                 TorServicePrefs(BaseService.getAppContext()), getDefaultTorSettings()
             )
 
@@ -423,7 +423,7 @@ class TorServiceController private constructor(): ServiceConsts() {
          * */
         @JvmStatic
         fun stopTor() {
-            TorServiceConnection.serviceBinder?.submitServiceAction(ServiceAction.Stop())
+            TorServiceConnection.getServiceBinder()?.submitServiceAction(ServiceAction.Stop.instantiate())
         }
 
         /**
@@ -431,7 +431,7 @@ class TorServiceController private constructor(): ServiceConsts() {
          * */
         @JvmStatic
         fun restartTor() {
-            TorServiceConnection.serviceBinder?.submitServiceAction(ServiceAction.RestartTor())
+            TorServiceConnection.getServiceBinder()?.submitServiceAction(ServiceAction.RestartTor.instantiate())
         }
 
         /**
@@ -439,7 +439,7 @@ class TorServiceController private constructor(): ServiceConsts() {
          * */
         @JvmStatic
         fun newIdentity() {
-            TorServiceConnection.serviceBinder?.submitServiceAction(ServiceAction.NewId())
+            TorServiceConnection.getServiceBinder()?.submitServiceAction(ServiceAction.NewId.instantiate())
         }
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefsListener.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefsListener.kt
@@ -75,22 +75,29 @@ import android.content.SharedPreferences
 import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.service.TorService
 import io.matthewnelson.topl_service_base.BaseServiceConsts.PrefKeyBoolean
+import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceActionName
 import io.matthewnelson.topl_service_base.TorServicePrefs
 
 /**
  * Listens to [TorServicePrefs] for changes such that while Tor is running, it can
  * query [TorService.onionProxyManager] to have it updated immediately (if the setting doesn't
- * require a restart), or submit [io.matthewnelson.topl_service.util.ServiceConsts.ServiceActionName]'s
- * to [io.matthewnelson.topl_service.service.components.actions.ServiceActionProcessor] to be
+ * require a restart), or submit [ServiceActionName]'s to
+ * [io.matthewnelson.topl_service.service.components.actions.ServiceActionProcessor] to be
  * queued for execution.
  *
  * @param [torService] To instantiate [TorServicePrefs]
  * */
-internal class TorServicePrefsListener(
+internal class TorServicePrefsListener private constructor(
     private val torService: BaseService
 ): SharedPreferences.OnSharedPreferenceChangeListener {
 
-    private val torServicePrefs = TorServicePrefs(torService.context)
+    companion object {
+        @JvmSynthetic
+        fun instantiate(torService: BaseService): TorServicePrefsListener =
+            TorServicePrefsListener(torService)
+    }
+
+    private val torServicePrefs = TorServicePrefs(torService.getContext())
     private val broadcastLogger = torService.getBroadcastLogger(TorServicePrefsListener::class.java)
 
     init {
@@ -101,6 +108,7 @@ internal class TorServicePrefsListener(
     /**
      * Called from [TorService.onDestroy].
      * */
+    @JvmSynthetic
     fun unregister() {
         torServicePrefs.unregisterListener(this)
         broadcastLogger.debug("Has been unregistered")

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -111,41 +111,38 @@ internal abstract class BaseService internal constructor(): Service() {
 
         private var buildConfigVersionCode: Int = -1
         @JvmSynthetic
-        internal fun getBuildConfigVersionCode(): Int =
+        fun getBuildConfigVersionCode(): Int =
             buildConfigVersionCode
 
         private var buildConfigDebug: Boolean = BuildConfig.DEBUG
         @JvmSynthetic
-        internal fun getBuildConfigDebug(): Boolean =
+        fun getBuildConfigDebug(): Boolean =
             buildConfigDebug
 
         private var geoipAssetPath: String = ""
         @JvmSynthetic
-        internal fun getGeoipAssetPath(): String =
+        fun getGeoipAssetPath(): String =
             geoipAssetPath
 
         private var geoip6AssetPath: String = ""
         @JvmSynthetic
-        internal fun getGeoip6AssetPath(): String =
+        fun getGeoip6AssetPath(): String =
             geoip6AssetPath
 
         private lateinit var torConfigFiles: TorConfigFiles
         @JvmSynthetic
-        internal fun getTorConfigFiles(): TorConfigFiles =
+        fun getTorConfigFiles(): TorConfigFiles =
             torConfigFiles
 
         private lateinit var defaultTorSettings: ApplicationDefaultTorSettings
         @JvmSynthetic
-        internal fun getApplicationDefaultTorSettings(): ApplicationDefaultTorSettings =
+        fun getApplicationDefaultTorSettings(): ApplicationDefaultTorSettings =
             defaultTorSettings
 
         private var stopServiceOnTaskRemoved: Boolean = true
-        @JvmSynthetic
-        internal fun getStopServiceOnTaskRemoved(): Boolean =
-            stopServiceOnTaskRemoved
 
         @JvmSynthetic
-        internal fun initialize(
+        fun initialize(
             application: Application,
             buildConfigVersionCode: Int,
             torSettings: ApplicationDefaultTorSettings,
@@ -169,14 +166,14 @@ internal abstract class BaseService internal constructor(): Service() {
 
         @JvmSynthetic
         @Throws(RuntimeException::class)
-        internal fun getAppContext(): Context =
+        fun getAppContext(): Context =
             application?.applicationContext ?: throw RuntimeException(
                 "Builder.build has not been called yet"
             )
 
         // For things that can't be saved to TorServicePrefs, such as BuildConfig.VERSION_CODE
         @JvmSynthetic
-        internal fun getLocalPrefs(context: Context): SharedPreferences =
+        fun getLocalPrefs(context: Context): SharedPreferences =
             context.getSharedPreferences("TorServiceLocalPrefs", Context.MODE_PRIVATE)
 
 
@@ -196,7 +193,7 @@ internal abstract class BaseService internal constructor(): Service() {
          * @param [serviceAction] The [ServiceActionName] to update [lastAcceptedServiceAction] to
          * */
         @JvmSynthetic
-        internal fun updateLastAcceptedServiceAction(@ServiceActionName serviceAction: String) {
+        fun updateLastAcceptedServiceAction(@ServiceActionName serviceAction: String) {
             lastAcceptedServiceAction = serviceAction
         }
 
@@ -221,7 +218,7 @@ internal abstract class BaseService internal constructor(): Service() {
          * @return true if startService didn't throw an exception, false if it did.
          * */
         @JvmSynthetic
-        internal fun startService(
+        fun startService(
             context: Context,
             serviceClass: Class<*>,
             includeIntentActionStart: Boolean = true,
@@ -254,7 +251,7 @@ internal abstract class BaseService internal constructor(): Service() {
          * @return true if startService didn't throw an exception, false if it did.
          * */
         @JvmSynthetic
-        internal fun bindService(
+        fun bindService(
             context: Context,
             serviceClass: Class<*>,
             bindServiceFlag: Int = Context.BIND_AUTO_CREATE
@@ -276,7 +273,7 @@ internal abstract class BaseService internal constructor(): Service() {
          * */
         @JvmSynthetic
         @Throws(IllegalArgumentException::class)
-        internal fun unbindService(context: Context) {
+        fun unbindService(context: Context) {
             TorServiceConnection.getTorServiceConnection().clearServiceBinderReference()
             context.applicationContext.unbindService(TorServiceConnection.getTorServiceConnection())
         }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -104,26 +104,48 @@ import java.io.IOException
  * [TorService]. It acts as the glue and helps with integration testing of the individual
  * components that make [TorService] work.
  * */
-internal abstract class BaseService: Service() {
+internal abstract class BaseService internal constructor(): Service() {
 
     companion object {
         private var application: Application? = null
-        var buildConfigVersionCode: Int = -1
-            private set
-        var buildConfigDebug: Boolean = BuildConfig.DEBUG
-            private set
-        var geoipAssetPath: String = ""
-            private set
-        var geoip6AssetPath: String = ""
-            private set
-        lateinit var torConfigFiles: TorConfigFiles
-            private set
-        lateinit var defaultTorSettings: ApplicationDefaultTorSettings
-            private set
-        var stopServiceOnTaskRemoved: Boolean = true
-            private set
 
-        fun initialize(
+        private var buildConfigVersionCode: Int = -1
+        @JvmSynthetic
+        internal fun getBuildConfigVersionCode(): Int =
+            buildConfigVersionCode
+
+        private var buildConfigDebug: Boolean = BuildConfig.DEBUG
+        @JvmSynthetic
+        internal fun getBuildConfigDebug(): Boolean =
+            buildConfigDebug
+
+        private var geoipAssetPath: String = ""
+        @JvmSynthetic
+        internal fun getGeoipAssetPath(): String =
+            geoipAssetPath
+
+        private var geoip6AssetPath: String = ""
+        @JvmSynthetic
+        internal fun getGeoip6AssetPath(): String =
+            geoip6AssetPath
+
+        private lateinit var torConfigFiles: TorConfigFiles
+        @JvmSynthetic
+        internal fun getTorConfigFiles(): TorConfigFiles =
+            torConfigFiles
+
+        private lateinit var defaultTorSettings: ApplicationDefaultTorSettings
+        @JvmSynthetic
+        internal fun getApplicationDefaultTorSettings(): ApplicationDefaultTorSettings =
+            defaultTorSettings
+
+        private var stopServiceOnTaskRemoved: Boolean = true
+        @JvmSynthetic
+        internal fun getStopServiceOnTaskRemoved(): Boolean =
+            stopServiceOnTaskRemoved
+
+        @JvmSynthetic
+        internal fun initialize(
             application: Application,
             buildConfigVersionCode: Int,
             torSettings: ApplicationDefaultTorSettings,
@@ -145,14 +167,16 @@ internal abstract class BaseService: Service() {
             }
         }
 
+        @JvmSynthetic
         @Throws(RuntimeException::class)
-        fun getAppContext(): Context =
+        internal fun getAppContext(): Context =
             application?.applicationContext ?: throw RuntimeException(
                 "Builder.build has not been called yet"
             )
 
         // For things that can't be saved to TorServicePrefs, such as BuildConfig.VERSION_CODE
-        fun getLocalPrefs(context: Context): SharedPreferences =
+        @JvmSynthetic
+        internal fun getLocalPrefs(context: Context): SharedPreferences =
             context.getSharedPreferences("TorServiceLocalPrefs", Context.MODE_PRIVATE)
 
 
@@ -171,7 +195,8 @@ internal abstract class BaseService: Service() {
          *
          * @param [serviceAction] The [ServiceActionName] to update [lastAcceptedServiceAction] to
          * */
-        fun updateLastAcceptedServiceAction(@ServiceActionName serviceAction: String) {
+        @JvmSynthetic
+        internal fun updateLastAcceptedServiceAction(@ServiceActionName serviceAction: String) {
             lastAcceptedServiceAction = serviceAction
         }
 
@@ -195,7 +220,8 @@ internal abstract class BaseService: Service() {
          * @param [bindServiceFlag] The flag to use when binding to [TorService]
          * @return true if startService didn't throw an exception, false if it did.
          * */
-        fun startService(
+        @JvmSynthetic
+        internal fun startService(
             context: Context,
             serviceClass: Class<*>,
             includeIntentActionStart: Boolean = true,
@@ -227,14 +253,15 @@ internal abstract class BaseService: Service() {
          * @param [bindServiceFlag] The flag to use when binding to [TorService]
          * @return true if startService didn't throw an exception, false if it did.
          * */
-        fun bindService(
+        @JvmSynthetic
+        internal fun bindService(
             context: Context,
             serviceClass: Class<*>,
             bindServiceFlag: Int = Context.BIND_AUTO_CREATE
         ) {
             context.applicationContext.bindService(
                 Intent(context.applicationContext, serviceClass),
-                TorServiceConnection.torServiceConnection,
+                TorServiceConnection.getTorServiceConnection(),
                 bindServiceFlag
             )
         }
@@ -247,22 +274,25 @@ internal abstract class BaseService: Service() {
          * @param [context] [Context]
          * @throws [IllegalArgumentException] If no binding exists
          * */
+        @JvmSynthetic
         @Throws(IllegalArgumentException::class)
-        fun unbindService(context: Context) {
-            TorServiceConnection.torServiceConnection.clearServiceBinderReference()
-            context.applicationContext.unbindService(TorServiceConnection.torServiceConnection)
+        internal fun unbindService(context: Context) {
+            TorServiceConnection.getTorServiceConnection().clearServiceBinderReference()
+            context.applicationContext.unbindService(TorServiceConnection.getTorServiceConnection())
         }
     }
 
     // All classes that interact with APIs which require Context to do something
     // call this in production (torService.context). This allows for easily
     // swapping it out with what we want to use when testing.
-    abstract val context: Context
+    @JvmSynthetic
+    abstract fun getContext(): Context
 
 
     ///////////////
     /// Binding ///
     ///////////////
+    @JvmSynthetic
     open fun unbindTorService() {
         TorServiceController.appEventBroadcaster?.broadcastServiceLifecycleEvent(
             ServiceLifecycleEvent.ON_UNBIND, this.hashCode()
@@ -280,16 +310,22 @@ internal abstract class BaseService: Service() {
     /////////////////////////
     /// BroadcastReceiver ///
     /////////////////////////
+    @JvmSynthetic
     abstract fun registerReceiver()
+    @JvmSynthetic
     abstract fun setIsDeviceLocked()
+    @JvmSynthetic
     abstract fun unregisterReceiver()
 
 
     //////////////////
     /// Coroutines ///
     //////////////////
+    @JvmSynthetic
     abstract fun getScopeDefault(): CoroutineScope
+    @JvmSynthetic
     abstract fun getScopeIO(): CoroutineScope
+    @JvmSynthetic
     abstract fun getScopeMain(): CoroutineScope
 
 
@@ -297,12 +333,14 @@ internal abstract class BaseService: Service() {
     /// ServiceActionProcessor ///
     //////////////////////////////
     private val serviceActionProcessor by lazy {
-        ServiceActionProcessor(this)
+        ServiceActionProcessor.instantiate(this)
     }
 
+    @JvmSynthetic
     fun processServiceAction(serviceAction: ServiceAction) {
         serviceActionProcessor.processServiceAction(serviceAction)
     }
+    @JvmSynthetic
     open fun stopService() {
         stopSelf()
     }
@@ -312,11 +350,13 @@ internal abstract class BaseService: Service() {
     /// ServiceNotification ///
     ///////////////////////////
     private val serviceNotification: ServiceNotification
-        get() = ServiceNotification.serviceNotification
+        get() = ServiceNotification.getServiceNotification()
 
+    @JvmSynthetic
     fun addNotificationActions() {
         serviceNotification.addActions(this)
     }
+    @JvmSynthetic
     fun doesReceiverNeedToListenForLockScreen(): Boolean {
         return when {
             serviceNotification.visibility == NotificationCompat.VISIBILITY_SECRET -> {
@@ -330,30 +370,39 @@ internal abstract class BaseService: Service() {
             }
         }
     }
+    @JvmSynthetic
     open fun refreshNotificationActions(): Boolean {
         return serviceNotification.refreshActions(this)
     }
+    @JvmSynthetic
     fun removeNotification() {
         serviceNotification.remove()
     }
+    @JvmSynthetic
     fun removeNotificationActions() {
         serviceNotification.removeActions(this)
     }
+    @JvmSynthetic
     open fun startForegroundService(): Boolean {
         return serviceNotification.startForeground(this)
     }
+    @JvmSynthetic
     open fun stopForegroundService(): Boolean {
         return serviceNotification.stopForeground(this)
     }
+    @JvmSynthetic
     fun updateNotificationContentText(string: String) {
         serviceNotification.updateContentText(this, string)
     }
+    @JvmSynthetic
     fun updateNotificationContentTitle(title: String) {
         serviceNotification.updateContentTitle(this, title)
     }
+    @JvmSynthetic
     fun updateNotificationIcon(@NotificationImage notificationImage: Int) {
         serviceNotification.updateIcon(this, notificationImage)
     }
+    @JvmSynthetic
     fun updateNotificationProgress(show: Boolean, progress: Int?) {
         serviceNotification.updateProgress(this, show, progress)
     }
@@ -362,24 +411,36 @@ internal abstract class BaseService: Service() {
     /////////////////
     /// TOPL-Core ///
     /////////////////
+    @JvmSynthetic
     @WorkerThread
     @Throws(IOException::class)
     abstract fun copyAsset(assetPath: String, file: File)
+    @JvmSynthetic
     @WorkerThread
     @Throws(IOException::class, NullPointerException::class)
     abstract fun disableNetwork(disable: Boolean)
+    @JvmSynthetic
     abstract fun getBroadcastLogger(clazz: Class<*>): BroadcastLogger
+    @JvmSynthetic
     abstract fun hasNetworkConnectivity(): Boolean
+    @JvmSynthetic
     abstract fun hasControlConnection(): Boolean
+    @JvmSynthetic
     abstract fun isTorOff(): Boolean
+    @JvmSynthetic
     abstract fun isTorOn(): Boolean
+    @JvmSynthetic
     abstract fun refreshBroadcastLoggersHasDebugLogsVar()
+    @JvmSynthetic
     @WorkerThread
     abstract fun signalControlConnection(torControlCommand: String): Boolean
+    @JvmSynthetic
     @WorkerThread
     abstract suspend fun signalNewNym()
+    @JvmSynthetic
     @WorkerThread
     abstract suspend fun startTor()
+    @JvmSynthetic
     @WorkerThread
     abstract suspend fun stopTor()
 
@@ -393,7 +454,7 @@ internal abstract class BaseService: Service() {
     //  Background manager
     private fun registerPrefsListener() {
         torServicePrefsListener?.unregister()
-        torServicePrefsListener = TorServicePrefsListener(this)
+        torServicePrefsListener = TorServicePrefsListener.instantiate(this)
     }
     private fun unregisterPrefsListener() {
         torServicePrefsListener?.unregister()
@@ -414,7 +475,7 @@ internal abstract class BaseService: Service() {
         TorServiceController.serviceExecutionHooks?.let { hooks ->
             getScopeDefault().launch {
                 try {
-                    hooks.executeOnCreateTorService(context.applicationContext)
+                    hooks.executeOnCreateTorService(getContext().applicationContext)
                 } catch (e: Exception) {
                     TorServiceController.appEventBroadcaster?.broadcastException(
                         "${BroadcastType.EXCEPTION}|" +
@@ -442,9 +503,9 @@ internal abstract class BaseService: Service() {
      * */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.action == ServiceActionName.START) {
-            processServiceAction(ServiceAction.Start())
+            processServiceAction(ServiceAction.Start.instantiate())
         } else {
-            processServiceAction(ServiceAction.Start(updateLastServiceAction = false))
+            processServiceAction(ServiceAction.Start.instantiate(updateLastServiceAction = false))
         }
 
         return START_NOT_STICKY
@@ -463,7 +524,7 @@ internal abstract class BaseService: Service() {
 
         // Shutdown Tor and stop the Service.
         if (stopServiceOnTaskRemoved) {
-            processServiceAction(ServiceAction.Stop(updateLastServiceAction = false))
+            processServiceAction(ServiceAction.Stop.instantiate(updateLastServiceAction = false))
         }
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -97,8 +97,7 @@ import java.lang.reflect.InvocationTargetException
 internal class TorService internal constructor(): BaseService() {
 
     @JvmSynthetic
-    override fun getContext(): Context =
-        this
+    override fun getContext(): Context = this
 
 
     ///////////////

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceAction.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceAction.kt
@@ -107,6 +107,7 @@ internal sealed class ServiceAction {
      *
      * @return The 0th element within [delayLengthQueue], or 0L if empty
      * */
+    @JvmSynthetic
     fun consumeDelayLength(): Long =
         if (delayLengthQueue.isNotEmpty())
             delayLengthQueue.removeAt(0)
@@ -123,10 +124,19 @@ internal sealed class ServiceAction {
      * */
     open val updateLastAction: Boolean = true
 
-    class SetDisableNetwork(
+    internal class SetDisableNetwork private constructor(
         override val name: String,
         updateLastServiceAction: Boolean = false
     ): ServiceAction() {
+
+        companion object {
+            @JvmSynthetic
+            fun instantiate(
+                name: String,
+                updateLastServiceAction: Boolean = false
+            ): SetDisableNetwork =
+                SetDisableNetwork(name, updateLastServiceAction)
+        }
 
         override val commands: Array<String>
             get() = when (name) {
@@ -149,12 +159,18 @@ internal sealed class ServiceAction {
             }
 
 
-        override val delayLengthQueue = mutableListOf(ServiceActionProcessor.disableNetworkDelay)
+        override val delayLengthQueue = mutableListOf(ServiceActionProcessor.getDisableNetworkDelay())
 
         override val updateLastAction: Boolean = updateLastServiceAction
     }
 
-    class NewId: ServiceAction() {
+    internal class NewId private constructor(): ServiceAction() {
+
+        companion object {
+            @JvmSynthetic
+            fun instantiate(): NewId =
+                NewId()
+        }
 
         @ServiceActionName
         override val name: String = ServiceActionName.NEW_ID
@@ -165,7 +181,13 @@ internal sealed class ServiceAction {
             )
     }
 
-    class RestartTor: ServiceAction() {
+    internal class RestartTor private constructor(): ServiceAction() {
+
+        companion object {
+            @JvmSynthetic
+            fun instantiate(): RestartTor =
+                RestartTor()
+        }
 
         @ServiceActionName
         override val name: String = ServiceActionName.RESTART_TOR
@@ -177,10 +199,18 @@ internal sealed class ServiceAction {
                 ServiceActionCommand.START_TOR
             )
 
-        override val delayLengthQueue = mutableListOf(ServiceActionProcessor.restartTorDelayTime)
+        override val delayLengthQueue = mutableListOf(ServiceActionProcessor.getRestartTorDelayTime())
     }
 
-    class Start(updateLastServiceAction: Boolean = true): ServiceAction() {
+    internal class Start private constructor(
+        updateLastServiceAction: Boolean = true
+    ): ServiceAction() {
+
+        companion object {
+            @JvmSynthetic
+            fun instantiate(updateLastServiceAction: Boolean = true): Start =
+                Start(updateLastServiceAction)
+        }
 
         @ServiceActionName
         override val name: String = ServiceActionName.START
@@ -193,7 +223,15 @@ internal sealed class ServiceAction {
         override val updateLastAction: Boolean = updateLastServiceAction
     }
 
-    class Stop(updateLastServiceAction: Boolean = true): ServiceAction() {
+    internal class Stop private constructor(
+        updateLastServiceAction: Boolean = true
+    ): ServiceAction() {
+
+        companion object {
+            @JvmSynthetic
+            fun instantiate(updateLastServiceAction: Boolean = true): Stop =
+                Stop(updateLastServiceAction)
+        }
 
         @ServiceActionName
         override val name: String = ServiceActionName.STOP
@@ -205,7 +243,7 @@ internal sealed class ServiceAction {
                 ServiceActionCommand.STOP_SERVICE
             )
 
-        override val delayLengthQueue = mutableListOf(ServiceActionProcessor.stopServiceDelayTime)
+        override val delayLengthQueue = mutableListOf(ServiceActionProcessor.getStopServiceDelayTime())
 
         override val updateLastAction: Boolean = updateLastServiceAction
     }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/BaseServiceBinder.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/BaseServiceBinder.kt
@@ -82,14 +82,18 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 
-internal abstract class BaseServiceBinder(private val torService: BaseService): Binder() {
+internal abstract class BaseServiceBinder internal constructor(
+    private val torService: BaseService
+): Binder() {
 
+    @JvmSynthetic
     abstract fun getTorService(): BaseService?
 
     /**
      * Accepts all [ServiceAction] except [ServiceAction.Start], which gets issued via
      * [io.matthewnelson.topl_service.service.TorService.onStartCommand].
      * */
+    @JvmSynthetic
     fun submitServiceAction(serviceAction: ServiceAction) {
         if (serviceAction is ServiceAction.Start) return
         torService.processServiceAction(serviceAction)
@@ -112,6 +116,7 @@ internal abstract class BaseServiceBinder(private val torService: BaseService): 
      * @param [policy] The [BackgroundPolicy] to be executed
      * @param [executionDelay] the time expressed in your [BackgroundManager.Builder.Policy]
      * */
+    @JvmSynthetic
     fun executeBackgroundPolicyJob(@BackgroundPolicy policy: String, executionDelay: Long) {
         cancelExecuteBackgroundPolicyJob()
         backgroundPolicyExecutionJob = torService.getScopeMain().launch {
@@ -124,7 +129,7 @@ internal abstract class BaseServiceBinder(private val torService: BaseService): 
                     delay(executionDelay)
                     bgMgrBroadcastLogger.debug("Executing background management policy")
                     torService.processServiceAction(
-                        ServiceAction.Stop(updateLastServiceAction = false)
+                        ServiceAction.Stop.instantiate(updateLastServiceAction = false)
                     )
                 }
             }
@@ -134,6 +139,7 @@ internal abstract class BaseServiceBinder(private val torService: BaseService): 
     /**
      * Cancels the coroutine executing the [BackgroundPolicy] if it is active.
      * */
+    @JvmSynthetic
     fun cancelExecuteBackgroundPolicyJob() {
         backgroundPolicyExecutionJob?.let {
             if (it.isActive) {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/TorServiceBinder.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/TorServiceBinder.kt
@@ -74,11 +74,20 @@ package io.matthewnelson.topl_service.service.components.binding
 import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.service.TorService
 
-internal class TorServiceBinder(torService: TorService): BaseServiceBinder(torService) {
+internal class TorServiceBinder private constructor(
+    torService: TorService
+): BaseServiceBinder(torService) {
+
+    companion object {
+        @JvmSynthetic
+        fun instantiate(torService: TorService): TorServiceBinder =
+            TorServiceBinder(torService)
+    }
 
     /**
      * Always return null in production.
      * */
+    @JvmSynthetic
     override fun getTorService(): BaseService? {
         return null
     }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/TorServiceConnection.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/TorServiceConnection.kt
@@ -99,7 +99,7 @@ internal class TorServiceConnection private constructor(): ServiceConnection {
      * suggests.
      * */
     @JvmSynthetic
-    internal fun clearServiceBinderReference() {
+    fun clearServiceBinderReference() {
         serviceBinder = null
     }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/TorServiceConnection.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/TorServiceConnection.kt
@@ -75,16 +75,22 @@ import android.content.ComponentName
 import android.content.ServiceConnection
 import android.os.IBinder
 
-internal class TorServiceConnection: ServiceConnection {
+internal class TorServiceConnection private constructor(): ServiceConnection {
 
     companion object {
-        val torServiceConnection by lazy {
+        private val torServiceConnection by lazy {
             TorServiceConnection()
         }
 
+        @JvmSynthetic
+        internal fun getTorServiceConnection(): TorServiceConnection =
+            torServiceConnection
+
         @Volatile
-        var serviceBinder: BaseServiceBinder? = null
-            private set
+        private var serviceBinder: BaseServiceBinder? = null
+        @JvmSynthetic
+        fun getServiceBinder(): BaseServiceBinder? =
+            serviceBinder
     }
 
     /**
@@ -92,7 +98,8 @@ internal class TorServiceConnection: ServiceConnection {
      * [onServiceDisconnected] is not always called on disconnect, as the name
      * suggests.
      * */
-    fun clearServiceBinderReference() {
+    @JvmSynthetic
+    internal fun clearServiceBinderReference() {
         serviceBinder = null
     }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
@@ -97,7 +97,15 @@ import net.freehaven.tor.control.TorControlCommands
  *
  * @param [torService] [BaseService] for context.
  * */
-internal class ServiceEventBroadcaster(private val torService: BaseService): EventBroadcaster() {
+internal class ServiceEventBroadcaster private constructor(
+    private val torService: BaseService
+): EventBroadcaster() {
+
+    companion object {
+        @JvmSynthetic
+        fun instantiate(torService: BaseService): ServiceEventBroadcaster =
+            ServiceEventBroadcaster(torService)
+    }
 
     private val scopeMain: CoroutineScope
         get() = torService.getScopeMain()

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventListener.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventListener.kt
@@ -79,7 +79,13 @@ import net.freehaven.tor.control.TorControlCommands
  * [io.matthewnelson.topl_core.OnionProxyManager.start] method such that messages from
  * Tor get funneled here. They get modify as needed, then shipped to it's final destination.
  * */
-internal class ServiceEventListener: BaseEventListener() {
+internal class ServiceEventListener private constructor(): BaseEventListener() {
+
+    companion object {
+        @JvmSynthetic
+        fun instantiate(): ServiceEventListener =
+            ServiceEventListener()
+    }
 
     // broadcastLogger is available from BaseEventListener and is instantiated as soon as
     // OnionProxyManager gets initialized.

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorInstaller.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorInstaller.kt
@@ -103,8 +103,6 @@ internal class ServiceTorInstaller private constructor(
     private val torConfigFiles: TorConfigFiles
         get() = TorServiceController.getTorConfigFiles()
 
-    private val torServicePrefs by lazy { TorServicePrefs(torService.getContext()) }
-    private val localPrefs by lazy { BaseService.getLocalPrefs(torService.getContext()) }
     private var geoIpFileCopied = false
     private var geoIpv6FileCopied = false
 
@@ -125,6 +123,8 @@ internal class ServiceTorInstaller private constructor(
         if (!torConfigFiles.v3AuthPrivateDir.exists()) {
             torConfigFiles.v3AuthPrivateDir.mkdirs()
         }
+
+        val localPrefs = BaseService.getLocalPrefs(torService.getContext())
 
         // If the app version has been increased, or if this is a debug build, copy over
         // geoip assets then update SharedPreferences with the new version code. This
@@ -183,8 +183,10 @@ internal class ServiceTorInstaller private constructor(
             If length is greater than 9, then we know this is a custom bridge
         * */
         // TODO: Completely refactor how bridges work.
-        val userDefinedBridgeList: String =
-            torServicePrefs.getList(PrefKeyList.USER_DEFINED_BRIDGES, arrayListOf()).joinToString()
+        val userDefinedBridgeList: String = TorServicePrefs(torService.getContext())
+            .getList(PrefKeyList.USER_DEFINED_BRIDGES, arrayListOf())
+            .joinToString()
+
         var bridgeType = (if (userDefinedBridgeList.length > 9) 1 else 0).toByte()
         // Terrible hack. Must keep in sync with topl::addBridgesFromResources.
         if (bridgeType.toInt() == 0) {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorSettings.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorSettings.kt
@@ -80,10 +80,19 @@ import io.matthewnelson.topl_service_base.BaseServiceConsts.PrefKeyBoolean
 import io.matthewnelson.topl_service_base.BaseServiceTorSettings
 import io.matthewnelson.topl_service_base.TorServicePrefs
 
-internal class ServiceTorSettings(
+internal class ServiceTorSettings private constructor(
     servicePrefs: TorServicePrefs,
     defaultTorSettings: ApplicationDefaultTorSettings
 ): BaseServiceTorSettings(servicePrefs, defaultTorSettings) {
+
+    companion object {
+        @JvmSynthetic
+        fun instantiate(
+            servicePrefs: TorServicePrefs,
+            defaultTorSettings: ApplicationDefaultTorSettings
+        ): ServiceTorSettings =
+            ServiceTorSettings(servicePrefs, defaultTorSettings)
+    }
 
     @WorkerThread
     override fun dormantClientTimeoutSave(minutes: Int?) {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
@@ -113,13 +113,13 @@ internal class TorServiceReceiver private constructor(
         @Volatile
         private var isRegistered = false
         @JvmSynthetic
-        internal fun isRegistered(): Boolean =
+        fun isRegistered(): Boolean =
             isRegistered
 
         @Volatile
         private var deviceIsLocked: Boolean? = null
         @JvmSynthetic
-        internal fun deviceIsLocked(): Boolean? =
+        fun deviceIsLocked(): Boolean? =
             deviceIsLocked
     }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
@@ -118,12 +118,18 @@ abstract class ServiceConsts: BaseServiceConsts() {
     internal annotation class ServiceActionCommand {
         companion object {
             private const val ACTION_COMMAND = "Command_"
-            const val DELAY = "${ACTION_COMMAND}DELAY"
-            const val NEW_ID = "${ACTION_COMMAND}NEW_ID"
-            const val SET_DISABLE_NETWORK = "${ACTION_COMMAND}SET_DISABLE_NETWORK"
-            const val START_TOR = "${ACTION_COMMAND}START_TOR"
-            const val STOP_SERVICE = "${ACTION_COMMAND}STOP_SERVICE"
-            const val STOP_TOR = "${ACTION_COMMAND}STOP_TOR"
+            @JvmSynthetic
+            internal const val DELAY = "${ACTION_COMMAND}DELAY"
+            @JvmSynthetic
+            internal const val NEW_ID = "${ACTION_COMMAND}NEW_ID"
+            @JvmSynthetic
+            internal const val SET_DISABLE_NETWORK = "${ACTION_COMMAND}SET_DISABLE_NETWORK"
+            @JvmSynthetic
+            internal const val START_TOR = "${ACTION_COMMAND}START_TOR"
+            @JvmSynthetic
+            internal const val STOP_SERVICE = "${ACTION_COMMAND}STOP_SERVICE"
+            @JvmSynthetic
+            internal const val STOP_TOR = "${ACTION_COMMAND}STOP_TOR"
         }
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
@@ -118,18 +118,12 @@ abstract class ServiceConsts: BaseServiceConsts() {
     internal annotation class ServiceActionCommand {
         companion object {
             private const val ACTION_COMMAND = "Command_"
-            @JvmSynthetic
-            internal const val DELAY = "${ACTION_COMMAND}DELAY"
-            @JvmSynthetic
-            internal const val NEW_ID = "${ACTION_COMMAND}NEW_ID"
-            @JvmSynthetic
-            internal const val SET_DISABLE_NETWORK = "${ACTION_COMMAND}SET_DISABLE_NETWORK"
-            @JvmSynthetic
-            internal const val START_TOR = "${ACTION_COMMAND}START_TOR"
-            @JvmSynthetic
-            internal const val STOP_SERVICE = "${ACTION_COMMAND}STOP_SERVICE"
-            @JvmSynthetic
-            internal const val STOP_TOR = "${ACTION_COMMAND}STOP_TOR"
+            const val DELAY = "${ACTION_COMMAND}DELAY"
+            const val NEW_ID = "${ACTION_COMMAND}NEW_ID"
+            const val SET_DISABLE_NETWORK = "${ACTION_COMMAND}SET_DISABLE_NETWORK"
+            const val START_TOR = "${ACTION_COMMAND}START_TOR"
+            const val STOP_SERVICE = "${ACTION_COMMAND}STOP_SERVICE"
+            const val STOP_TOR = "${ACTION_COMMAND}STOP_TOR"
         }
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/V3ClientAuthManager.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/V3ClientAuthManager.kt
@@ -85,9 +85,15 @@ import java.io.File
  * Use [io.matthewnelson.topl_service.TorServiceController.getV3ClientAuthManager] to
  * instantiate an instance of the Manager.
  * */
-internal class V3ClientAuthManager(
+internal class V3ClientAuthManager private constructor(
     private val torConfigFiles: TorConfigFiles
 ): BaseV3ClientAuthManager() {
+
+    companion object {
+        @JvmSynthetic
+        fun instantiate(torConfigFiles: TorConfigFiles): V3ClientAuthManager =
+            V3ClientAuthManager(torConfigFiles)
+    }
 
     ///////////////////////////////////
     /// Add v3 Client Authorization ///

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
@@ -82,11 +82,9 @@ import io.matthewnelson.topl_core.broadcaster.BroadcastLogger
 import io.matthewnelson.topl_core_base.BaseConsts.TorNetworkState
 import io.matthewnelson.topl_core_base.BaseConsts.TorState
 import io.matthewnelson.topl_service.TorServiceController
-import io.matthewnelson.topl_service_base.TorServicePrefs
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceEventBroadcaster
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceEventListener
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorInstaller
-import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
 import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.service.components.actions.ServiceActionProcessor
 import io.matthewnelson.topl_service.service.components.receiver.TorServiceReceiver
@@ -99,9 +97,13 @@ import java.io.IOException
 import java.lang.reflect.InvocationTargetException
 
 internal class TestTorService(
-    override val context: Context,
+    private val context: Context,
     dispatcher: CoroutineDispatcher
 ): BaseService() {
+
+    override fun getContext(): Context {
+        return context
+    }
 
 
     ///////////////
@@ -113,7 +115,7 @@ internal class TestTorService(
 
     override fun unbindTorService() {
         try {
-            unbindService(context)
+            unbindService(getContext())
         } catch (e: IllegalArgumentException) {}
     }
     override fun onBind(intent: Intent?): IBinder? {
@@ -125,7 +127,7 @@ internal class TestTorService(
     /// BroadcastReceiver ///
     /////////////////////////
     val torServiceReceiver by lazy {
-        TorServiceReceiver(this)
+        TorServiceReceiver.instantiate(this)
     }
     override fun registerReceiver() {
         torServiceReceiver.register()
@@ -180,20 +182,20 @@ internal class TestTorService(
         getBroadcastLogger(TestTorService::class.java)
     }
     val serviceEventBroadcaster: ServiceEventBroadcaster by lazy {
-        ServiceEventBroadcaster(this)
+        ServiceEventBroadcaster.instantiate(this)
     }
     val serviceTorSettings: BaseServiceTorSettings by lazy {
         TorServiceController.getServiceTorSettings()
     }
     val onionProxyManager: OnionProxyManager by lazy {
         OnionProxyManager(
-            context,
+            getContext(),
             TorServiceController.getTorConfigFiles(),
-            ServiceTorInstaller(this),
+            ServiceTorInstaller.instantiate(this),
             serviceTorSettings,
-            ServiceEventListener(),
+            ServiceEventListener.instantiate(),
             serviceEventBroadcaster,
-            buildConfigDebug
+            getBuildConfigDebug()
         )
     }
 

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
@@ -150,10 +150,10 @@ internal class TorServiceControllerUnitTest {
     @Test
     fun `_z_ensure builder methods properly initialize variables when build called`() {
         // Hasn't been initialized yet
-        assertEquals(BuildConfig.DEBUG, BaseService.buildConfigDebug)
+        assertEquals(BuildConfig.DEBUG, BaseService.getBuildConfigDebug())
         assertNull(TorServiceController.appEventBroadcaster)
-        val initialRestartTorDelay = ServiceActionProcessor.restartTorDelayTime
-        val initialStopServiceDelay = ServiceActionProcessor.stopServiceDelayTime
+        val initialRestartTorDelay = ServiceActionProcessor.getRestartTorDelayTime()
+        val initialStopServiceDelay = ServiceActionProcessor.getStopServiceDelayTime()
 
         val timeToAdd = 300L
 
@@ -165,9 +165,9 @@ internal class TorServiceControllerUnitTest {
             .setEventBroadcaster(TestEventBroadcaster())
             .build()
 
-        assertEquals(ServiceActionProcessor.restartTorDelayTime, initialRestartTorDelay + timeToAdd)
-        assertEquals(ServiceActionProcessor.stopServiceDelayTime, initialStopServiceDelay + timeToAdd)
-        assertEquals(BaseService.buildConfigDebug, !BuildConfig.DEBUG)
+        assertEquals(ServiceActionProcessor.getRestartTorDelayTime(), initialRestartTorDelay + timeToAdd)
+        assertEquals(ServiceActionProcessor.getStopServiceDelayTime(), initialStopServiceDelay + timeToAdd)
+        assertEquals(BaseService.getBuildConfigDebug(), !BuildConfig.DEBUG)
         assertNotNull(TorServiceController.appEventBroadcaster)
     }
 
@@ -175,12 +175,12 @@ internal class TorServiceControllerUnitTest {
     fun `_zz_ensure one-time initialization if build called more than once`() {
         try {
             TorServiceController.getDefaultTorSettings()
-            assertNotNull(BaseService.buildConfigDebug)
+            assertNotNull(BaseService.getBuildConfigDebug())
             // build has been called in a previous test
         } catch (e: RuntimeException) {
-            assertNull(BaseService.buildConfigDebug)
+            assertNull(BaseService.getBuildConfigDebug())
             getNewControllerBuilder().build()
-            assertNotNull(BaseService.buildConfigDebug)
+            assertNotNull(BaseService.getBuildConfigDebug())
         }
 
         val initialHashCode = TorServiceController.getDefaultTorSettings().hashCode()

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/service/TorServiceUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/service/TorServiceUnitTest.kt
@@ -130,7 +130,7 @@ internal class TorServiceUnitTest {
     private val serviceEventBroadcaster: ServiceEventBroadcaster
         get() = testTorService.serviceEventBroadcaster
     private val serviceNotification: ServiceNotification
-        get() = ServiceNotification.serviceNotification
+        get() = ServiceNotification.getServiceNotification()
 
     private val testDispatcher = TestCoroutineDispatcher()
 
@@ -175,7 +175,7 @@ internal class TorServiceUnitTest {
         )
         BaseService.startService(app, TestTorService::class.java)
         assertEquals(shadowOf(app).nextStartedService.action, ServiceActionName.START)
-        assertNotNull(TorServiceConnection.serviceBinder)
+        assertNotNull(TorServiceConnection.getServiceBinder())
 
         // Simulate startup
         testTorService.onCreate()
@@ -227,13 +227,13 @@ internal class TorServiceUnitTest {
         var statePair = testTorService.getSimulatedTorStates()
         assertEquals(TorState.STARTING, statePair.first)
         assertEquals(TorNetworkState.DISABLED, statePair.second)
-        assertEquals(TorState.STARTING, serviceNotification.currentContentTitle)
+        assertEquals(TorState.STARTING, serviceNotification.getCurrentContentTitle())
         delay(1000)
 
         statePair = testTorService.getSimulatedTorStates()
         assertEquals(TorState.ON, statePair.first)
         assertEquals(TorNetworkState.DISABLED, statePair.second)
-        assertEquals(TorState.ON, serviceNotification.currentContentTitle)
+        assertEquals(TorState.ON, serviceNotification.getCurrentContentTitle())
         delay(1000)
 
         // Ensure ServiceActionProcessor started Tor, messages broadcast properly,
@@ -241,31 +241,31 @@ internal class TorServiceUnitTest {
         statePair = testTorService.getSimulatedTorStates()
         assertEquals(TorState.ON, statePair.first)
         assertEquals(TorNetworkState.ENABLED, statePair.second)
-        assertEquals(TorState.ON, serviceNotification.currentContentTitle)
+        assertEquals(TorState.ON, serviceNotification.getCurrentContentTitle())
 
         // Waiting to Bootstrap
-        assertEquals(true, serviceNotification.progressBarShown)
-        assertEquals(serviceNotification.imageNetworkDisabled, serviceNotification.currentIcon)
+        assertEquals(true, serviceNotification.getProgressBarShown())
+        assertEquals(serviceNotification.imageNetworkDisabled, serviceNotification.getCurrentIcon())
         delay(1000)
 
         // Bootstrapped
-        assertEquals("Bootstrapped 95%", serviceNotification.currentContentText)
+        assertEquals("Bootstrapped 95%", serviceNotification.getCurrentContentText())
         delay(1000)
 
-        assertEquals("Bootstrapped 100%", serviceNotification.currentContentText)
-        assertEquals(false, serviceNotification.progressBarShown)
-        assertEquals(serviceNotification.imageNetworkEnabled, serviceNotification.currentIcon)
+        assertEquals("Bootstrapped 100%", serviceNotification.getCurrentContentText())
+        assertEquals(false, serviceNotification.getProgressBarShown())
+        assertEquals(serviceNotification.imageNetworkEnabled, serviceNotification.getCurrentIcon())
         delay(1000)
 
         // Data transfer
         val bandwidth = testTorService.bandwidth1000
         val contentTextString =
             ServiceUtilities.getFormattedBandwidthString(bandwidth.toLong(), bandwidth.toLong())
-        assertEquals(contentTextString, serviceNotification.currentContentText)
-        assertEquals(serviceNotification.imageDataTransfer, serviceNotification.currentIcon)
+        assertEquals(contentTextString, serviceNotification.getCurrentContentText())
+        assertEquals(serviceNotification.imageDataTransfer, serviceNotification.getCurrentIcon())
         delay(1000)
 
-        assertEquals(serviceNotification.imageNetworkEnabled, serviceNotification.currentIcon)
+        assertEquals(serviceNotification.imageNetworkEnabled, serviceNotification.getCurrentIcon())
         delay(1000)
 
         // Ensure Receivers were registered
@@ -273,7 +273,7 @@ internal class TorServiceUnitTest {
             // Registered with the system
             assertEquals(testTorService.torServiceReceiver, it.broadcastReceiver)
             // Boolean value is correct
-            assertEquals(true, TorServiceReceiver.isRegistered)
+            assertEquals(true, TorServiceReceiver.isRegistered())
         }
 
         // Test TorServicePrefsListener is working (will refresh Loggers if tor is _not_ off)
@@ -295,20 +295,20 @@ internal class TorServiceUnitTest {
         var statePair = testTorService.getSimulatedTorStates()
         assertEquals(TorState.STOPPING, statePair.first)
         assertEquals(TorNetworkState.ENABLED, statePair.second)
-        assertEquals(TorState.STOPPING, serviceNotification.currentContentTitle)
-        assertEquals("Stopping Service...", serviceNotification.currentContentText)
+        assertEquals(TorState.STOPPING, serviceNotification.getCurrentContentTitle())
+        assertEquals("Stopping Service...", serviceNotification.getCurrentContentText())
         delay(1000)
 
         statePair = testTorService.getSimulatedTorStates()
         assertEquals(TorState.STOPPING, statePair.first)
         assertEquals(TorNetworkState.DISABLED, statePair.second)
-        assertEquals(TorState.STOPPING, serviceNotification.currentContentTitle)
+        assertEquals(TorState.STOPPING, serviceNotification.getCurrentContentTitle())
         delay(1000)
 
         statePair = testTorService.getSimulatedTorStates()
         assertEquals(TorState.OFF, statePair.first)
         assertEquals(TorNetworkState.DISABLED, statePair.second)
-        assertEquals(TorState.OFF, serviceNotification.currentContentTitle)
+        assertEquals(TorState.OFF, serviceNotification.getCurrentContentTitle())
         delay(1000)
 
         // Ensure Receivers were unregistered
@@ -316,7 +316,7 @@ internal class TorServiceUnitTest {
             // Registered with the system
             assertNull(it.broadcastReceiver)
             // Boolean value is correct
-            assertEquals(false, TorServiceReceiver.isRegistered)
+            assertEquals(false, TorServiceReceiver.isRegistered())
         }
 
         // Test TorServicePrefsListener is unregistered


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR refactors the `topl-service` and `topl-core` modules' visibility modifiers to prevent java projects from accessing class constructors/methods/variables marked as `internal`.

Fixes #100 

SNAPSHOT available by:
 - In your Application module’s build.gradle file, add the following (outside the android block):
```groovy
repositories {
    maven {
        url 'https://oss.sonatype.org/content/repositories/snapshots/'
    }
}
```

- In your Application module’s build.gradle file, add (or modify) the following in the dependencies block:
```groovy
def topl_android_version = "2.0.3e-SNAPSHOT"
implementation 'io.matthewnelson.topl-android:topl-service:$topl_android_version'
```