### PR TITLE
BugFix: Duplicate v3 Auth Private File Content

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=io.matthewnelson.topl-android
-VERSION_NAME=2.0.3g-SNAPSHOT
+VERSION_NAME=2.0.3h-SNAPSHOT
 
 # The trailing 2 digits are for `alpha##` releases. For example:
 #     4.4.1-alpha02 = 441102 where `102` stands for alpha02

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
@@ -110,7 +110,8 @@ object OnionAuthUtilities {
      *
      * @return The File if it was created properly, `null` if it was not
      * @throws [IllegalArgumentException] If passed arguments are not compliant with the spec
-     * @throws [IllegalStateException] If the file already exists (and must be deleted before overwriting)
+     * @throws [IllegalStateException] If the file already exists (and must be deleted before
+     *   overwriting), or if a file exists with the same onion address & private key
      * @throws [SecurityException] If access is not authorized
      * */
     @WorkerThread
@@ -159,7 +160,23 @@ object OnionAuthUtilities {
             )
         }
 
+        val existingFiles = getAllFiles(torConfigFiles)
+
         synchronized(torConfigFiles.v3AuthPrivateDirLock) {
+
+            if (existingFiles != null) {
+                for (existingFile in existingFiles) {
+                    existingFile.readText().split(':').let { split ->
+                        if (
+                            split.getOrNull(0) == onionAddress &&
+                            split.getOrNull(3) == base32EncodedPrivateKey
+                        ) {
+                            throw IllegalStateException("A file with identical information already exists")
+                        }
+                    }
+                }
+            }
+
             if (file.createNewFileIfDoesNotExist() != true) {
                 return null
             }

--- a/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
+++ b/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
@@ -192,6 +192,12 @@ class OnionAuthUtilitiesUnitTest {
         addV3ClientAuthenticationPrivateKey()
     }
 
+    @Test(expected = IllegalStateException::class)
+    fun `file with same content already exists throws exception`() {
+        addV3ClientAuthenticationPrivateKey()
+        addV3ClientAuthenticationPrivateKey(name = validNickname + "_diff")
+    }
+
     @Test(expected = AssertionError::class)
     fun `check assertion method throws exception if null`() {
         checkAddAuthPrivateAssertions(null)
@@ -244,10 +250,10 @@ class OnionAuthUtilitiesUnitTest {
     }
 
     @Throws(AssertionError::class)
-    private fun checkAddAuthPrivateAssertions(file: File?) {
+    private fun checkAddAuthPrivateAssertions(file: File?, expectedContent: String = expectedFileContent) {
         Assert.assertTrue(file?.exists() == true)
         Assert.assertEquals(file?.parentFile, torConfigFiles.v3AuthPrivateDir)
-        Assert.assertEquals(expectedFileContent, file?.readText())
+        Assert.assertEquals(expectedContent, file?.readText())
     }
 
 
@@ -265,12 +271,12 @@ class OnionAuthUtilitiesUnitTest {
         val name1 = "name1"
         val name2 = "name2"
         val name3 = "name3"
-        val file1 = addV3ClientAuthenticationPrivateKey(name1)
-        val file2 = addV3ClientAuthenticationPrivateKey(name2)
-        val file3 = addV3ClientAuthenticationPrivateKey(name3)
-        checkAddAuthPrivateAssertions(file1)
-        checkAddAuthPrivateAssertions(file2)
-        checkAddAuthPrivateAssertions(file3)
+        val file1 = addV3ClientAuthenticationPrivateKey(name1, privateKey = validClientAuthKey.dropLast(1) + "A")
+        val file2 = addV3ClientAuthenticationPrivateKey(name2, privateKey = validClientAuthKey.dropLast(1) + "B")
+        val file3 = addV3ClientAuthenticationPrivateKey(name3, privateKey = validClientAuthKey.dropLast(1) + "C")
+        checkAddAuthPrivateAssertions(file1, expectedFileContent.dropLast(1) + "A")
+        checkAddAuthPrivateAssertions(file2, expectedFileContent.dropLast(1) + "B")
+        checkAddAuthPrivateAssertions(file3, expectedFileContent.dropLast(1) + "C")
 
         val expectedArray = arrayOf(file1, file2, file3)
 
@@ -316,12 +322,12 @@ class OnionAuthUtilitiesUnitTest {
         val name1 = "name1"
         val name2 = "name2"
         val name3 = "name3"
-        val file1 = addV3ClientAuthenticationPrivateKey(name1)
-        val file2 = addV3ClientAuthenticationPrivateKey(name2)
-        val file3 = addV3ClientAuthenticationPrivateKey(name3)
-        checkAddAuthPrivateAssertions(file1)
-        checkAddAuthPrivateAssertions(file2)
-        checkAddAuthPrivateAssertions(file3)
+        val file1 = addV3ClientAuthenticationPrivateKey(name1, privateKey = validClientAuthKey.dropLast(1) + "A")
+        val file2 = addV3ClientAuthenticationPrivateKey(name2, privateKey = validClientAuthKey.dropLast(1) + "B")
+        val file3 = addV3ClientAuthenticationPrivateKey(name3, privateKey = validClientAuthKey.dropLast(1) + "C")
+        checkAddAuthPrivateAssertions(file1, expectedFileContent.dropLast(1) + "A")
+        checkAddAuthPrivateAssertions(file2, expectedFileContent.dropLast(1) + "B")
+        checkAddAuthPrivateAssertions(file3, expectedFileContent.dropLast(1) + "C")
 
         val expectedNicknames = arrayOf(name1, name2, name3)
 

--- a/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/BaseV3ClientAuthManager.kt
+++ b/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/BaseV3ClientAuthManager.kt
@@ -106,7 +106,8 @@ abstract class BaseV3ClientAuthManager {
      *
      * @return The File if it was created properly, `null` if it was not
      * @throws [IllegalArgumentException] If passed arguments are not compliant with the spec
-     * @throws [IllegalStateException] If the file already exists (and must be deleted before overwriting)
+     * @throws [IllegalStateException] If the file already exists (and must be deleted before
+     *   overwriting), or if a file exists with the same onion address & private key
      * @throws [SecurityException] If access is not authorized
      * */
     @WorkerThread


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR adds logic to `:topl-core::OnionAuthUtilities.addV3ClientAuthenticationPrivateKey` to also check for a file that contains the same content in order to inhibit duplicate entries (which causes Tor to fail on startup).

Fixes #105 

SNAPSHOT available by:
 - In your Application module’s build.gradle file, add the following (outside the android block):
```groovy
repositories {
    maven {
        url 'https://oss.sonatype.org/content/repositories/snapshots/'
    }
}
```

- In your Application module’s build.gradle file, add (or modify) the following in the dependencies block:
```groovy
def topl_android_version = "2.0.3h-SNAPSHOT"
implementation 'io.matthewnelson.topl-android:topl-service:$topl_android_version'
```


## Type of change
<!--    [x] = check mark on preview     -->
<!--    [ ] = empty box on preview      -->
<!---->
<!-- Please REMOVE unchecked selections -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status
<!-- Please REMOVE unchecked selections -->

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?
<!-- Please REMOVE unchecked selections -->

- [x] Unit Tests

# Checklist
<!-- Please KEEP unchecked selections -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] There are no merge conflicts
