### PR TITLE
Add execution hook method for prior to stopping service

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=io.matthewnelson.topl-android
-VERSION_NAME=2.0.3e-SNAPSHOT
+VERSION_NAME=2.0.3f-SNAPSHOT
 
 # The trailing 2 digits are for `alpha##` releases. For example:
 #     4.4.1-alpha02 = 441102 where `102` stands for alpha02

--- a/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/ServiceExecutionHooks.kt
+++ b/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/ServiceExecutionHooks.kt
@@ -10,6 +10,9 @@ abstract class ServiceExecutionHooks {
     /**
      * Is executed from TorService.onCreate on Dispatchers.Default launched from
      * it's own coroutine.
+     *
+     * **NOTE**: Exceptions thrown from your implementation will be broadcast via
+     * the EventBroadcaster on Dispatchers.Main.
      * */
     open suspend fun executeOnCreateTorService(context: Context) {}
 
@@ -17,14 +20,14 @@ abstract class ServiceExecutionHooks {
      * Is executed from TorService.startTor on Dispatchers.IO
      *
      * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
-     * Flow or something) will inhibit the reset of the `startTor` method from
+     * Flow or something) will inhibit the rest of the `startTor` method from
      * executing; perform those tasks from [executeOnCreateTorService].
      *
-     * This is meant to provide synchronous execution prior to the
-     * start of Tor.
+     * This is meant to provide synchronous code execution prior to the
+     * start of Tor, and will be executed every single time Tor is started (even on restarts).
      *
      * **NOTE**: Exceptions thrown from your implementation will inhibit starting
-     * Tor and will be broadcast via the EventBroadcaster.
+     * Tor and will be broadcast via the EventBroadcaster on Dispatchers.Main.
      * */
     open suspend fun executeBeforeStartTor(context: Context) {}
 
@@ -32,11 +35,29 @@ abstract class ServiceExecutionHooks {
      * Is executed from TorService.stopTor on Dispatchers.IO
      *
      * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
-     * Flow or something) will inhibit the reset of the `stopTor` method from
+     * Flow or something) will inhibit the rest of the `stopTor` method from
      * executing; perform those tasks from [executeOnCreateTorService].
      *
-     * This is meant to provide synchronous execution of code after Tor has been
-     * stopped, prior to TorService being stopped.
+     * This is meant to provide synchronous code execution after Tor has been
+     * stopped, and will be executed every single time Tor is stopped (even on restarts).
+     *
+     * **NOTE**: Exceptions thrown from your implementation will be broadcast via
+     * the EventBroadcaster on Dispatchers.Main.
      * */
     open suspend fun executeAfterStopTor(context: Context) {}
+
+    /**
+     * Is executed from TorService.stopService on Dispatchers.IO
+     *
+     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
+     * Flow or something) will inhibit the rest of the `stopService` method from
+     * executing.
+     *
+     * This is meant to provide synchronous code execution prior to calling
+     * stopSelf() on the service.
+     *
+     * **NOTE**: Exceptions thrown from your implementation will be broadcast via
+     * the EventBroadcaster on Dispatchers.Main.
+     * */
+    open suspend fun executeBeforeStoppingService(context: Context) {}
 }

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
@@ -169,7 +169,7 @@ internal class TestTorService(
      * is simulated properly in that it will stop processing the queue and the Coroutine
      * Job will move to `complete`.
      * */
-    override fun stopService() {
+    override suspend fun stopService() {
         stopSelfCalled = true
         getScopeMain().launch { onDestroy() }
     }


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR:
 - Adds better documentation to the `ServiceExecutionHooks` class.
 - Adds a method for code execution prior to calling `stopSelf()` on the service
 - Ensures all exceptions are broadcast on Dispatchers.Main

SNAPSHOT available by:
 - In your Application module’s build.gradle file, add the following (outside the android block):
```groovy
repositories {
    maven {
        url 'https://oss.sonatype.org/content/repositories/snapshots/'
    }
}
```

- In your Application module’s build.gradle file, add (or modify) the following in the dependencies block:
```groovy
def topl_android_version = "2.0.3f-SNAPSHOT"
implementation 'io.matthewnelson.topl-android:topl-service:$topl_android_version'
```