### PR TITLE
Adds execution hook for on start command

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=io.matthewnelson.topl-android
-VERSION_NAME=2.0.3f-SNAPSHOT
+VERSION_NAME=2.0.3g-SNAPSHOT
 
 # The trailing 2 digits are for `alpha##` releases. For example:
 #     4.4.1-alpha02 = 441102 where `102` stands for alpha02

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyServiceExecutionHooks.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyServiceExecutionHooks.kt
@@ -1,13 +1,157 @@
 package io.matthewnelson.sampleapp.topl_android
 
 import android.content.Context
+import io.matthewnelson.topl_core_base.BaseConsts.BroadcastType
+import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service_base.ServiceExecutionHooks
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 
 class MyServiceExecutionHooks: ServiceExecutionHooks() {
 
-    override suspend fun executeOnCreateTorService(context: Context) {}
+    override suspend fun executeOnCreateTorService(context: Context) {
+        // Executed on Dispatchers.Default, so querying shared prefs has to switch
+        // context to IO.
+        withContext(Dispatchers.Main) {
+            TorServiceController.getServiceTorSettings()
+        }.let { settings ->
+            withContext(Dispatchers.IO) {
+                settings.hasDebugLogs
+            }.let { debugLogs ->
+                if (!debugLogs) {
+                    return
+                }
 
-    override suspend fun executeBeforeStartTor(context: Context) {}
+                withContext(Dispatchers.Main) {
+                    TorServiceController.appEventBroadcaster?.broadcastDebug(
+                        "${BroadcastType.DEBUG}|" +
+                                "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                                "onCreateTorService execution hook started"
+                    )
 
-    override suspend fun executeAfterStopTor(context: Context) {}
+                    delay(20_000L)
+
+                    TorServiceController.appEventBroadcaster?.broadcastDebug(
+                        "${BroadcastType.DEBUG}|" +
+                                "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                                "onCreateTorService execution hook completed"
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun executeOnStartCommandBeforeStartTor(context: Context) {
+        // Executed on Dispatchers.Default, so querying shared prefs has to switch
+        // context to IO.
+        withContext(Dispatchers.Main) {
+            TorServiceController.getServiceTorSettings()
+        }.let { settings ->
+            withContext(Dispatchers.IO) {
+                settings.hasDebugLogs
+            }.let { debugLogs ->
+                if (!debugLogs) {
+                    return
+                }
+
+                withContext(Dispatchers.Main) {
+                    TorServiceController.appEventBroadcaster?.broadcastDebug(
+                        "${BroadcastType.DEBUG}|" +
+                                "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                                "OnStartCommandBeforeStartTor execution hook started"
+                    )
+
+                    delay(1_000L)
+
+                    TorServiceController.appEventBroadcaster?.broadcastDebug(
+                        "${BroadcastType.DEBUG}|" +
+                                "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                                "OnStartCommandBeforeStartTor execution hook completed"
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun executeBeforeStartTor(context: Context) {
+        // Executed on Dispatchers.IO
+        withContext(Dispatchers.Main) {
+            TorServiceController.getServiceTorSettings()
+        }.let { settings ->
+            if (!settings.hasDebugLogs) {
+                return
+            }
+
+            withContext(Dispatchers.Main) {
+                TorServiceController.appEventBroadcaster?.broadcastDebug(
+                    "${BroadcastType.DEBUG}|" +
+                            "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                            "BeforeStartTor execution hook started"
+                )
+
+                delay(500L)
+
+                TorServiceController.appEventBroadcaster?.broadcastDebug(
+                    "${BroadcastType.DEBUG}|" +
+                            "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                            "BeforeStartTor execution hook completed"
+                )
+            }
+        }
+    }
+
+    override suspend fun executeAfterStopTor(context: Context) {
+        // Executed on Dispatchers.IO
+        withContext(Dispatchers.Main) {
+            TorServiceController.getServiceTorSettings()
+        }.let { settings ->
+            if (!settings.hasDebugLogs) {
+                return
+            }
+
+            withContext(Dispatchers.Main) {
+                TorServiceController.appEventBroadcaster?.broadcastDebug(
+                    "${BroadcastType.DEBUG}|" +
+                            "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                            "AfterStopTor execution hook started"
+                )
+
+                delay(500L)
+
+                TorServiceController.appEventBroadcaster?.broadcastDebug(
+                    "${BroadcastType.DEBUG}|" +
+                            "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                            "AfterStopTor execution hook completed"
+                )
+            }
+        }
+    }
+
+    override suspend fun executeBeforeStoppingService(context: Context) {
+        // Executed on Dispatchers.IO
+        withContext(Dispatchers.Main) {
+            TorServiceController.getServiceTorSettings()
+        }.let { settings ->
+            if (!settings.hasDebugLogs) {
+                return
+            }
+
+            withContext(Dispatchers.Main) {
+                TorServiceController.appEventBroadcaster?.broadcastDebug(
+                    "${BroadcastType.DEBUG}|" +
+                            "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                            "BeforeStoppingService execution hook started"
+                )
+
+                delay(2_000L)
+
+                TorServiceController.appEventBroadcaster?.broadcastDebug(
+                    "${BroadcastType.DEBUG}|" +
+                            "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                            "BeforeStoppingService execution hook completed"
+                )
+            }
+        }
+    }
 }

--- a/topl-service-base/build.gradle
+++ b/topl-service-base/build.gradle
@@ -46,6 +46,7 @@ dokka {
         includeNonPublic = false
         skipEmptyPackages = true
         samples = [
+                "$rootDir/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyServiceExecutionHooks.kt".toString(),
                 "$rootDir/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyEventBroadcaster.kt".toString()
         ]
         sourceLink {

--- a/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/ServiceExecutionHooks.kt
+++ b/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/ServiceExecutionHooks.kt
@@ -4,6 +4,8 @@ import android.content.Context
 
 /**
  * Set Hooks to be executed from TorService.
+ *
+ * @sample [io.matthewnelson.sampleapp.topl_android.MyServiceExecutionHooks]
  * */
 abstract class ServiceExecutionHooks {
 
@@ -13,51 +15,96 @@ abstract class ServiceExecutionHooks {
      *
      * **NOTE**: Exceptions thrown from your implementation will be broadcast via
      * the EventBroadcaster on Dispatchers.Main.
+     *
+     * @sample [io.matthewnelson.sampleapp.topl_android.MyServiceExecutionHooks.executeOnCreateTorService]
      * */
     open suspend fun executeOnCreateTorService(context: Context) {}
 
     /**
      * Is executed from TorService.startTor on Dispatchers.IO
      *
-     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
-     * Flow or something) will inhibit the rest of the `startTor` method from
-     * executing; perform those tasks from [executeOnCreateTorService].
-     *
      * This is meant to provide synchronous code execution prior to the
      * start of Tor, and will be executed every single time Tor is started (even on restarts).
      *
+     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
+     * Flow or something) will also indefinitely suspend the ServiceActionProcessor
+     * which will inhibit processing of any other commands; perform those tasks
+     * from [executeOnCreateTorService].
+     *
      * **NOTE**: Exceptions thrown from your implementation will inhibit starting
      * Tor and will be broadcast via the EventBroadcaster on Dispatchers.Main.
+     *
+     * @sample [io.matthewnelson.sampleapp.topl_android.MyServiceExecutionHooks.executeBeforeStartTor]
      * */
     open suspend fun executeBeforeStartTor(context: Context) {}
 
     /**
      * Is executed from TorService.stopTor on Dispatchers.IO
      *
-     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
-     * Flow or something) will inhibit the rest of the `stopTor` method from
-     * executing; perform those tasks from [executeOnCreateTorService].
-     *
      * This is meant to provide synchronous code execution after Tor has been
      * stopped, and will be executed every single time Tor is stopped (even on restarts).
      *
+     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
+     * Flow or something) will also indefinitely suspend the ServiceActionProcessor
+     * which will inhibit processing of any other commands; perform those tasks
+     * from [executeOnCreateTorService].
+     *
      * **NOTE**: Exceptions thrown from your implementation will be broadcast via
      * the EventBroadcaster on Dispatchers.Main.
+     *
+     * @sample [io.matthewnelson.sampleapp.topl_android.MyServiceExecutionHooks.executeAfterStopTor]
      * */
     open suspend fun executeAfterStopTor(context: Context) {}
 
     /**
      * Is executed from TorService.stopService on Dispatchers.IO
      *
-     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
-     * Flow or something) will inhibit the rest of the `stopService` method from
-     * executing.
-     *
      * This is meant to provide synchronous code execution prior to calling
-     * stopSelf() on the service.
+     * stopSelf() on the service. When this is called for execution,
+     * [executeOnStartCommandBeforeStartTor], will be allowed to execute again
+     * if TorServiceController.startTor() is called prior to this method's completion.
+     *
+     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
+     * Flow or something) will also indefinitely suspend the ServiceActionProcessor
+     * which will inhibit processing of any other commands; perform those tasks
+     * from [executeOnCreateTorService].
      *
      * **NOTE**: Exceptions thrown from your implementation will be broadcast via
      * the EventBroadcaster on Dispatchers.Main.
+     *
+     * @sample [io.matthewnelson.sampleapp.topl_android.MyServiceExecutionHooks.executeBeforeStoppingService]
      * */
     open suspend fun executeBeforeStoppingService(context: Context) {}
+
+    /**
+     * Is executed from TorService.onStartCommand on Dispatchers.Default. This works in
+     * conjunction with [executeBeforeStoppingService] such that if
+     * [executeBeforeStoppingService] is active, [executeOnStartCommandBeforeStartTor] will
+     * suspend until that has been completed, then execute, then start Tor.
+     *
+     * This is meant to provide quasi one-time synchronous code execution at first start of
+     * TorService, prior to starting Tor.
+     *
+     * Example usage:
+     *
+     *   If you want to query a DB for V3 Client Authorization Keys stored in
+     *   an encrypted fashion, write them to disk prior to first start of Tor, then in
+     *   [executeBeforeStoppingService] delete the private keys.
+     *
+     *   If the user (or some other process) executes TorServiceController.startTor()
+     *   while [executeBeforeStoppingService] is active, TorService.stopSelf() be prevented
+     *   from being called, execution of this method will suspend until
+     *   [executeBeforeStoppingService] completes, then execute, then Tor will be started again.
+     *
+     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
+     * Flow or something) will also indefinitely suspend the ServiceActionProcessor
+     * which will inhibit processing of any other commands; perform those tasks
+     * from [executeOnCreateTorService].
+     *
+     * **NOTE**: Exceptions thrown from your implementation will be broadcast via
+     * the EventBroadcaster on Dispatchers.Main.
+     *
+     * @sample [io.matthewnelson.sampleapp.topl_android.MyServiceExecutionHooks.executeOnStartCommandBeforeStartTor]
+     * */
+    open suspend fun executeOnStartCommandBeforeStartTor(context: Context) {}
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -94,10 +94,7 @@ import io.matthewnelson.topl_service.util.ServiceConsts.NotificationImage
 import io.matthewnelson.topl_service_base.ApplicationDefaultTorSettings
 import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceActionName
 import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceLifecycleEvent
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.*
 import java.io.File
 import java.io.IOException
 
@@ -339,10 +336,22 @@ internal abstract class BaseService internal constructor(): Service() {
     fun processServiceAction(serviceAction: ServiceAction) {
         serviceActionProcessor.processServiceAction(serviceAction)
     }
+
+    @Volatile
+    private var stopServiceExecutionHookJob: Job? = null
     @JvmSynthetic
     open suspend fun stopService() {
+        // TODO: Need to synchronize with onStartCommand execution hook b/c if the service
+        //  is re-bound before this is completed, stopSelf() won't fire. Maybe just set the
+        //  onStartcommand job to null so that if startservice is called that it will be again?
+        onStartCommandExecutionHookJob = null
         TorServiceController.serviceExecutionHooks?.let { hooks ->
             try {
+                stopServiceExecutionHookJob = getScopeMain().launch {
+                    while (currentCoroutineContext().isActive) {
+                        delay(50L)
+                    }
+                }
                 hooks.executeBeforeStoppingService(getContext().applicationContext)
             } catch (e: Exception) {
                 TorServiceController.appEventBroadcaster?.let { broadcaster ->
@@ -355,9 +364,14 @@ internal abstract class BaseService internal constructor(): Service() {
                         )
                     }
                 }
+            } finally {
+                stopServiceExecutionHookJob?.cancel()
             }
         }
-        stopSelf()
+
+        if (onStartCommandExecutionHookJob == null) {
+            stopSelf()
+        }
     }
 
 
@@ -514,6 +528,13 @@ internal abstract class BaseService internal constructor(): Service() {
         unregisterPrefsListener()
     }
 
+    @Volatile
+    private var onStartCommandExecutionHookJob: Job? = null
+    @JvmSynthetic
+    open fun getOnStartCommandExecutionHookJob(): Job? {
+        return onStartCommandExecutionHookJob
+    }
+
     /**
      * No matter what Intent comes in, it starts Tor. If the Intent comes with no Action,
      * it will not update [ServiceActionProcessor.lastServiceAction].
@@ -521,6 +542,33 @@ internal abstract class BaseService internal constructor(): Service() {
      * @see [Companion.startService]
      * */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (onStartCommandExecutionHookJob == null) {
+            TorServiceController.serviceExecutionHooks?.let { hooks ->
+                onStartCommandExecutionHookJob = getScopeDefault().launch {
+                    // slight delay needed here before joining of stopService job b/c
+                    // onStartCommand job gets set to null outside/before launching of the
+                    // stopService Job (necessary for immediate user responsiveness).
+                    delay(50L)
+                    stopServiceExecutionHookJob?.join()
+
+                    try {
+                        hooks.executeOnStartCommandBeforeStartTor(getContext().applicationContext)
+                    } catch (e: Exception) {
+                        TorServiceController.appEventBroadcaster?.let { broadcaster ->
+                            withContext(Dispatchers.Main) {
+                                broadcaster.broadcastException(
+                                    "${BroadcastType.EXCEPTION}|" +
+                                            "${this@BaseService.javaClass.simpleName}|" +
+                                            "${e.message}",
+                                    e
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         if (intent?.action == ServiceActionName.START) {
             processServiceAction(ServiceAction.Start.instantiate())
         } else {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -341,9 +341,6 @@ internal abstract class BaseService internal constructor(): Service() {
     private var stopServiceExecutionHookJob: Job? = null
     @JvmSynthetic
     open suspend fun stopService() {
-        // TODO: Need to synchronize with onStartCommand execution hook b/c if the service
-        //  is re-bound before this is completed, stopSelf() won't fire. Maybe just set the
-        //  onStartcommand job to null so that if startservice is called that it will be again?
         onStartCommandExecutionHookJob = null
         TorServiceController.serviceExecutionHooks?.let { hooks ->
             try {
@@ -531,8 +528,8 @@ internal abstract class BaseService internal constructor(): Service() {
     @Volatile
     private var onStartCommandExecutionHookJob: Job? = null
     @JvmSynthetic
-    open fun getOnStartCommandExecutionHookJob(): Job? {
-        return onStartCommandExecutionHookJob
+    open suspend fun joinOnStartCommandExecutionHookJob() {
+        onStartCommandExecutionHookJob?.join()
     }
 
     /**

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
@@ -261,7 +261,7 @@ internal class ServiceActionProcessor private constructor(
             broadcastDebugMsgWithObjectDetails("Processing Queue: ", this)
 
             while (actionQueue.isNotEmpty() && isActive) {
-                torService.getOnStartCommandExecutionHookJob()?.join()
+                torService.joinOnStartCommandExecutionHookJob()
                 val serviceAction = getActionQueueElementAtOrNull()
                 if (serviceAction == null) {
                     return@launch

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
@@ -261,6 +261,7 @@ internal class ServiceActionProcessor private constructor(
             broadcastDebugMsgWithObjectDetails("Processing Queue: ", this)
 
             while (actionQueue.isNotEmpty() && isActive) {
+                torService.getOnStartCommandExecutionHookJob()?.join()
                 val serviceAction = getActionQueueElementAtOrNull()
                 if (serviceAction == null) {
                     return@launch


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR adds an additional ServiceExecutionHook method. It will be executed once at first start of `TorService`, and works in conjunction with the `BeforeStopService` execution hook to enable responsive reaction to user input for start/stop operations.

SNAPSHOT available by:
 - In your Application module’s build.gradle file, add the following (outside the android block):
```groovy
repositories {
    maven {
        url 'https://oss.sonatype.org/content/repositories/snapshots/'
    }
}
```

- In your Application module’s build.gradle file, add (or modify) the following in the dependencies block:
```groovy
def topl_android_version = "2.0.3g-SNAPSHOT"
implementation 'io.matthewnelson.topl-android:topl-service:$topl_android_version'
```