### PR TITLE
BugFix: #110

### DIFF
--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     implementation deps.kotlin.stdlib
 
     implementation 'io.matthewnelson.encrypted-storage:encrypted-storage:2.0.1'
-    implementation 'io.matthewnelson.topl-android:tor-binary:0.4.4.0'
+    implementation 'io.matthewnelson.topl-android:tor-binary:0.4.5.4'
 
     testImplementation testDeps.junit
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
@@ -263,28 +263,28 @@ internal class ServiceEventBroadcaster private constructor(
             }
             // Dns Port
             // NOTICE|OnionProxyManager|Opened DNS listener on 127.0.0.1:5400
-            msg.contains("Opened DNS listener on ") -> {
+            msg.contains("Opened DNS listener ") -> {
                 dnsPort = getPortFromMsg(msg)
                 if (isBootstrappingComplete())
                     updateAppEventBroadcasterWithPortInfo()
             }
             // Http Tunnel Port
             // NOTICE|BaseEventListener|Opened HTTP tunnel listener on 127.0.0.1:8118
-            msg.contains("Opened HTTP tunnel listener on ") -> {
+            msg.contains("Opened HTTP tunnel listener ") -> {
                 httpTunnelPort = getPortFromMsg(msg)
                 if (isBootstrappingComplete())
                     updateAppEventBroadcasterWithPortInfo()
             }
             // Socks Port
             // NOTICE|BaseEventListener|Opened Socks listener on 127.0.0.1:9050
-            msg.contains("Opened Socks listener on ") -> {
+            msg.contains("Opened Socks listener ") -> {
                 socksPort = getPortFromMsg(msg)
                 if (isBootstrappingComplete())
                     updateAppEventBroadcasterWithPortInfo()
             }
             // Trans Port
             // NOTICE|BaseEventListener|Opened Transparent pf/netfilter listener on 127.0.0.1:9040
-            msg.contains("Opened Transparent pf/netfilter listener on ") -> {
+            msg.contains("Opened Transparent pf/netfilter listener ") -> {
                 transPort = getPortFromMsg(msg)
                 if (isBootstrappingComplete())
                     updateAppEventBroadcasterWithPortInfo()


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR Fixes #110 by modifying `topl-service`'s notice broadcast filters to accommodate changes in Tor's event broadcast messages. Modifications are backwards compatible with previous versions of Tor such that users of an updated TOPL-Android release and an older release of Tor will not be affected.