### PR TITLE
Fix incorrect variable reference when checking for duplicate v3 auth private entries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=io.matthewnelson.topl-android
-VERSION_NAME=2.0.3h-SNAPSHOT
+VERSION_NAME=2.0.3i-SNAPSHOT
 
 # The trailing 2 digits are for `alpha##` releases. For example:
 #     4.4.1-alpha02 = 441102 where `102` stands for alpha02

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
@@ -168,8 +168,8 @@ object OnionAuthUtilities {
                 for (existingFile in existingFiles) {
                     existingFile.readText().split(':').let { split ->
                         if (
-                            split.getOrNull(0) == onionAddress &&
-                            split.getOrNull(3) == base32EncodedPrivateKey
+                            split.getOrNull(0) == onion &&
+                            split.getOrNull(3) == key
                         ) {
                             throw IllegalStateException("A file with identical information already exists")
                         }

--- a/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
+++ b/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
@@ -198,6 +198,12 @@ class OnionAuthUtilitiesUnitTest {
         addV3ClientAuthenticationPrivateKey(name = validNickname + "_diff")
     }
 
+    @Test(expected = IllegalStateException::class)
+    fun `file with same content already exists throws exception with onion appendage`() {
+        addV3ClientAuthenticationPrivateKey()
+        addV3ClientAuthenticationPrivateKey(name = validNickname + "_diff", "$validOnion.onion")
+    }
+
     @Test(expected = AssertionError::class)
     fun `check assertion method throws exception if null`() {
         checkAddAuthPrivateAssertions(null)


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
#106 fix referenced incorrect variables when checking for duplicate entries. This PR references the correct, cleansed values in lieu of what was passed in the constructor argument.

Fixes #107

SNAPSHOT available by:
 - In your Application module’s build.gradle file, add the following (outside the android block):
```groovy
repositories {
    maven {
        url 'https://oss.sonatype.org/content/repositories/snapshots/'
    }
}
```

- In your Application module’s build.gradle file, add (or modify) the following in the dependencies block:
```groovy
def topl_android_version = "2.0.3i-SNAPSHOT"
implementation 'io.matthewnelson.topl-android:topl-service:$topl_android_version'
```

## Type of change
<!--    [x] = check mark on preview     -->
<!--    [ ] = empty box on preview      -->
<!---->
<!-- Please REMOVE unchecked selections -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status
<!-- Please REMOVE unchecked selections -->

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?
<!-- Please REMOVE unchecked selections -->

- [x] Unit Tests

# Checklist
<!-- Please KEEP unchecked selections -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/ui tests pass locally with my changes
- [x] There are no merge conflicts
