### PR TITLE
Merge development branch for 2.1.0 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=io.matthewnelson.topl-android
-VERSION_NAME=2.0.3-SNAPSHOT
+VERSION_NAME=2.0.3b-SNAPSHOT
 
 # The trailing 2 digits are for `alpha##` releases. For example:
 #     4.4.1-alpha02 = 441102 where `102` stands for alpha02

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=io.matthewnelson.topl-android
-VERSION_NAME=2.0.3g-SNAPSHOT
+VERSION_NAME=2.0.3h-SNAPSHOT
 
 # The trailing 2 digits are for `alpha##` releases. For example:
 #     4.4.1-alpha02 = 441102 where `102` stands for alpha02

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=io.matthewnelson.topl-android
-VERSION_NAME=2.0.3e-SNAPSHOT
+VERSION_NAME=2.0.3f-SNAPSHOT
 
 # The trailing 2 digits are for `alpha##` releases. For example:
 #     4.4.1-alpha02 = 441102 where `102` stands for alpha02

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=io.matthewnelson.topl-android
-VERSION_NAME=2.0.3h-SNAPSHOT
+VERSION_NAME=2.0.3i-SNAPSHOT
 
 # The trailing 2 digits are for `alpha##` releases. For example:
 #     4.4.1-alpha02 = 441102 where `102` stands for alpha02

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=io.matthewnelson.topl-android
-VERSION_NAME=2.0.3b-SNAPSHOT
+VERSION_NAME=2.0.3e-SNAPSHOT
 
 # The trailing 2 digits are for `alpha##` releases. For example:
 #     4.4.1-alpha02 = 441102 where `102` stands for alpha02

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=io.matthewnelson.topl-android
-VERSION_NAME=2.0.3f-SNAPSHOT
+VERSION_NAME=2.0.3g-SNAPSHOT
 
 # The trailing 2 digits are for `alpha##` releases. For example:
 #     4.4.1-alpha02 = 441102 where `102` stands for alpha02

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,10 +3,10 @@ ext.versions = [
     'compileSdk': 30,
     'minSdk': 16,
 
-    'coroutines': '1.4.0-M1',
+    'coroutines': '1.4.2',
     'lifecycle': '2.2.0',
-    'kotlin': '1.4.10',
-    'navigation': '2.3.1',
+    'kotlin': '1.4.20',
+    'navigation': '2.3.2',
 ]
 
 /**
@@ -44,13 +44,13 @@ ext.deps = [
 ]
 
 ext.plugin = [
-    androidGradle: "com.android.tools.build:gradle:4.1.0",
-    gradleVersions: "com.github.ben-manes:gradle-versions-plugin:0.33.0",
+    androidGradle: "com.android.tools.build:gradle:4.1.1",
+    gradleVersions: "com.github.ben-manes:gradle-versions-plugin:0.36.0",
     kotlin: [
         dokka: "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1",
         gradle: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
     ],
-    mavenPublish: "com.vanniktech:gradle-maven-publish-plugin:0.12.0",
+    mavenPublish: "com.vanniktech:gradle-maven-publish-plugin:0.13.0",
 ]
 
 /**

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -5,8 +5,8 @@ ext.versions = [
 
     'coroutines': '1.4.2',
     'lifecycle': '2.2.0',
-    'kotlin': '1.4.20',
-    'navigation': '2.3.2',
+    'kotlin': '1.4.21-2',
+    'navigation': '2.3.3',
 ]
 
 /**
@@ -44,7 +44,7 @@ ext.deps = [
 ]
 
 ext.plugin = [
-    androidGradle: "com.android.tools.build:gradle:4.1.1",
+    androidGradle: "com.android.tools.build:gradle:4.1.2",
     gradleVersions: "com.github.ben-manes:gradle-versions-plugin:0.36.0",
     kotlin: [
         dokka: "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 # https://gradle.org/release-checksums/
-distributionSha256Sum=0080de8491f0918e4f529a6db6820fa0b9e818ee2386117f4394f95feb1d5583
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionSha256Sum=22449f5231796abd892c98b2a07c9ceebe4688d192cd2d6763f8e3bf8acbedeb
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 # https://gradle.org/release-checksums/
-distributionSha256Sum=22449f5231796abd892c98b2a07c9ceebe4688d192cd2d6763f8e3bf8acbedeb
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionSha256Sum=3db89524a3981819ff28c3f979236c1274a726e146ced0c8a2020417f9bc0782
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     implementation deps.kotlin.stdlib
 
     implementation 'io.matthewnelson.encrypted-storage:encrypted-storage:2.0.1'
-    implementation 'io.matthewnelson.topl-android:tor-binary:0.4.4.0'
+    implementation 'io.matthewnelson.topl-android:tor-binary:0.4.5.4'
 
     testImplementation testDeps.junit
 }

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     packagingOptions {

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/App.kt
@@ -77,6 +77,7 @@ import android.content.Intent
 import android.os.Process
 import io.matthewnelson.encrypted_storage.Prefs
 import io.matthewnelson.sampleapp.topl_android.MyEventBroadcaster
+import io.matthewnelson.sampleapp.topl_android.MyServiceExecutionHooks
 import io.matthewnelson.sampleapp.topl_android.MyTorSettings
 import io.matthewnelson.sampleapp.ui.MainActivity
 import io.matthewnelson.sampleapp.ui.fragments.dashboard.DashMessage
@@ -186,6 +187,7 @@ class App: Application() {
                 .disableStopServiceOnTaskRemoved(stopServiceOnTaskRemoved)
                 .setBuildConfigDebug(buildConfigDebug)
                 .setEventBroadcaster(eventBroadcaster = MyEventBroadcaster())
+                .setServiceExecutionHooks(executionHooks = MyServiceExecutionHooks())
         }
     }
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/CodeSamples.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/CodeSamples.kt
@@ -178,6 +178,7 @@ class CodeSamples {
             // TorServiceController.Companion?.appEventBroadcaster and cast what's returned
             // as MyEventBroadcaster
             .setEventBroadcaster(eventBroadcaster = MyEventBroadcaster())
+            .setServiceExecutionHooks(executionHooks = MyServiceExecutionHooks())
 
             // Only needed if you wish to customize the directories/files used by Tor if
             // the defaults aren't to your liking.

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyEventBroadcaster.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyEventBroadcaster.kt
@@ -96,6 +96,10 @@ class MyEventBroadcaster: TorServiceEventBroadcaster() {
         _liveTorPortInfo.value = torPortInfo
     }
 
+    override fun broadcastServiceLifecycleEvent(event: String, hashCode: Int) {
+        broadcastLogMessage("NOTICE|TorService|LCE=$event - HashCode=$hashCode")
+    }
+
 
     /////////////////
     /// Bandwidth ///

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyServiceExecutionHooks.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyServiceExecutionHooks.kt
@@ -1,13 +1,157 @@
 package io.matthewnelson.sampleapp.topl_android
 
 import android.content.Context
+import io.matthewnelson.topl_core_base.BaseConsts.BroadcastType
+import io.matthewnelson.topl_service.TorServiceController
 import io.matthewnelson.topl_service_base.ServiceExecutionHooks
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 
 class MyServiceExecutionHooks: ServiceExecutionHooks() {
 
-    override suspend fun executeOnCreateTorService(context: Context) {}
+    override suspend fun executeOnCreateTorService(context: Context) {
+        // Executed on Dispatchers.Default, so querying shared prefs has to switch
+        // context to IO.
+        withContext(Dispatchers.Main) {
+            TorServiceController.getServiceTorSettings()
+        }.let { settings ->
+            withContext(Dispatchers.IO) {
+                settings.hasDebugLogs
+            }.let { debugLogs ->
+                if (!debugLogs) {
+                    return
+                }
 
-    override suspend fun executeBeforeStartTor(context: Context) {}
+                withContext(Dispatchers.Main) {
+                    TorServiceController.appEventBroadcaster?.broadcastDebug(
+                        "${BroadcastType.DEBUG}|" +
+                                "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                                "onCreateTorService execution hook started"
+                    )
 
-    override suspend fun executeAfterStopTor(context: Context) {}
+                    delay(20_000L)
+
+                    TorServiceController.appEventBroadcaster?.broadcastDebug(
+                        "${BroadcastType.DEBUG}|" +
+                                "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                                "onCreateTorService execution hook completed"
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun executeOnStartCommandBeforeStartTor(context: Context) {
+        // Executed on Dispatchers.Default, so querying shared prefs has to switch
+        // context to IO.
+        withContext(Dispatchers.Main) {
+            TorServiceController.getServiceTorSettings()
+        }.let { settings ->
+            withContext(Dispatchers.IO) {
+                settings.hasDebugLogs
+            }.let { debugLogs ->
+                if (!debugLogs) {
+                    return
+                }
+
+                withContext(Dispatchers.Main) {
+                    TorServiceController.appEventBroadcaster?.broadcastDebug(
+                        "${BroadcastType.DEBUG}|" +
+                                "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                                "OnStartCommandBeforeStartTor execution hook started"
+                    )
+
+                    delay(1_000L)
+
+                    TorServiceController.appEventBroadcaster?.broadcastDebug(
+                        "${BroadcastType.DEBUG}|" +
+                                "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                                "OnStartCommandBeforeStartTor execution hook completed"
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun executeBeforeStartTor(context: Context) {
+        // Executed on Dispatchers.IO
+        withContext(Dispatchers.Main) {
+            TorServiceController.getServiceTorSettings()
+        }.let { settings ->
+            if (!settings.hasDebugLogs) {
+                return
+            }
+
+            withContext(Dispatchers.Main) {
+                TorServiceController.appEventBroadcaster?.broadcastDebug(
+                    "${BroadcastType.DEBUG}|" +
+                            "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                            "BeforeStartTor execution hook started"
+                )
+
+                delay(500L)
+
+                TorServiceController.appEventBroadcaster?.broadcastDebug(
+                    "${BroadcastType.DEBUG}|" +
+                            "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                            "BeforeStartTor execution hook completed"
+                )
+            }
+        }
+    }
+
+    override suspend fun executeAfterStopTor(context: Context) {
+        // Executed on Dispatchers.IO
+        withContext(Dispatchers.Main) {
+            TorServiceController.getServiceTorSettings()
+        }.let { settings ->
+            if (!settings.hasDebugLogs) {
+                return
+            }
+
+            withContext(Dispatchers.Main) {
+                TorServiceController.appEventBroadcaster?.broadcastDebug(
+                    "${BroadcastType.DEBUG}|" +
+                            "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                            "AfterStopTor execution hook started"
+                )
+
+                delay(500L)
+
+                TorServiceController.appEventBroadcaster?.broadcastDebug(
+                    "${BroadcastType.DEBUG}|" +
+                            "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                            "AfterStopTor execution hook completed"
+                )
+            }
+        }
+    }
+
+    override suspend fun executeBeforeStoppingService(context: Context) {
+        // Executed on Dispatchers.IO
+        withContext(Dispatchers.Main) {
+            TorServiceController.getServiceTorSettings()
+        }.let { settings ->
+            if (!settings.hasDebugLogs) {
+                return
+            }
+
+            withContext(Dispatchers.Main) {
+                TorServiceController.appEventBroadcaster?.broadcastDebug(
+                    "${BroadcastType.DEBUG}|" +
+                            "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                            "BeforeStoppingService execution hook started"
+                )
+
+                delay(2_000L)
+
+                TorServiceController.appEventBroadcaster?.broadcastDebug(
+                    "${BroadcastType.DEBUG}|" +
+                            "${this@MyServiceExecutionHooks.javaClass.simpleName}|" +
+                            "BeforeStoppingService execution hook completed"
+                )
+            }
+        }
+    }
 }

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyServiceExecutionHooks.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyServiceExecutionHooks.kt
@@ -1,9 +1,7 @@
 package io.matthewnelson.sampleapp.topl_android
 
 import android.content.Context
-import android.widget.Toast
 import io.matthewnelson.topl_service_base.ServiceExecutionHooks
-import kotlinx.coroutines.delay
 
 class MyServiceExecutionHooks: ServiceExecutionHooks() {
 

--- a/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyServiceExecutionHooks.kt
+++ b/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyServiceExecutionHooks.kt
@@ -1,0 +1,15 @@
+package io.matthewnelson.sampleapp.topl_android
+
+import android.content.Context
+import android.widget.Toast
+import io.matthewnelson.topl_service_base.ServiceExecutionHooks
+import kotlinx.coroutines.delay
+
+class MyServiceExecutionHooks: ServiceExecutionHooks() {
+
+    override suspend fun executeOnCreateTorService(context: Context) {}
+
+    override suspend fun executeBeforeStartTor(context: Context) {}
+
+    override suspend fun executeAfterStopTor(context: Context) {}
+}

--- a/topl-core-base/build.gradle
+++ b/topl-core-base/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply from: rootProject.file('gradle/maven-publish.gradle')
 
 android {

--- a/topl-core/build.gradle
+++ b/topl-core/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply from: rootProject.file('gradle/maven-publish.gradle')
 
 android {

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/OnionProxyContext.kt
@@ -123,15 +123,27 @@ import java.io.*
  * @param [torInstaller] [TorInstaller]
  * @param [torSettings] [TorSettings] Basically your torrc file
  */
-internal class OnionProxyContext(
+internal class OnionProxyContext private constructor(
     val torConfigFiles: TorConfigFiles,
     val torInstaller: TorInstaller,
     val torSettings: TorSettings
 ): CoreConsts() {
 
+    companion object {
+        @JvmSynthetic
+        fun instantiate(
+            torConfigFiles: TorConfigFiles,
+            torInstaller: TorInstaller,
+            torSettings: TorSettings
+        ): OnionProxyContext =
+            OnionProxyContext(torConfigFiles, torInstaller, torSettings)
+    }
+
     // Gets initialized in OnionProxyManager _immediately_ after
     // OnionProxyContext is instantiated.
     private lateinit var broadcastLogger: BroadcastLogger
+
+    @JvmSynthetic
     fun initBroadcastLogger(onionProxyBroadcastLogger: BroadcastLogger) {
         if (!::broadcastLogger.isInitialized)
             broadcastLogger = onionProxyBroadcastLogger
@@ -157,6 +169,7 @@ internal class OnionProxyContext(
      * @throws [IllegalArgumentException] If [configFileReference] is an invalid argument, or null file.
      * @throws [SecurityException] See [WriteObserver.checkExists]
      */
+    @JvmSynthetic
     @Throws(IllegalArgumentException::class, SecurityException::class)
     fun createFileObserver(@ConfigFile configFileReference: String): WriteObserver {
         broadcastLogger.debug("Creating FileObserver for $configFileReference")
@@ -190,6 +203,7 @@ internal class OnionProxyContext(
      * @return True if file exists or is created successfully, otherwise false.
      * @throws [SecurityException] Unauthorized access to file/directory.
      * */
+    @JvmSynthetic
     @Throws(IllegalArgumentException::class, SecurityException::class)
     fun createNewFileIfDoesNotExist(@ConfigFile configFileReference: String): Boolean {
         broadcastLogger.debug("Creating $configFileReference if DNE")
@@ -238,6 +252,7 @@ internal class OnionProxyContext(
      * @throws [SecurityException] Unauthorized access to file/directory.
      * @throws [IllegalArgumentException]
      * */
+    @JvmSynthetic
     @Throws(SecurityException::class, IllegalArgumentException::class)
     fun deleteFile(@ConfigFile configFileReference: String): Boolean {
         broadcastLogger.debug("Deleting $configFileReference")
@@ -273,6 +288,7 @@ internal class OnionProxyContext(
      * @throws [EOFException] Errors while reading file.
      * @throws [SecurityException] Unauthorized access to file/directory.
      * */
+    @JvmSynthetic
     @Throws(IOException::class, EOFException::class, SecurityException::class)
     fun readFile(@ConfigFile configFileReference: String): ByteArray {
         broadcastLogger.debug("Reading $configFileReference")
@@ -307,6 +323,7 @@ internal class OnionProxyContext(
      * @return True if directory exists or is created successfully, otherwise false.
      * @throws [SecurityException] Unauthorized access to file/directory.
      */
+    @JvmSynthetic
     @Throws(SecurityException::class)
     fun createDataDir(): Boolean =
         synchronized(dataDirLock) {
@@ -319,6 +336,7 @@ internal class OnionProxyContext(
      * @throws [RuntimeException] Was unable to delete a file.
      * @throws [SecurityException] Unauthorized access to file/directory.
      */
+    @JvmSynthetic
     @Throws(RuntimeException::class, SecurityException::class)
     fun deleteDataDirExceptHiddenServiceAndAuthPrivate() {
         synchronized(dataDirLock) {
@@ -337,6 +355,7 @@ internal class OnionProxyContext(
     ////////////////////
     /// HostnameFile ///
     ////////////////////
+    @JvmSynthetic
     @Throws(SecurityException::class)
     fun setHostnameDirPermissionsToReadOnly(): Boolean =
         synchronized(hostnameFileLock) {
@@ -354,6 +373,7 @@ internal class OnionProxyContext(
      * @return The resolveConf file with newly added ip addresses for Quad9
      * @throws [IOException] from FileWriter
      */
+    @JvmSynthetic
     @Throws(IOException::class)
     fun createQuad9NameserverFile(): File =
         synchronized(resolvConfFileLock) {
@@ -370,6 +390,7 @@ internal class OnionProxyContext(
      *
      * @return process id
      */
-    val processId: String
-        get() = Process.myPid().toString()
+    @JvmSynthetic
+    fun getProcessId(): String =
+        Process.myPid().toString()
 }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/BroadcastLogger.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/BroadcastLogger.kt
@@ -95,20 +95,29 @@ import io.matthewnelson.topl_core_base.TorSettings
  * @param [buildConfigDebug] To enable/disable Logcat messages
  * @param [hasDebugLogs] To switch debug logs on/off, as well as Logcat messages on Debug builds.
  * */
-class BroadcastLogger internal constructor(
+class BroadcastLogger private constructor(
     val TAG: String,
     val eventBroadcaster: EventBroadcaster,
     private val buildConfigDebug: Boolean,
-    hasDebugLogs: Boolean
+    @Volatile
+    private var hasDebugLogs: Boolean
 ): CoreConsts() {
 
-    @Volatile
-    internal var hasDebugLogs: Boolean = hasDebugLogs
-        private set
+    companion object {
+        @JvmSynthetic
+        internal fun instantiate(
+            tag: String,
+            eventBroadcaster: EventBroadcaster,
+            buildConfigDebug: Boolean,
+            hasDebugLogs: Boolean
+        ): BroadcastLogger =
+            BroadcastLogger(tag, eventBroadcaster, buildConfigDebug, hasDebugLogs)
+    }
 
     /**
      * See [io.matthewnelson.topl_core.broadcaster.BroadcastLoggerHelper.refreshBroadcastLoggersHasDebugLogsVar]
      * */
+    @JvmSynthetic
     internal fun updateHasDebugLogs(hasDebugLogs: Boolean) {
         this.hasDebugLogs = hasDebugLogs
     }
@@ -154,5 +163,4 @@ class BroadcastLogger internal constructor(
     fun torState(@TorState state: String, @TorNetworkState networkState: String) {
         eventBroadcaster.broadcastTorState(state, networkState)
     }
-
 }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/BroadcastLoggerHelper.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/BroadcastLoggerHelper.kt
@@ -82,16 +82,26 @@ import io.matthewnelson.topl_core_base.EventBroadcaster
  * can be controlled in a more efficient/effective manner. It also handles initialization of
  * several other classes [BroadcastLogger]'s upon instantiation.
  * */
-internal class BroadcastLoggerHelper(
+internal class BroadcastLoggerHelper private constructor(
     private val onionProxyManager: OnionProxyManager,
     private val eventBroadcaster: EventBroadcaster,
     private val buildConfigDebug: Boolean
 ) {
 
+    companion object {
+        @JvmSynthetic
+        internal fun instantiate(
+            onionProxyManager: OnionProxyManager,
+            eventBroadcaster: EventBroadcaster,
+            buildConfigDebug: Boolean
+        ): BroadcastLoggerHelper =
+            BroadcastLoggerHelper(onionProxyManager, eventBroadcaster, buildConfigDebug)
+    }
+
     private val broadcastLoggerList = mutableListOf<BroadcastLogger>()
 
     init {
-        onionProxyManager.onionProxyContext.initBroadcastLogger(
+        onionProxyManager.initOnionProxyContextBroadcastLogger(
             getBroadcastLogger(OnionProxyContext::class.java)
         )
         onionProxyManager.torInstaller.initBroadcastLogger(
@@ -107,6 +117,7 @@ internal class BroadcastLoggerHelper(
      * This gets called automatically at every [OnionProxyManager.start]. Can be called at
      * any time whether Tor's State is ON or OFF.
      * */
+    @JvmSynthetic
     fun refreshBroadcastLoggersHasDebugLogsVar() {
         if (broadcastLoggerList.size < 1) return
         val hasDebugLogs = onionProxyManager.torSettings.hasDebugLogs
@@ -124,6 +135,7 @@ internal class BroadcastLoggerHelper(
      *
      * @param [clazz] Class<*> - For initializing [BroadcastLogger.TAG] with your class' name.
      * */
+    @JvmSynthetic
     fun getBroadcastLogger(clazz: Class<*>): BroadcastLogger =
         getBroadcastLogger(clazz.simpleName)
 
@@ -134,10 +146,11 @@ internal class BroadcastLoggerHelper(
      *
      * @param [tagName] String - For initialize [BroadcastLogger.TAG].
      * */
+    @JvmSynthetic
     fun getBroadcastLogger(tagName: String): BroadcastLogger {
         var bl: BroadcastLogger? = checkIfBroadcastLoggerExists(tagName)
         if (bl == null) {
-            bl = BroadcastLogger(
+            bl = BroadcastLogger.instantiate(
                 tagName,
                 eventBroadcaster,
                 buildConfigDebug,

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/TorStateMachine.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/broadcaster/TorStateMachine.kt
@@ -99,7 +99,15 @@ import io.matthewnelson.topl_core.util.CoreConsts
 /**
  * Current State of Tor
  */
-class TorStateMachine(private val broadcastLogger: BroadcastLogger): CoreConsts() {
+class TorStateMachine private constructor(
+    private val broadcastLogger: BroadcastLogger
+): CoreConsts() {
+
+    companion object {
+        @JvmSynthetic
+        internal fun instantiate(broadcastLogger: BroadcastLogger): TorStateMachine =
+            TorStateMachine(broadcastLogger)
+    }
 
     private var currentTorState: @TorState String = TorState.OFF
     private var currentTorNetworkState: @TorNetworkState String = TorNetworkState.DISABLED
@@ -125,6 +133,7 @@ class TorStateMachine(private val broadcastLogger: BroadcastLogger): CoreConsts(
      * @param [state] [io.matthewnelson.topl_core_base.BaseConsts.TorState]
      * @return Previous [io.matthewnelson.topl_core_base.BaseConsts.TorState]
      * */
+    @JvmSynthetic
     @Synchronized
     internal fun setTorState(@TorState state: String): @TorState String {
         val currentState = currentTorState
@@ -144,6 +153,7 @@ class TorStateMachine(private val broadcastLogger: BroadcastLogger): CoreConsts(
      * @param [networkState] [io.matthewnelson.topl_core_base.BaseConsts.TorNetworkState]
      * @return Previous [io.matthewnelson.topl_core_base.BaseConsts.TorNetworkState]
      * */
+    @JvmSynthetic
     @Synchronized
     internal fun setTorNetworkState(@TorNetworkState networkState: String): @TorNetworkState String {
         val currentNetworkState = currentTorNetworkState

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/listener/BaseEventListener.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/listener/BaseEventListener.kt
@@ -86,8 +86,10 @@ abstract class BaseEventListener: EventListener() {
      * This gets set as soon as [io.matthewnelson.topl_core.OnionProxyManager] is instantiated,
      * and can be used to broadcast messages in your class which extends [TorInstaller].
      * */
-    var broadcastLogger: BroadcastLogger? = null
+    protected var broadcastLogger: BroadcastLogger? = null
         private set
+
+    @JvmSynthetic
     internal fun initBroadcastLogger(torInstallerBroadcastLogger: BroadcastLogger) {
         if (broadcastLogger == null)
             broadcastLogger = torInstallerBroadcastLogger
@@ -111,6 +113,7 @@ abstract class BaseEventListener: EventListener() {
      *
      * TODO: find a less hacky way to do this...
      * */
+    @JvmSynthetic
     internal suspend fun beginWatchingNoticeMsgs() {
         noticeMsgBuffer = StringBuffer()
         delay(50)
@@ -123,6 +126,7 @@ abstract class BaseEventListener: EventListener() {
      * @param [delayMilliseconds] Length of time you wish to delay the coroutine for before executing
      * @return True if it contains the string, false if not.
      * */
+    @JvmSynthetic
     internal suspend fun doesNoticeMsgBufferContain(string: String, delayMilliseconds: Long): Boolean {
         delay(delayMilliseconds)
         val boolean = noticeMsgBuffer.toString().contains(string)

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/settings/TorSettingsBuilder.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/settings/TorSettingsBuilder.kt
@@ -127,10 +127,19 @@ import java.util.*
  * @param [broadcastLogger] for broadcasting/logging
  * @sample [io.matthewnelson.topl_service.service.TorService.generateTorrcFile]
  * */
-class TorSettingsBuilder internal constructor(
+class TorSettingsBuilder private constructor(
     private val onionProxyContext: OnionProxyContext,
     private val broadcastLogger: BroadcastLogger
 ): CoreConsts() {
+
+    companion object {
+        @JvmSynthetic
+        internal fun instantiate(
+            onionProxyContext: OnionProxyContext,
+            broadcastLogger: BroadcastLogger
+        ): TorSettingsBuilder =
+            TorSettingsBuilder(onionProxyContext, broadcastLogger)
+    }
 
     private var buffer = StringBuffer()
     private val torConfigFiles: TorConfigFiles

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
@@ -110,7 +110,8 @@ object OnionAuthUtilities {
      *
      * @return The File if it was created properly, `null` if it was not
      * @throws [IllegalArgumentException] If passed arguments are not compliant with the spec
-     * @throws [IllegalStateException] If the file already exists (and must be deleted before overwriting)
+     * @throws [IllegalStateException] If the file already exists (and must be deleted before
+     *   overwriting), or if a file exists with the same onion address & private key
      * @throws [SecurityException] If access is not authorized
      * */
     @WorkerThread
@@ -159,7 +160,23 @@ object OnionAuthUtilities {
             )
         }
 
+        val existingFiles = getAllFiles(torConfigFiles)
+
         synchronized(torConfigFiles.v3AuthPrivateDirLock) {
+
+            if (existingFiles != null) {
+                for (existingFile in existingFiles) {
+                    existingFile.readText().split(':').let { split ->
+                        if (
+                            split.getOrNull(0) == onionAddress &&
+                            split.getOrNull(3) == base32EncodedPrivateKey
+                        ) {
+                            throw IllegalStateException("A file with identical information already exists")
+                        }
+                    }
+                }
+            }
+
             if (file.createNewFileIfDoesNotExist() != true) {
                 return null
             }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/OnionAuthUtilities.kt
@@ -168,8 +168,8 @@ object OnionAuthUtilities {
                 for (existingFile in existingFiles) {
                     existingFile.readText().split(':').let { split ->
                         if (
-                            split.getOrNull(0) == onionAddress &&
-                            split.getOrNull(3) == base32EncodedPrivateKey
+                            split.getOrNull(0) == onion &&
+                            split.getOrNull(3) == key
                         ) {
                             throw IllegalStateException("A file with identical information already exists")
                         }

--- a/topl-core/src/main/java/io/matthewnelson/topl_core/util/TorInstaller.kt
+++ b/topl-core/src/main/java/io/matthewnelson/topl_core/util/TorInstaller.kt
@@ -113,8 +113,10 @@ abstract class TorInstaller: CoreConsts() {
      * This gets set as soon as [io.matthewnelson.topl_core.OnionProxyManager] is instantiated,
      * and can be used to broadcast messages in your class which extends [TorInstaller].
      * */
-    var broadcastLogger: BroadcastLogger? = null
+    protected var broadcastLogger: BroadcastLogger? = null
         private set
+
+    @JvmSynthetic
     internal fun initBroadcastLogger(torInstallerBroadcastLogger: BroadcastLogger) {
         if (broadcastLogger == null)
             broadcastLogger = torInstallerBroadcastLogger

--- a/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
+++ b/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
@@ -198,6 +198,12 @@ class OnionAuthUtilitiesUnitTest {
         addV3ClientAuthenticationPrivateKey(name = validNickname + "_diff")
     }
 
+    @Test(expected = IllegalStateException::class)
+    fun `file with same content already exists throws exception with onion appendage`() {
+        addV3ClientAuthenticationPrivateKey()
+        addV3ClientAuthenticationPrivateKey(name = validNickname + "_diff", "$validOnion.onion")
+    }
+
     @Test(expected = AssertionError::class)
     fun `check assertion method throws exception if null`() {
         checkAddAuthPrivateAssertions(null)

--- a/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
+++ b/topl-core/src/test/java/io/matthewnelson/topl_core/util/OnionAuthUtilitiesUnitTest.kt
@@ -192,6 +192,12 @@ class OnionAuthUtilitiesUnitTest {
         addV3ClientAuthenticationPrivateKey()
     }
 
+    @Test(expected = IllegalStateException::class)
+    fun `file with same content already exists throws exception`() {
+        addV3ClientAuthenticationPrivateKey()
+        addV3ClientAuthenticationPrivateKey(name = validNickname + "_diff")
+    }
+
     @Test(expected = AssertionError::class)
     fun `check assertion method throws exception if null`() {
         checkAddAuthPrivateAssertions(null)
@@ -244,10 +250,10 @@ class OnionAuthUtilitiesUnitTest {
     }
 
     @Throws(AssertionError::class)
-    private fun checkAddAuthPrivateAssertions(file: File?) {
+    private fun checkAddAuthPrivateAssertions(file: File?, expectedContent: String = expectedFileContent) {
         Assert.assertTrue(file?.exists() == true)
         Assert.assertEquals(file?.parentFile, torConfigFiles.v3AuthPrivateDir)
-        Assert.assertEquals(expectedFileContent, file?.readText())
+        Assert.assertEquals(expectedContent, file?.readText())
     }
 
 
@@ -265,12 +271,12 @@ class OnionAuthUtilitiesUnitTest {
         val name1 = "name1"
         val name2 = "name2"
         val name3 = "name3"
-        val file1 = addV3ClientAuthenticationPrivateKey(name1)
-        val file2 = addV3ClientAuthenticationPrivateKey(name2)
-        val file3 = addV3ClientAuthenticationPrivateKey(name3)
-        checkAddAuthPrivateAssertions(file1)
-        checkAddAuthPrivateAssertions(file2)
-        checkAddAuthPrivateAssertions(file3)
+        val file1 = addV3ClientAuthenticationPrivateKey(name1, privateKey = validClientAuthKey.dropLast(1) + "A")
+        val file2 = addV3ClientAuthenticationPrivateKey(name2, privateKey = validClientAuthKey.dropLast(1) + "B")
+        val file3 = addV3ClientAuthenticationPrivateKey(name3, privateKey = validClientAuthKey.dropLast(1) + "C")
+        checkAddAuthPrivateAssertions(file1, expectedFileContent.dropLast(1) + "A")
+        checkAddAuthPrivateAssertions(file2, expectedFileContent.dropLast(1) + "B")
+        checkAddAuthPrivateAssertions(file3, expectedFileContent.dropLast(1) + "C")
 
         val expectedArray = arrayOf(file1, file2, file3)
 
@@ -316,12 +322,12 @@ class OnionAuthUtilitiesUnitTest {
         val name1 = "name1"
         val name2 = "name2"
         val name3 = "name3"
-        val file1 = addV3ClientAuthenticationPrivateKey(name1)
-        val file2 = addV3ClientAuthenticationPrivateKey(name2)
-        val file3 = addV3ClientAuthenticationPrivateKey(name3)
-        checkAddAuthPrivateAssertions(file1)
-        checkAddAuthPrivateAssertions(file2)
-        checkAddAuthPrivateAssertions(file3)
+        val file1 = addV3ClientAuthenticationPrivateKey(name1, privateKey = validClientAuthKey.dropLast(1) + "A")
+        val file2 = addV3ClientAuthenticationPrivateKey(name2, privateKey = validClientAuthKey.dropLast(1) + "B")
+        val file3 = addV3ClientAuthenticationPrivateKey(name3, privateKey = validClientAuthKey.dropLast(1) + "C")
+        checkAddAuthPrivateAssertions(file1, expectedFileContent.dropLast(1) + "A")
+        checkAddAuthPrivateAssertions(file2, expectedFileContent.dropLast(1) + "B")
+        checkAddAuthPrivateAssertions(file3, expectedFileContent.dropLast(1) + "C")
 
         val expectedNicknames = arrayOf(name1, name2, name3)
 

--- a/topl-service-base/build.gradle
+++ b/topl-service-base/build.gradle
@@ -46,6 +46,7 @@ dokka {
         includeNonPublic = false
         skipEmptyPackages = true
         samples = [
+                "$rootDir/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyServiceExecutionHooks.kt".toString(),
                 "$rootDir/sampleapp/src/main/java/io/matthewnelson/sampleapp/topl_android/MyEventBroadcaster.kt".toString()
         ]
         sourceLink {

--- a/topl-service-base/build.gradle
+++ b/topl-service-base/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply from: rootProject.file('gradle/maven-publish.gradle')
 
 android {

--- a/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/BaseServiceConsts.kt
+++ b/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/BaseServiceConsts.kt
@@ -100,6 +100,37 @@ abstract class BaseServiceConsts: BaseConsts() {
     }
 
 
+    /////////////////////
+    /// ServiceAction ///
+    /////////////////////
+    @Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.TYPE,
+        AnnotationTarget.PROPERTY
+    )
+    @StringDef(
+        ServiceActionName.DISABLE_NETWORK,
+        ServiceActionName.ENABLE_NETWORK,
+        ServiceActionName.NEW_ID,
+        ServiceActionName.RESTART_TOR,
+        ServiceActionName.START,
+        ServiceActionName.STOP
+    )
+    @Retention(AnnotationRetention.SOURCE)
+    annotation class ServiceActionName {
+        companion object {
+            private const val ACTION_NAME = "Action_"
+            const val DISABLE_NETWORK = "${ACTION_NAME}DISABLE_NETWORK"
+            const val ENABLE_NETWORK = "${ACTION_NAME}ENABLE_NETWORK"
+            const val NEW_ID = "${ACTION_NAME}NEW_ID"
+            const val RESTART_TOR = "${ACTION_NAME}RESTART_TOR"
+            const val START = "${ACTION_NAME}START"
+            const val STOP = "${ACTION_NAME}STOP"
+        }
+    }
+
+
     ////////////////////////////////
     /// Service Lifecycle Events ///
     ////////////////////////////////

--- a/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/BaseServiceConsts.kt
+++ b/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/BaseServiceConsts.kt
@@ -100,9 +100,43 @@ abstract class BaseServiceConsts: BaseConsts() {
     }
 
 
+    ////////////////////////////////
+    /// Service Lifecycle Events ///
+    ////////////////////////////////
+    @Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.PROPERTY,
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.TYPE
+    )
+    @StringDef(
+        ServiceLifecycleEvent.CREATED,
+        ServiceLifecycleEvent.DESTROYED,
+        ServiceLifecycleEvent.ON_BIND,
+        ServiceLifecycleEvent.ON_UNBIND,
+        ServiceLifecycleEvent.TASK_REMOVED,
+    )
+    @Retention(AnnotationRetention.SOURCE)
+    annotation class ServiceLifecycleEvent {
+        companion object {
+            const val CREATED = "onCreate"
+            const val DESTROYED = "onDestroy"
+            const val ON_BIND = "onBind"
+            const val ON_UNBIND = "onUnbind"
+            const val TASK_REMOVED = "onTaskRemoved"
+        }
+    }
+
+
     ///////////////////////
     /// TorServicePrefs ///
     ///////////////////////
+    @Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.PROPERTY,
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.TYPE
+    )
     @StringDef(
         PrefKeyBoolean.DISABLE_NETWORK,
         PrefKeyBoolean.HAS_BRIDGES,
@@ -142,6 +176,12 @@ abstract class BaseServiceConsts: BaseConsts() {
         }
     }
 
+    @Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.PROPERTY,
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.TYPE
+    )
     @StringDef(
         PrefKeyInt.DORMANT_CLIENT_TIMEOUT,
         PrefKeyInt.PROXY_PORT,
@@ -157,6 +197,12 @@ abstract class BaseServiceConsts: BaseConsts() {
         }
     }
 
+    @Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.PROPERTY,
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.TYPE
+    )
     @StringDef(
         PrefKeyList.DNS_PORT_ISOLATION_FLAGS,
         PrefKeyList.HTTP_TUNNEL_PORT_ISOLATION_FLAGS,
@@ -176,6 +222,12 @@ abstract class BaseServiceConsts: BaseConsts() {
         }
     }
 
+    @Target(
+        AnnotationTarget.CLASS,
+        AnnotationTarget.PROPERTY,
+        AnnotationTarget.VALUE_PARAMETER,
+        AnnotationTarget.TYPE
+    )
     @StringDef(
         PrefKeyString.DNS_PORT,
         PrefKeyString.CUSTOM_TORRC,

--- a/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/BaseV3ClientAuthManager.kt
+++ b/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/BaseV3ClientAuthManager.kt
@@ -106,7 +106,8 @@ abstract class BaseV3ClientAuthManager {
      *
      * @return The File if it was created properly, `null` if it was not
      * @throws [IllegalArgumentException] If passed arguments are not compliant with the spec
-     * @throws [IllegalStateException] If the file already exists (and must be deleted before overwriting)
+     * @throws [IllegalStateException] If the file already exists (and must be deleted before
+     *   overwriting), or if a file exists with the same onion address & private key
      * @throws [SecurityException] If access is not authorized
      * */
     @WorkerThread

--- a/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/ServiceExecutionHooks.kt
+++ b/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/ServiceExecutionHooks.kt
@@ -8,17 +8,35 @@ import android.content.Context
 abstract class ServiceExecutionHooks {
 
     /**
-     * Is executed from TorService.onCreate on Dispatchers.Main
+     * Is executed from TorService.onCreate on Dispatchers.Default launched from
+     * it's own coroutine.
      * */
-    abstract suspend fun executeOnCreateTorService(context: Context)
+    open suspend fun executeOnCreateTorService(context: Context) {}
 
     /**
-     * Is executed from ServiceActionProcessor.processQueue on Dispatchers.Main
+     * Is executed from TorService.startTor on Dispatchers.IO
+     *
+     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
+     * Flow or something) will inhibit the reset of the `startTor` method from
+     * executing; perform those tasks from [executeOnCreateTorService].
+     *
+     * This is meant to provide synchronous execution prior to the
+     * start of Tor.
+     *
+     * **NOTE**: Exceptions thrown from your implementation will inhibit starting
+     * Tor and will be broadcast via the EventBroadcaster.
      * */
-    abstract suspend fun executeBeforeStartTor(context: Context)
+    open suspend fun executeBeforeStartTor(context: Context) {}
 
     /**
-     * Is executed from ServiceActionProcessor.processQueue on Dispatchers.Main
+     * Is executed from TorService.stopTor on Dispatchers.IO
+     *
+     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
+     * Flow or something) will inhibit the reset of the `stopTor` method from
+     * executing; perform those tasks from [executeOnCreateTorService].
+     *
+     * This is meant to provide synchronous execution of code after Tor has been
+     * stopped, prior to TorService being stopped.
      * */
-    abstract suspend fun executeAfterStopTor(context: Context)
+    open suspend fun executeAfterStopTor(context: Context) {}
 }

--- a/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/ServiceExecutionHooks.kt
+++ b/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/ServiceExecutionHooks.kt
@@ -10,6 +10,9 @@ abstract class ServiceExecutionHooks {
     /**
      * Is executed from TorService.onCreate on Dispatchers.Default launched from
      * it's own coroutine.
+     *
+     * **NOTE**: Exceptions thrown from your implementation will be broadcast via
+     * the EventBroadcaster on Dispatchers.Main.
      * */
     open suspend fun executeOnCreateTorService(context: Context) {}
 
@@ -17,14 +20,14 @@ abstract class ServiceExecutionHooks {
      * Is executed from TorService.startTor on Dispatchers.IO
      *
      * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
-     * Flow or something) will inhibit the reset of the `startTor` method from
+     * Flow or something) will inhibit the rest of the `startTor` method from
      * executing; perform those tasks from [executeOnCreateTorService].
      *
-     * This is meant to provide synchronous execution prior to the
-     * start of Tor.
+     * This is meant to provide synchronous code execution prior to the
+     * start of Tor, and will be executed every single time Tor is started (even on restarts).
      *
      * **NOTE**: Exceptions thrown from your implementation will inhibit starting
-     * Tor and will be broadcast via the EventBroadcaster.
+     * Tor and will be broadcast via the EventBroadcaster on Dispatchers.Main.
      * */
     open suspend fun executeBeforeStartTor(context: Context) {}
 
@@ -32,11 +35,29 @@ abstract class ServiceExecutionHooks {
      * Is executed from TorService.stopTor on Dispatchers.IO
      *
      * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
-     * Flow or something) will inhibit the reset of the `stopTor` method from
+     * Flow or something) will inhibit the rest of the `stopTor` method from
      * executing; perform those tasks from [executeOnCreateTorService].
      *
-     * This is meant to provide synchronous execution of code after Tor has been
-     * stopped, prior to TorService being stopped.
+     * This is meant to provide synchronous code execution after Tor has been
+     * stopped, and will be executed every single time Tor is stopped (even on restarts).
+     *
+     * **NOTE**: Exceptions thrown from your implementation will be broadcast via
+     * the EventBroadcaster on Dispatchers.Main.
      * */
     open suspend fun executeAfterStopTor(context: Context) {}
+
+    /**
+     * Is executed from TorService.stopService on Dispatchers.IO
+     *
+     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
+     * Flow or something) will inhibit the rest of the `stopService` method from
+     * executing.
+     *
+     * This is meant to provide synchronous code execution prior to calling
+     * stopSelf() on the service.
+     *
+     * **NOTE**: Exceptions thrown from your implementation will be broadcast via
+     * the EventBroadcaster on Dispatchers.Main.
+     * */
+    open suspend fun executeBeforeStoppingService(context: Context) {}
 }

--- a/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/ServiceExecutionHooks.kt
+++ b/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/ServiceExecutionHooks.kt
@@ -4,6 +4,8 @@ import android.content.Context
 
 /**
  * Set Hooks to be executed from TorService.
+ *
+ * @sample [io.matthewnelson.sampleapp.topl_android.MyServiceExecutionHooks]
  * */
 abstract class ServiceExecutionHooks {
 
@@ -13,51 +15,96 @@ abstract class ServiceExecutionHooks {
      *
      * **NOTE**: Exceptions thrown from your implementation will be broadcast via
      * the EventBroadcaster on Dispatchers.Main.
+     *
+     * @sample [io.matthewnelson.sampleapp.topl_android.MyServiceExecutionHooks.executeOnCreateTorService]
      * */
     open suspend fun executeOnCreateTorService(context: Context) {}
 
     /**
      * Is executed from TorService.startTor on Dispatchers.IO
      *
-     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
-     * Flow or something) will inhibit the rest of the `startTor` method from
-     * executing; perform those tasks from [executeOnCreateTorService].
-     *
      * This is meant to provide synchronous code execution prior to the
      * start of Tor, and will be executed every single time Tor is started (even on restarts).
      *
+     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
+     * Flow or something) will also indefinitely suspend the ServiceActionProcessor
+     * which will inhibit processing of any other commands; perform those tasks
+     * from [executeOnCreateTorService].
+     *
      * **NOTE**: Exceptions thrown from your implementation will inhibit starting
      * Tor and will be broadcast via the EventBroadcaster on Dispatchers.Main.
+     *
+     * @sample [io.matthewnelson.sampleapp.topl_android.MyServiceExecutionHooks.executeBeforeStartTor]
      * */
     open suspend fun executeBeforeStartTor(context: Context) {}
 
     /**
      * Is executed from TorService.stopTor on Dispatchers.IO
      *
-     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
-     * Flow or something) will inhibit the rest of the `stopTor` method from
-     * executing; perform those tasks from [executeOnCreateTorService].
-     *
      * This is meant to provide synchronous code execution after Tor has been
      * stopped, and will be executed every single time Tor is stopped (even on restarts).
      *
+     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
+     * Flow or something) will also indefinitely suspend the ServiceActionProcessor
+     * which will inhibit processing of any other commands; perform those tasks
+     * from [executeOnCreateTorService].
+     *
      * **NOTE**: Exceptions thrown from your implementation will be broadcast via
      * the EventBroadcaster on Dispatchers.Main.
+     *
+     * @sample [io.matthewnelson.sampleapp.topl_android.MyServiceExecutionHooks.executeAfterStopTor]
      * */
     open suspend fun executeAfterStopTor(context: Context) {}
 
     /**
      * Is executed from TorService.stopService on Dispatchers.IO
      *
-     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
-     * Flow or something) will inhibit the rest of the `stopService` method from
-     * executing.
-     *
      * This is meant to provide synchronous code execution prior to calling
-     * stopSelf() on the service.
+     * stopSelf() on the service. When this is called for execution,
+     * [executeOnStartCommandBeforeStartTor], will be allowed to execute again
+     * if TorServiceController.startTor() is called prior to this method's completion.
+     *
+     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
+     * Flow or something) will also indefinitely suspend the ServiceActionProcessor
+     * which will inhibit processing of any other commands; perform those tasks
+     * from [executeOnCreateTorService].
      *
      * **NOTE**: Exceptions thrown from your implementation will be broadcast via
      * the EventBroadcaster on Dispatchers.Main.
+     *
+     * @sample [io.matthewnelson.sampleapp.topl_android.MyServiceExecutionHooks.executeBeforeStoppingService]
      * */
     open suspend fun executeBeforeStoppingService(context: Context) {}
+
+    /**
+     * Is executed from TorService.onStartCommand on Dispatchers.Default. This works in
+     * conjunction with [executeBeforeStoppingService] such that if
+     * [executeBeforeStoppingService] is active, [executeOnStartCommandBeforeStartTor] will
+     * suspend until that has been completed, then execute, then start Tor.
+     *
+     * This is meant to provide quasi one-time synchronous code execution at first start of
+     * TorService, prior to starting Tor.
+     *
+     * Example usage:
+     *
+     *   If you want to query a DB for V3 Client Authorization Keys stored in
+     *   an encrypted fashion, write them to disk prior to first start of Tor, then in
+     *   [executeBeforeStoppingService] delete the private keys.
+     *
+     *   If the user (or some other process) executes TorServiceController.startTor()
+     *   while [executeBeforeStoppingService] is active, TorService.stopSelf() be prevented
+     *   from being called, execution of this method will suspend until
+     *   [executeBeforeStoppingService] completes, then execute, then Tor will be started again.
+     *
+     * **WARNING**: Indefinitely suspending the coroutine (ex. collecting
+     * Flow or something) will also indefinitely suspend the ServiceActionProcessor
+     * which will inhibit processing of any other commands; perform those tasks
+     * from [executeOnCreateTorService].
+     *
+     * **NOTE**: Exceptions thrown from your implementation will be broadcast via
+     * the EventBroadcaster on Dispatchers.Main.
+     *
+     * @sample [io.matthewnelson.sampleapp.topl_android.MyServiceExecutionHooks.executeOnStartCommandBeforeStartTor]
+     * */
+    open suspend fun executeOnStartCommandBeforeStartTor(context: Context) {}
 }

--- a/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/ServiceExecutionHooks.kt
+++ b/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/ServiceExecutionHooks.kt
@@ -1,0 +1,24 @@
+package io.matthewnelson.topl_service_base
+
+import android.content.Context
+
+/**
+ * Set Hooks to be executed from TorService.
+ * */
+abstract class ServiceExecutionHooks {
+
+    /**
+     * Is executed from TorService.onCreate on Dispatchers.Main
+     * */
+    abstract suspend fun executeOnCreateTorService(context: Context)
+
+    /**
+     * Is executed from ServiceActionProcessor.processQueue on Dispatchers.Main
+     * */
+    abstract suspend fun executeBeforeStartTor(context: Context)
+
+    /**
+     * Is executed from ServiceActionProcessor.processQueue on Dispatchers.Main
+     * */
+    abstract suspend fun executeAfterStopTor(context: Context)
+}

--- a/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/TorServiceEventBroadcaster.kt
+++ b/topl-service-base/src/main/java/io/matthewnelson/topl_service_base/TorServiceEventBroadcaster.kt
@@ -71,6 +71,7 @@
 * */
 package io.matthewnelson.topl_service_base
 
+import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceLifecycleEvent
 import io.matthewnelson.topl_core_base.EventBroadcaster
 
 /**
@@ -98,4 +99,6 @@ abstract class TorServiceEventBroadcaster: EventBroadcaster() {
      * @see [TorPortInfo]
      * */
     abstract fun broadcastPortInformation(torPortInfo: TorPortInfo)
+
+    open fun broadcastServiceLifecycleEvent(@ServiceLifecycleEvent event: String, hashCode: Int) {}
 }

--- a/topl-service/build.gradle
+++ b/topl-service/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply from: rootProject.file('gradle/maven-publish.gradle')
 
 android {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -123,14 +123,14 @@ class TorServiceController private constructor(): ServiceConsts() {
     ) {
 
 //        private var heartbeatTime = BackgroundManager.heartbeatTime
-        private var disableNetworkDelay = ServiceActionProcessor.disableNetworkDelay
-        private var restartTorDelayTime = ServiceActionProcessor.restartTorDelayTime
-        private var stopServiceDelayTime = ServiceActionProcessor.stopServiceDelayTime
+        private var disableNetworkDelay = ServiceActionProcessor.getDisableNetworkDelay()
+        private var restartTorDelayTime = ServiceActionProcessor.getRestartTorDelayTime()
+        private var stopServiceDelayTime = ServiceActionProcessor.getStopServiceDelayTime()
         private var stopServiceOnTaskRemoved = true
         private var torConfigFiles: TorConfigFiles? = null
 
         // On published releases of this Library, this value will **always** be `false`.
-        private var buildConfigDebug = BaseService.buildConfigDebug
+        private var buildConfigDebug = BaseService.getBuildConfigDebug()
 
         /**
          * Default is set to 6_000ms, (what this method adds time to).
@@ -352,7 +352,7 @@ class TorServiceController private constructor(): ServiceConsts() {
         @Throws(RuntimeException::class)
         fun getTorConfigFiles(): TorConfigFiles {
             return try {
-                BaseService.torConfigFiles
+                BaseService.getTorConfigFiles()
             } catch (e: UninitializedPropertyAccessException) {
                 throw RuntimeException(e.message)
             }
@@ -370,7 +370,7 @@ class TorServiceController private constructor(): ServiceConsts() {
         @Throws(RuntimeException::class)
         fun getDefaultTorSettings(): ApplicationDefaultTorSettings {
             return try {
-                BaseService.defaultTorSettings
+                BaseService.getApplicationDefaultTorSettings()
             } catch (e: UninitializedPropertyAccessException) {
                 throw RuntimeException(e.message)
             }
@@ -387,7 +387,7 @@ class TorServiceController private constructor(): ServiceConsts() {
         @JvmStatic
         @Throws(RuntimeException::class)
         fun getV3ClientAuthManager(): BaseV3ClientAuthManager =
-            V3ClientAuthManager(getTorConfigFiles())
+            V3ClientAuthManager.instantiate(getTorConfigFiles())
 
         /**
          * This method will *never* throw the [RuntimeException] if you call it after
@@ -399,7 +399,7 @@ class TorServiceController private constructor(): ServiceConsts() {
         @JvmStatic
         @Throws(RuntimeException::class)
         fun getServiceTorSettings(): BaseServiceTorSettings =
-            ServiceTorSettings(
+            ServiceTorSettings.instantiate(
                 TorServicePrefs(BaseService.getAppContext()), getDefaultTorSettings()
             )
 
@@ -423,7 +423,7 @@ class TorServiceController private constructor(): ServiceConsts() {
          * */
         @JvmStatic
         fun stopTor() {
-            TorServiceConnection.serviceBinder?.submitServiceAction(ServiceAction.Stop())
+            TorServiceConnection.getServiceBinder()?.submitServiceAction(ServiceAction.Stop.instantiate())
         }
 
         /**
@@ -431,7 +431,7 @@ class TorServiceController private constructor(): ServiceConsts() {
          * */
         @JvmStatic
         fun restartTor() {
-            TorServiceConnection.serviceBinder?.submitServiceAction(ServiceAction.RestartTor())
+            TorServiceConnection.getServiceBinder()?.submitServiceAction(ServiceAction.RestartTor.instantiate())
         }
 
         /**
@@ -439,7 +439,7 @@ class TorServiceController private constructor(): ServiceConsts() {
          * */
         @JvmStatic
         fun newIdentity() {
-            TorServiceConnection.serviceBinder?.submitServiceAction(ServiceAction.NewId())
+            TorServiceConnection.getServiceBinder()?.submitServiceAction(ServiceAction.NewId.instantiate())
         }
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/TorServiceController.kt
@@ -246,8 +246,20 @@ class TorServiceController private constructor(): ServiceConsts() {
          * class actually is.
          * */
         fun setEventBroadcaster(eventBroadcaster: TorServiceEventBroadcaster): Builder {
-            if (Companion.appEventBroadcaster == null) {
+            if (appEventBroadcaster == null) {
                 appEventBroadcaster = eventBroadcaster
+            }
+            return this
+        }
+
+        /**
+         * Implement and set hooks to be executed in [TorService.onCreate], and
+         * [ServiceActionProcessor.processServiceAction] prior to starting of Tor, and
+         * post stopping of Tor.
+         * */
+        fun setServiceExecutionHooks(executionHooks: ServiceExecutionHooks): Builder {
+            if (serviceExecutionHooks == null) {
+                serviceExecutionHooks = executionHooks
             }
             return this
         }
@@ -321,6 +333,10 @@ class TorServiceController private constructor(): ServiceConsts() {
 
         @JvmStatic
         var appEventBroadcaster: TorServiceEventBroadcaster? = null
+            private set
+
+        @JvmStatic
+        var serviceExecutionHooks: ServiceExecutionHooks? = null
             private set
 
         /**

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefsListener.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/prefs/TorServicePrefsListener.kt
@@ -75,22 +75,29 @@ import android.content.SharedPreferences
 import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.service.TorService
 import io.matthewnelson.topl_service_base.BaseServiceConsts.PrefKeyBoolean
+import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceActionName
 import io.matthewnelson.topl_service_base.TorServicePrefs
 
 /**
  * Listens to [TorServicePrefs] for changes such that while Tor is running, it can
  * query [TorService.onionProxyManager] to have it updated immediately (if the setting doesn't
- * require a restart), or submit [io.matthewnelson.topl_service.util.ServiceConsts.ServiceActionName]'s
- * to [io.matthewnelson.topl_service.service.components.actions.ServiceActionProcessor] to be
+ * require a restart), or submit [ServiceActionName]'s to
+ * [io.matthewnelson.topl_service.service.components.actions.ServiceActionProcessor] to be
  * queued for execution.
  *
  * @param [torService] To instantiate [TorServicePrefs]
  * */
-internal class TorServicePrefsListener(
+internal class TorServicePrefsListener private constructor(
     private val torService: BaseService
 ): SharedPreferences.OnSharedPreferenceChangeListener {
 
-    private val torServicePrefs = TorServicePrefs(torService.context)
+    companion object {
+        @JvmSynthetic
+        fun instantiate(torService: BaseService): TorServicePrefsListener =
+            TorServicePrefsListener(torService)
+    }
+
+    private val torServicePrefs = TorServicePrefs(torService.getContext())
     private val broadcastLogger = torService.getBroadcastLogger(TorServicePrefsListener::class.java)
 
     init {
@@ -101,6 +108,7 @@ internal class TorServicePrefsListener(
     /**
      * Called from [TorService.onDestroy].
      * */
+    @JvmSynthetic
     fun unregister() {
         torServicePrefs.unregisterListener(this)
         broadcastLogger.debug("Has been unregistered")

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/BaseService.kt
@@ -89,9 +89,9 @@ import io.matthewnelson.topl_service.prefs.TorServicePrefsListener
 import io.matthewnelson.topl_service.service.components.actions.ServiceActionProcessor
 import io.matthewnelson.topl_service.service.components.actions.ServiceAction
 import io.matthewnelson.topl_service.service.components.binding.TorServiceConnection
-import io.matthewnelson.topl_service.util.ServiceConsts.ServiceActionName
 import io.matthewnelson.topl_service.util.ServiceConsts.NotificationImage
 import io.matthewnelson.topl_service_base.ApplicationDefaultTorSettings
+import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceActionName
 import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceLifecycleEvent
 import kotlinx.coroutines.CoroutineScope
 import java.io.File

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -94,22 +94,23 @@ import java.lang.reflect.InvocationTargetException
  *
  * @see [BaseService]
  * */
-internal class TorService: BaseService() {
+internal class TorService internal constructor(): BaseService() {
 
-    override val context: Context
-        get() = this
+    @JvmSynthetic
+    override fun getContext(): Context = this
 
 
     ///////////////
     /// Binding ///
     ///////////////
     private val torServiceBinder: TorServiceBinder by lazy {
-        TorServiceBinder(this)
+        TorServiceBinder.instantiate(this)
     }
 
+    @JvmSynthetic
     override fun unbindTorService() {
         try {
-            unbindService(context)
+            unbindService(getContext())
             super.unbindTorService()
         } catch (e: IllegalArgumentException) {}
     }
@@ -123,14 +124,17 @@ internal class TorService: BaseService() {
     /// BroadcastReceiver ///
     /////////////////////////
     private val torServiceReceiver by lazy {
-        TorServiceReceiver(this)
+        TorServiceReceiver.instantiate(this)
     }
+    @JvmSynthetic
     override fun registerReceiver() {
         torServiceReceiver.register()
     }
+    @JvmSynthetic
     override fun setIsDeviceLocked() {
         torServiceReceiver.setDeviceIsLocked()
     }
+    @JvmSynthetic
     override fun unregisterReceiver() {
         torServiceReceiver.unregister()
     }
@@ -144,12 +148,15 @@ internal class TorService: BaseService() {
     private val scopeIO = CoroutineScope(Dispatchers.IO + supervisorJob)
     private val scopeMain = CoroutineScope(Dispatchers.Main + supervisorJob)
 
+    @JvmSynthetic
     override fun getScopeDefault(): CoroutineScope {
         return scopeDefault
     }
+    @JvmSynthetic
     override fun getScopeIO(): CoroutineScope {
         return scopeIO
     }
+    @JvmSynthetic
     override fun getScopeMain(): CoroutineScope {
         return scopeMain
     }
@@ -168,10 +175,11 @@ internal class TorService: BaseService() {
 
     // See BaseService
 
+    @JvmSynthetic
     override fun refreshNotificationActions(): Boolean {
         val wasRefreshed = super.refreshNotificationActions()
         if (wasRefreshed) {
-            val debugMsg = if (TorServiceReceiver.deviceIsLocked == true)
+            val debugMsg = if (TorServiceReceiver.deviceIsLocked() == true)
                 "Removed Notification Actions"
             else
                 "Added Notification Actions"
@@ -179,6 +187,7 @@ internal class TorService: BaseService() {
         }
         return wasRefreshed
     }
+    @JvmSynthetic
     override fun startForegroundService(): Boolean {
         val wasStarted = super.startForegroundService()
         if (wasStarted) {
@@ -186,6 +195,7 @@ internal class TorService: BaseService() {
         }
         return wasStarted
     }
+    @JvmSynthetic
     override fun stopForegroundService(): Boolean {
         val wasStopped = super.stopForegroundService()
         if (wasStopped) {
@@ -203,62 +213,73 @@ internal class TorService: BaseService() {
     }
     private val onionProxyManager: OnionProxyManager by lazy {
         OnionProxyManager(
-            context,
+            getContext(),
             TorServiceController.getTorConfigFiles(),
-            ServiceTorInstaller(this),
+            ServiceTorInstaller.instantiate(this),
             TorServiceController.getServiceTorSettings(),
-            ServiceEventListener(),
-            ServiceEventBroadcaster(this),
-            buildConfigDebug
+            ServiceEventListener.instantiate(),
+            ServiceEventBroadcaster.instantiate(this),
+            getBuildConfigDebug()
         )
     }
 
+    @JvmSynthetic
     @WorkerThread
     @Throws(IOException::class)
     override fun copyAsset(assetPath: String, file: File) {
         try {
-            FileUtilities.copy(context.assets.open(assetPath), file.outputStream())
+            FileUtilities.copy(getContext().assets.open(assetPath), file.outputStream())
         } catch (e: Exception) {
             throw IOException("Failed copying asset from $assetPath", e)
         }
     }
+    @JvmSynthetic
     @WorkerThread
     @Throws(IOException::class, NullPointerException::class)
     override fun disableNetwork(disable: Boolean) {
         onionProxyManager.disableNetwork(disable)
     }
+    @JvmSynthetic
     override fun getBroadcastLogger(clazz: Class<*>): BroadcastLogger {
         return onionProxyManager.getBroadcastLogger(clazz)
     }
+    @JvmSynthetic
     override fun hasNetworkConnectivity(): Boolean {
         return onionProxyManager.hasNetworkConnectivity()
     }
+    @JvmSynthetic
     override fun hasControlConnection(): Boolean {
         return onionProxyManager.hasControlConnection
     }
+    @JvmSynthetic
     override fun isTorOff(): Boolean {
         return onionProxyManager.torStateMachine.isOff
     }
+    @JvmSynthetic
     override fun isTorOn(): Boolean {
         return onionProxyManager.torStateMachine.isOn
     }
+    @JvmSynthetic
     override fun refreshBroadcastLoggersHasDebugLogsVar() {
         onionProxyManager.refreshBroadcastLoggersHasDebugLogsVar()
     }
+    @JvmSynthetic
     @WorkerThread
     override fun signalControlConnection(torControlCommand: String): Boolean {
         return onionProxyManager.signalControlConnection(torControlCommand)
     }
+    @JvmSynthetic
     @WorkerThread
     override suspend fun signalNewNym() {
         onionProxyManager.signalNewNym()
     }
+    @JvmSynthetic
     @WorkerThread
     @Suppress("BlockingMethodInNonBlockingContext")
     override suspend fun startTor() {
         try {
             TorServiceController.serviceExecutionHooks
-                ?.executeBeforeStartTor(context.applicationContext)
+                ?.executeBeforeStartTor(getContext().applicationContext)
 
             onionProxyManager.setup()
             generateTorrcFile()
@@ -269,8 +290,9 @@ internal class TorService: BaseService() {
             broadcastLogger.exception(e)
         }
     }
-    @Suppress("BlockingMethodInNonBlockingContext")
+    @JvmSynthetic
     @WorkerThread
+    @Suppress("BlockingMethodInNonBlockingContext")
     override suspend fun stopTor() {
 
         try {
@@ -283,7 +305,7 @@ internal class TorService: BaseService() {
 
         try {
             TorServiceController.serviceExecutionHooks
-                ?.executeAfterStopTor(context.applicationContext)
+                ?.executeAfterStopTor(getContext().applicationContext)
         } catch (e: Exception) {
             broadcastLogger.exception(e)
         }
@@ -315,7 +337,7 @@ internal class TorService: BaseService() {
 
 
     override fun onCreate() {
-        broadcastLogger.notice("BuildConfig.DEBUG set to: $buildConfigDebug")
+        broadcastLogger.notice("BuildConfig.DEBUG set to: ${getBuildConfigDebug()}")
         super.onCreate()
     }
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/TorService.kt
@@ -110,11 +110,11 @@ internal class TorService: BaseService() {
     override fun unbindTorService() {
         try {
             unbindService(context)
-            broadcastLogger.debug("Has been unbound")
+            super.unbindTorService()
         } catch (e: IllegalArgumentException) {}
     }
     override fun onBind(intent: Intent?): IBinder? {
-        broadcastLogger.debug("Has been bound")
+        super.onBind(null)
         return torServiceBinder
     }
 
@@ -295,7 +295,7 @@ internal class TorService: BaseService() {
 
 
     override fun onCreate() {
-        broadcastLogger.notice("Created. BuildConfig.DEBUG set to: $buildConfigDebug")
+        broadcastLogger.notice("BuildConfig.DEBUG set to: $buildConfigDebug")
         super.onCreate()
     }
 
@@ -309,7 +309,6 @@ internal class TorService: BaseService() {
     override fun onTaskRemoved(rootIntent: Intent?) {
         // Cancel the BackgroundManager's coroutine if it's active so it doesn't execute
         torServiceBinder.cancelExecuteBackgroundPolicyJob()
-        broadcastLogger.notice("Task has been removed")
         super.onTaskRemoved(rootIntent)
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceAction.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceAction.kt
@@ -72,7 +72,7 @@
 package io.matthewnelson.topl_service.service.components.actions
 
 import io.matthewnelson.topl_service.util.ServiceConsts.ServiceActionCommand
-import io.matthewnelson.topl_service.util.ServiceConsts.ServiceActionName
+import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceActionName
 
 /**
  * There are multiple avenues to interacting with a Service (BroadcastReceiver, Binder,

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceAction.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceAction.kt
@@ -107,6 +107,7 @@ internal sealed class ServiceAction {
      *
      * @return The 0th element within [delayLengthQueue], or 0L if empty
      * */
+    @JvmSynthetic
     fun consumeDelayLength(): Long =
         if (delayLengthQueue.isNotEmpty())
             delayLengthQueue.removeAt(0)
@@ -123,10 +124,19 @@ internal sealed class ServiceAction {
      * */
     open val updateLastAction: Boolean = true
 
-    class SetDisableNetwork(
+    internal class SetDisableNetwork private constructor(
         override val name: String,
         updateLastServiceAction: Boolean = false
     ): ServiceAction() {
+
+        companion object {
+            @JvmSynthetic
+            fun instantiate(
+                name: String,
+                updateLastServiceAction: Boolean = false
+            ): SetDisableNetwork =
+                SetDisableNetwork(name, updateLastServiceAction)
+        }
 
         override val commands: Array<String>
             get() = when (name) {
@@ -149,12 +159,18 @@ internal sealed class ServiceAction {
             }
 
 
-        override val delayLengthQueue = mutableListOf(ServiceActionProcessor.disableNetworkDelay)
+        override val delayLengthQueue = mutableListOf(ServiceActionProcessor.getDisableNetworkDelay())
 
         override val updateLastAction: Boolean = updateLastServiceAction
     }
 
-    class NewId: ServiceAction() {
+    internal class NewId private constructor(): ServiceAction() {
+
+        companion object {
+            @JvmSynthetic
+            fun instantiate(): NewId =
+                NewId()
+        }
 
         @ServiceActionName
         override val name: String = ServiceActionName.NEW_ID
@@ -165,7 +181,13 @@ internal sealed class ServiceAction {
             )
     }
 
-    class RestartTor: ServiceAction() {
+    internal class RestartTor private constructor(): ServiceAction() {
+
+        companion object {
+            @JvmSynthetic
+            fun instantiate(): RestartTor =
+                RestartTor()
+        }
 
         @ServiceActionName
         override val name: String = ServiceActionName.RESTART_TOR
@@ -177,10 +199,18 @@ internal sealed class ServiceAction {
                 ServiceActionCommand.START_TOR
             )
 
-        override val delayLengthQueue = mutableListOf(ServiceActionProcessor.restartTorDelayTime)
+        override val delayLengthQueue = mutableListOf(ServiceActionProcessor.getRestartTorDelayTime())
     }
 
-    class Start(updateLastServiceAction: Boolean = true): ServiceAction() {
+    internal class Start private constructor(
+        updateLastServiceAction: Boolean = true
+    ): ServiceAction() {
+
+        companion object {
+            @JvmSynthetic
+            fun instantiate(updateLastServiceAction: Boolean = true): Start =
+                Start(updateLastServiceAction)
+        }
 
         @ServiceActionName
         override val name: String = ServiceActionName.START
@@ -193,7 +223,15 @@ internal sealed class ServiceAction {
         override val updateLastAction: Boolean = updateLastServiceAction
     }
 
-    class Stop(updateLastServiceAction: Boolean = true): ServiceAction() {
+    internal class Stop private constructor(
+        updateLastServiceAction: Boolean = true
+    ): ServiceAction() {
+
+        companion object {
+            @JvmSynthetic
+            fun instantiate(updateLastServiceAction: Boolean = true): Stop =
+                Stop(updateLastServiceAction)
+        }
 
         @ServiceActionName
         override val name: String = ServiceActionName.STOP
@@ -205,7 +243,7 @@ internal sealed class ServiceAction {
                 ServiceActionCommand.STOP_SERVICE
             )
 
-        override val delayLengthQueue = mutableListOf(ServiceActionProcessor.stopServiceDelayTime)
+        override val delayLengthQueue = mutableListOf(ServiceActionProcessor.getStopServiceDelayTime())
 
         override val updateLastAction: Boolean = updateLastServiceAction
     }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
@@ -261,6 +261,7 @@ internal class ServiceActionProcessor private constructor(
             broadcastDebugMsgWithObjectDetails("Processing Queue: ", this)
 
             while (actionQueue.isNotEmpty() && isActive) {
+                torService.joinOnStartCommandExecutionHookJob()
                 val serviceAction = getActionQueueElementAtOrNull()
                 if (serviceAction == null) {
                     return@launch

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
@@ -287,9 +287,7 @@ internal class ServiceActionProcessor(private val torService: BaseService): Serv
                             }
                             ServiceActionCommand.START_TOR -> {
                                 if (!torService.hasControlConnection()) {
-                                    torService.executionHookPreStartTor()
                                     torService.startTor()
-                                    delay(300L)
                                 }
                             }
                             ServiceActionCommand.STOP_SERVICE -> {
@@ -299,8 +297,6 @@ internal class ServiceActionProcessor(private val torService: BaseService): Serv
                             ServiceActionCommand.STOP_TOR -> {
                                 if (torService.hasControlConnection()) {
                                     torService.stopTor()
-                                    delay(300L)
-                                    torService.executionHookPostStopTor()
                                 }
                             }
                         }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/actions/ServiceActionProcessor.kt
@@ -287,6 +287,7 @@ internal class ServiceActionProcessor(private val torService: BaseService): Serv
                             }
                             ServiceActionCommand.START_TOR -> {
                                 if (!torService.hasControlConnection()) {
+                                    torService.executionHookPreStartTor()
                                     torService.startTor()
                                     delay(300L)
                                 }
@@ -299,6 +300,7 @@ internal class ServiceActionProcessor(private val torService: BaseService): Serv
                                 if (torService.hasControlConnection()) {
                                     torService.stopTor()
                                     delay(300L)
+                                    torService.executionHookPostStopTor()
                                 }
                             }
                         }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/BaseServiceBinder.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/BaseServiceBinder.kt
@@ -82,14 +82,18 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 
-internal abstract class BaseServiceBinder(private val torService: BaseService): Binder() {
+internal abstract class BaseServiceBinder internal constructor(
+    private val torService: BaseService
+): Binder() {
 
+    @JvmSynthetic
     abstract fun getTorService(): BaseService?
 
     /**
      * Accepts all [ServiceAction] except [ServiceAction.Start], which gets issued via
      * [io.matthewnelson.topl_service.service.TorService.onStartCommand].
      * */
+    @JvmSynthetic
     fun submitServiceAction(serviceAction: ServiceAction) {
         if (serviceAction is ServiceAction.Start) return
         torService.processServiceAction(serviceAction)
@@ -112,6 +116,7 @@ internal abstract class BaseServiceBinder(private val torService: BaseService): 
      * @param [policy] The [BackgroundPolicy] to be executed
      * @param [executionDelay] the time expressed in your [BackgroundManager.Builder.Policy]
      * */
+    @JvmSynthetic
     fun executeBackgroundPolicyJob(@BackgroundPolicy policy: String, executionDelay: Long) {
         cancelExecuteBackgroundPolicyJob()
         backgroundPolicyExecutionJob = torService.getScopeMain().launch {
@@ -124,7 +129,7 @@ internal abstract class BaseServiceBinder(private val torService: BaseService): 
                     delay(executionDelay)
                     bgMgrBroadcastLogger.debug("Executing background management policy")
                     torService.processServiceAction(
-                        ServiceAction.Stop(updateLastServiceAction = false)
+                        ServiceAction.Stop.instantiate(updateLastServiceAction = false)
                     )
                 }
             }
@@ -134,6 +139,7 @@ internal abstract class BaseServiceBinder(private val torService: BaseService): 
     /**
      * Cancels the coroutine executing the [BackgroundPolicy] if it is active.
      * */
+    @JvmSynthetic
     fun cancelExecuteBackgroundPolicyJob() {
         backgroundPolicyExecutionJob?.let {
             if (it.isActive) {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/TorServiceBinder.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/TorServiceBinder.kt
@@ -74,11 +74,20 @@ package io.matthewnelson.topl_service.service.components.binding
 import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.service.TorService
 
-internal class TorServiceBinder(torService: TorService): BaseServiceBinder(torService) {
+internal class TorServiceBinder private constructor(
+    torService: TorService
+): BaseServiceBinder(torService) {
+
+    companion object {
+        @JvmSynthetic
+        fun instantiate(torService: TorService): TorServiceBinder =
+            TorServiceBinder(torService)
+    }
 
     /**
      * Always return null in production.
      * */
+    @JvmSynthetic
     override fun getTorService(): BaseService? {
         return null
     }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/TorServiceConnection.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/binding/TorServiceConnection.kt
@@ -75,16 +75,22 @@ import android.content.ComponentName
 import android.content.ServiceConnection
 import android.os.IBinder
 
-internal class TorServiceConnection: ServiceConnection {
+internal class TorServiceConnection private constructor(): ServiceConnection {
 
     companion object {
-        val torServiceConnection by lazy {
+        private val torServiceConnection by lazy {
             TorServiceConnection()
         }
 
+        @JvmSynthetic
+        internal fun getTorServiceConnection(): TorServiceConnection =
+            torServiceConnection
+
         @Volatile
-        var serviceBinder: BaseServiceBinder? = null
-            private set
+        private var serviceBinder: BaseServiceBinder? = null
+        @JvmSynthetic
+        fun getServiceBinder(): BaseServiceBinder? =
+            serviceBinder
     }
 
     /**
@@ -92,6 +98,7 @@ internal class TorServiceConnection: ServiceConnection {
      * [onServiceDisconnected] is not always called on disconnect, as the name
      * suggests.
      * */
+    @JvmSynthetic
     fun clearServiceBinderReference() {
         serviceBinder = null
     }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
@@ -263,28 +263,28 @@ internal class ServiceEventBroadcaster private constructor(
             }
             // Dns Port
             // NOTICE|OnionProxyManager|Opened DNS listener on 127.0.0.1:5400
-            msg.contains("Opened DNS listener on ") -> {
+            msg.contains("Opened DNS listener ") -> {
                 dnsPort = getPortFromMsg(msg)
                 if (isBootstrappingComplete())
                     updateAppEventBroadcasterWithPortInfo()
             }
             // Http Tunnel Port
             // NOTICE|BaseEventListener|Opened HTTP tunnel listener on 127.0.0.1:8118
-            msg.contains("Opened HTTP tunnel listener on ") -> {
+            msg.contains("Opened HTTP tunnel listener ") -> {
                 httpTunnelPort = getPortFromMsg(msg)
                 if (isBootstrappingComplete())
                     updateAppEventBroadcasterWithPortInfo()
             }
             // Socks Port
             // NOTICE|BaseEventListener|Opened Socks listener on 127.0.0.1:9050
-            msg.contains("Opened Socks listener on ") -> {
+            msg.contains("Opened Socks listener ") -> {
                 socksPort = getPortFromMsg(msg)
                 if (isBootstrappingComplete())
                     updateAppEventBroadcasterWithPortInfo()
             }
             // Trans Port
             // NOTICE|BaseEventListener|Opened Transparent pf/netfilter listener on 127.0.0.1:9040
-            msg.contains("Opened Transparent pf/netfilter listener on ") -> {
+            msg.contains("Opened Transparent pf/netfilter listener ") -> {
                 transPort = getPortFromMsg(msg)
                 if (isBootstrappingComplete())
                     updateAppEventBroadcasterWithPortInfo()

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
@@ -78,8 +78,8 @@ import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.service.components.actions.ServiceActionProcessor
 import io.matthewnelson.topl_service.service.TorService
 import io.matthewnelson.topl_service_base.TorPortInfo
-import io.matthewnelson.topl_service.util.ServiceConsts.ServiceActionName
 import io.matthewnelson.topl_service.util.ServiceConsts.NotificationImage
+import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceActionName
 import io.matthewnelson.topl_service_base.ServiceUtilities
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventBroadcaster.kt
@@ -97,7 +97,15 @@ import net.freehaven.tor.control.TorControlCommands
  *
  * @param [torService] [BaseService] for context.
  * */
-internal class ServiceEventBroadcaster(private val torService: BaseService): EventBroadcaster() {
+internal class ServiceEventBroadcaster private constructor(
+    private val torService: BaseService
+): EventBroadcaster() {
+
+    companion object {
+        @JvmSynthetic
+        fun instantiate(torService: BaseService): ServiceEventBroadcaster =
+            ServiceEventBroadcaster(torService)
+    }
 
     private val scopeMain: CoroutineScope
         get() = torService.getScopeMain()

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventListener.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceEventListener.kt
@@ -79,7 +79,13 @@ import net.freehaven.tor.control.TorControlCommands
  * [io.matthewnelson.topl_core.OnionProxyManager.start] method such that messages from
  * Tor get funneled here. They get modify as needed, then shipped to it's final destination.
  * */
-internal class ServiceEventListener: BaseEventListener() {
+internal class ServiceEventListener private constructor(): BaseEventListener() {
+
+    companion object {
+        @JvmSynthetic
+        fun instantiate(): ServiceEventListener =
+            ServiceEventListener()
+    }
 
     // broadcastLogger is available from BaseEventListener and is instantiated as soon as
     // OnionProxyManager gets initialized.

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorSettings.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/onionproxy/ServiceTorSettings.kt
@@ -80,10 +80,19 @@ import io.matthewnelson.topl_service_base.BaseServiceConsts.PrefKeyBoolean
 import io.matthewnelson.topl_service_base.BaseServiceTorSettings
 import io.matthewnelson.topl_service_base.TorServicePrefs
 
-internal class ServiceTorSettings(
+internal class ServiceTorSettings private constructor(
     servicePrefs: TorServicePrefs,
     defaultTorSettings: ApplicationDefaultTorSettings
 ): BaseServiceTorSettings(servicePrefs, defaultTorSettings) {
+
+    companion object {
+        @JvmSynthetic
+        fun instantiate(
+            servicePrefs: TorServicePrefs,
+            defaultTorSettings: ApplicationDefaultTorSettings
+        ): ServiceTorSettings =
+            ServiceTorSettings(servicePrefs, defaultTorSettings)
+    }
 
     @WorkerThread
     override fun dormantClientTimeoutSave(minutes: Int?) {

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
@@ -91,28 +91,43 @@ import java.security.SecureRandom
  *
  * @param [torService]
  * */
-internal class TorServiceReceiver(private val torService: BaseService): BroadcastReceiver() {
+internal class TorServiceReceiver private constructor(
+    private val torService: BaseService
+): BroadcastReceiver() {
 
     companion object {
+        @JvmSynthetic
+        fun instantiate(torService: BaseService): TorServiceReceiver =
+            TorServiceReceiver(torService)
+
         // Secures the intent filter at each application startup.
         // Also serves as the key to string extras containing the ServiceAction to be executed.
-        val SERVICE_INTENT_FILTER: String by lazy {
+        private val SERVICE_INTENT_FILTER: String by lazy {
             BigInteger(130, SecureRandom()).toString(32)
         }
 
-        @Volatile
-        var isRegistered = false
-            private set
+        @JvmSynthetic
+        fun getServiceIntentFilter(): String =
+            SERVICE_INTENT_FILTER
 
         @Volatile
-        var deviceIsLocked: Boolean? = null
-            private set
+        private var isRegistered = false
+        @JvmSynthetic
+        fun isRegistered(): Boolean =
+            isRegistered
+
+        @Volatile
+        private var deviceIsLocked: Boolean? = null
+        @JvmSynthetic
+        fun deviceIsLocked(): Boolean? =
+            deviceIsLocked
     }
 
     private val broadcastLogger by lazy {
         torService.getBroadcastLogger(TorServiceReceiver::class.java)
     }
 
+    @JvmSynthetic
     fun register() {
         val filter = IntentFilter(SERVICE_INTENT_FILTER)
         @Suppress("DEPRECATION")
@@ -123,7 +138,7 @@ internal class TorServiceReceiver(private val torService: BaseService): Broadcas
             filter.addAction(Intent.ACTION_SCREEN_ON)
             filter.addAction(Intent.ACTION_USER_PRESENT)
         }
-        torService.context.applicationContext.registerReceiver(this, filter)
+        torService.getContext().applicationContext.registerReceiver(this, filter)
         if (!isRegistered)
             broadcastLogger.debug("Has been registered")
         isRegistered = true
@@ -133,14 +148,16 @@ internal class TorServiceReceiver(private val torService: BaseService): Broadcas
      * Sets [deviceIsLocked] to the value sent. If [value] is null, it will check
      * KeyguardManager.
      * */
+    @JvmSynthetic
     fun setDeviceIsLocked(value: Boolean? = null) {
         deviceIsLocked = value ?: checkIfDeviceIsLocked()
     }
 
+    @JvmSynthetic
     fun unregister() {
         if (isRegistered) {
             try {
-                torService.context.applicationContext.unregisterReceiver(this)
+                torService.getContext().applicationContext.unregisterReceiver(this)
                 isRegistered = false
                 setDeviceIsLocked()
                 broadcastLogger.debug("Has been unregistered")
@@ -151,7 +168,7 @@ internal class TorServiceReceiver(private val torService: BaseService): Broadcas
     }
 
     private fun checkIfDeviceIsLocked(): Boolean? {
-        val keyguardManager = torService.context.applicationContext
+        val keyguardManager = torService.getContext().applicationContext
             .getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager?
         return keyguardManager?.isKeyguardLocked
     }
@@ -167,9 +184,9 @@ internal class TorServiceReceiver(private val torService: BaseService): Broadcas
                     broadcastLogger.notice("Network connectivity: $connectivity")
 
                     val actionObject = if (connectivity) {
-                        ServiceAction.SetDisableNetwork(ServiceActionName.ENABLE_NETWORK)
+                        ServiceAction.SetDisableNetwork.instantiate(ServiceActionName.ENABLE_NETWORK)
                     } else {
-                        ServiceAction.SetDisableNetwork(ServiceActionName.DISABLE_NETWORK)
+                        ServiceAction.SetDisableNetwork.instantiate(ServiceActionName.DISABLE_NETWORK)
                     }
 
                     torService.processServiceAction(actionObject)
@@ -188,13 +205,13 @@ internal class TorServiceReceiver(private val torService: BaseService): Broadcas
 
                     when (val serviceAction = intent.getStringExtra(SERVICE_INTENT_FILTER)) {
                         ServiceActionName.NEW_ID -> {
-                            torService.processServiceAction(ServiceAction.NewId())
+                            torService.processServiceAction(ServiceAction.NewId.instantiate())
                         }
                         ServiceActionName.RESTART_TOR -> {
-                            torService.processServiceAction(ServiceAction.RestartTor())
+                            torService.processServiceAction(ServiceAction.RestartTor.instantiate())
                         }
                         ServiceActionName.STOP -> {
-                            torService.processServiceAction(ServiceAction.Stop())
+                            torService.processServiceAction(ServiceAction.Stop.instantiate())
                         }
                         else -> {
                             broadcastLogger.warn(

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/service/components/receiver/TorServiceReceiver.kt
@@ -80,7 +80,7 @@ import android.net.ConnectivityManager
 import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.service.TorService
 import io.matthewnelson.topl_service.service.components.actions.ServiceAction
-import io.matthewnelson.topl_service.util.ServiceConsts.ServiceActionName
+import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceActionName
 import java.math.BigInteger
 import java.security.SecureRandom
 

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/ServiceConsts.kt
@@ -77,6 +77,7 @@ import io.matthewnelson.topl_service_base.BaseServiceConsts
 
 abstract class ServiceConsts: BaseServiceConsts() {
 
+
     //////////////////////////
     /// NotificationImages ///
     //////////////////////////
@@ -97,9 +98,9 @@ abstract class ServiceConsts: BaseServiceConsts() {
     }
 
 
-    //////////////////////
+    /////////////////////
     /// ServiceAction ///
-    //////////////////////
+    /////////////////////
     @Target(
         AnnotationTarget.TYPE,
         AnnotationTarget.CLASS,
@@ -123,33 +124,6 @@ abstract class ServiceConsts: BaseServiceConsts() {
             const val START_TOR = "${ACTION_COMMAND}START_TOR"
             const val STOP_SERVICE = "${ACTION_COMMAND}STOP_SERVICE"
             const val STOP_TOR = "${ACTION_COMMAND}STOP_TOR"
-        }
-    }
-
-    @Target(
-        AnnotationTarget.CLASS,
-        AnnotationTarget.VALUE_PARAMETER,
-        AnnotationTarget.TYPE,
-        AnnotationTarget.PROPERTY
-    )
-    @StringDef(
-        ServiceActionName.DISABLE_NETWORK,
-        ServiceActionName.ENABLE_NETWORK,
-        ServiceActionName.NEW_ID,
-        ServiceActionName.RESTART_TOR,
-        ServiceActionName.START,
-        ServiceActionName.STOP
-    )
-    @Retention(AnnotationRetention.SOURCE)
-    internal annotation class ServiceActionName {
-        companion object {
-            private const val ACTION_NAME = "Action_"
-            const val DISABLE_NETWORK = "${ACTION_NAME}DISABLE_NETWORK"
-            const val ENABLE_NETWORK = "${ACTION_NAME}ENABLE_NETWORK"
-            const val NEW_ID = "${ACTION_NAME}NEW_ID"
-            const val RESTART_TOR = "${ACTION_NAME}RESTART_TOR"
-            const val START = "${ACTION_NAME}START"
-            const val STOP = "${ACTION_NAME}STOP"
         }
     }
 }

--- a/topl-service/src/main/java/io/matthewnelson/topl_service/util/V3ClientAuthManager.kt
+++ b/topl-service/src/main/java/io/matthewnelson/topl_service/util/V3ClientAuthManager.kt
@@ -85,9 +85,15 @@ import java.io.File
  * Use [io.matthewnelson.topl_service.TorServiceController.getV3ClientAuthManager] to
  * instantiate an instance of the Manager.
  * */
-internal class V3ClientAuthManager(
+internal class V3ClientAuthManager private constructor(
     private val torConfigFiles: TorConfigFiles
 ): BaseV3ClientAuthManager() {
+
+    companion object {
+        @JvmSynthetic
+        fun instantiate(torConfigFiles: TorConfigFiles): V3ClientAuthManager =
+            V3ClientAuthManager(torConfigFiles)
+    }
 
     ///////////////////////////////////
     /// Add v3 Client Authorization ///

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
@@ -144,6 +144,9 @@ internal class TestTorService(
     val supervisorJob = SupervisorJob()
     val testCoroutineScope = TestCoroutineScope(dispatcher + supervisorJob)
 
+    override fun getScopeDefault(): CoroutineScope {
+        return testCoroutineScope
+    }
     override fun getScopeIO(): CoroutineScope {
         return testCoroutineScope
     }
@@ -251,7 +254,7 @@ internal class TestTorService(
         return true
     }
     @WorkerThread
-    override fun startTor() {
+    override suspend fun startTor() {
         simulateStart()
     }
 
@@ -259,6 +262,7 @@ internal class TestTorService(
     val bandwidth0 = "0"
 
     // Add 6_000ms delay at start of each test to account for startup time.
+    @Suppress("BlockingMethodInNonBlockingContext")
     private fun simulateStart() = getScopeIO().launch {
         try {
             onionProxyManager.setup()
@@ -282,7 +286,7 @@ internal class TestTorService(
         }
     }
     @WorkerThread
-    override fun stopTor() {
+    override suspend fun stopTor() {
         simulateStopTor()
     }
 

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
@@ -169,7 +169,7 @@ internal class TestTorService(
      * is simulated properly in that it will stop processing the queue and the Coroutine
      * Job will move to `complete`.
      * */
-    override fun stopService() {
+    override suspend fun stopService() {
         stopSelfCalled = true
         getScopeMain().launch { onDestroy() }
     }

--- a/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
+++ b/topl-service/src/test/java/io/matthewnelson/test_helpers/service/TestTorService.kt
@@ -82,11 +82,9 @@ import io.matthewnelson.topl_core.broadcaster.BroadcastLogger
 import io.matthewnelson.topl_core_base.BaseConsts.TorNetworkState
 import io.matthewnelson.topl_core_base.BaseConsts.TorState
 import io.matthewnelson.topl_service.TorServiceController
-import io.matthewnelson.topl_service_base.TorServicePrefs
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceEventBroadcaster
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceEventListener
 import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorInstaller
-import io.matthewnelson.topl_service.service.components.onionproxy.ServiceTorSettings
 import io.matthewnelson.topl_service.service.BaseService
 import io.matthewnelson.topl_service.service.components.actions.ServiceActionProcessor
 import io.matthewnelson.topl_service.service.components.receiver.TorServiceReceiver
@@ -99,9 +97,13 @@ import java.io.IOException
 import java.lang.reflect.InvocationTargetException
 
 internal class TestTorService(
-    override val context: Context,
+    private val context: Context,
     dispatcher: CoroutineDispatcher
 ): BaseService() {
+
+    override fun getContext(): Context {
+        return context
+    }
 
 
     ///////////////
@@ -113,7 +115,7 @@ internal class TestTorService(
 
     override fun unbindTorService() {
         try {
-            unbindService(context)
+            unbindService(getContext())
         } catch (e: IllegalArgumentException) {}
     }
     override fun onBind(intent: Intent?): IBinder? {
@@ -125,7 +127,7 @@ internal class TestTorService(
     /// BroadcastReceiver ///
     /////////////////////////
     val torServiceReceiver by lazy {
-        TorServiceReceiver(this)
+        TorServiceReceiver.instantiate(this)
     }
     override fun registerReceiver() {
         torServiceReceiver.register()
@@ -180,20 +182,20 @@ internal class TestTorService(
         getBroadcastLogger(TestTorService::class.java)
     }
     val serviceEventBroadcaster: ServiceEventBroadcaster by lazy {
-        ServiceEventBroadcaster(this)
+        ServiceEventBroadcaster.instantiate(this)
     }
     val serviceTorSettings: BaseServiceTorSettings by lazy {
         TorServiceController.getServiceTorSettings()
     }
     val onionProxyManager: OnionProxyManager by lazy {
         OnionProxyManager(
-            context,
+            getContext(),
             TorServiceController.getTorConfigFiles(),
-            ServiceTorInstaller(this),
+            ServiceTorInstaller.instantiate(this),
             serviceTorSettings,
-            ServiceEventListener(),
+            ServiceEventListener.instantiate(),
             serviceEventBroadcaster,
-            buildConfigDebug
+            getBuildConfigDebug()
         )
     }
 

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/TorServiceControllerUnitTest.kt
@@ -150,10 +150,10 @@ internal class TorServiceControllerUnitTest {
     @Test
     fun `_z_ensure builder methods properly initialize variables when build called`() {
         // Hasn't been initialized yet
-        assertEquals(BuildConfig.DEBUG, BaseService.buildConfigDebug)
+        assertEquals(BuildConfig.DEBUG, BaseService.getBuildConfigDebug())
         assertNull(TorServiceController.appEventBroadcaster)
-        val initialRestartTorDelay = ServiceActionProcessor.restartTorDelayTime
-        val initialStopServiceDelay = ServiceActionProcessor.stopServiceDelayTime
+        val initialRestartTorDelay = ServiceActionProcessor.getRestartTorDelayTime()
+        val initialStopServiceDelay = ServiceActionProcessor.getStopServiceDelayTime()
 
         val timeToAdd = 300L
 
@@ -165,9 +165,9 @@ internal class TorServiceControllerUnitTest {
             .setEventBroadcaster(TestEventBroadcaster())
             .build()
 
-        assertEquals(ServiceActionProcessor.restartTorDelayTime, initialRestartTorDelay + timeToAdd)
-        assertEquals(ServiceActionProcessor.stopServiceDelayTime, initialStopServiceDelay + timeToAdd)
-        assertEquals(BaseService.buildConfigDebug, !BuildConfig.DEBUG)
+        assertEquals(ServiceActionProcessor.getRestartTorDelayTime(), initialRestartTorDelay + timeToAdd)
+        assertEquals(ServiceActionProcessor.getStopServiceDelayTime(), initialStopServiceDelay + timeToAdd)
+        assertEquals(BaseService.getBuildConfigDebug(), !BuildConfig.DEBUG)
         assertNotNull(TorServiceController.appEventBroadcaster)
     }
 
@@ -175,12 +175,12 @@ internal class TorServiceControllerUnitTest {
     fun `_zz_ensure one-time initialization if build called more than once`() {
         try {
             TorServiceController.getDefaultTorSettings()
-            assertNotNull(BaseService.buildConfigDebug)
+            assertNotNull(BaseService.getBuildConfigDebug())
             // build has been called in a previous test
         } catch (e: RuntimeException) {
-            assertNull(BaseService.buildConfigDebug)
+            assertNull(BaseService.getBuildConfigDebug())
             getNewControllerBuilder().build()
-            assertNotNull(BaseService.buildConfigDebug)
+            assertNotNull(BaseService.getBuildConfigDebug())
         }
 
         val initialHashCode = TorServiceController.getDefaultTorSettings().hashCode()

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/service/TorServiceUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/service/TorServiceUnitTest.kt
@@ -130,7 +130,7 @@ internal class TorServiceUnitTest {
     private val serviceEventBroadcaster: ServiceEventBroadcaster
         get() = testTorService.serviceEventBroadcaster
     private val serviceNotification: ServiceNotification
-        get() = ServiceNotification.serviceNotification
+        get() = ServiceNotification.getServiceNotification()
 
     private val testDispatcher = TestCoroutineDispatcher()
 
@@ -175,7 +175,7 @@ internal class TorServiceUnitTest {
         )
         BaseService.startService(app, TestTorService::class.java)
         assertEquals(shadowOf(app).nextStartedService.action, ServiceActionName.START)
-        assertNotNull(TorServiceConnection.serviceBinder)
+        assertNotNull(TorServiceConnection.getServiceBinder())
 
         // Simulate startup
         testTorService.onCreate()
@@ -227,13 +227,13 @@ internal class TorServiceUnitTest {
         var statePair = testTorService.getSimulatedTorStates()
         assertEquals(TorState.STARTING, statePair.first)
         assertEquals(TorNetworkState.DISABLED, statePair.second)
-        assertEquals(TorState.STARTING, serviceNotification.currentContentTitle)
+        assertEquals(TorState.STARTING, serviceNotification.getCurrentContentTitle())
         delay(1000)
 
         statePair = testTorService.getSimulatedTorStates()
         assertEquals(TorState.ON, statePair.first)
         assertEquals(TorNetworkState.DISABLED, statePair.second)
-        assertEquals(TorState.ON, serviceNotification.currentContentTitle)
+        assertEquals(TorState.ON, serviceNotification.getCurrentContentTitle())
         delay(1000)
 
         // Ensure ServiceActionProcessor started Tor, messages broadcast properly,
@@ -241,31 +241,31 @@ internal class TorServiceUnitTest {
         statePair = testTorService.getSimulatedTorStates()
         assertEquals(TorState.ON, statePair.first)
         assertEquals(TorNetworkState.ENABLED, statePair.second)
-        assertEquals(TorState.ON, serviceNotification.currentContentTitle)
+        assertEquals(TorState.ON, serviceNotification.getCurrentContentTitle())
 
         // Waiting to Bootstrap
-        assertEquals(true, serviceNotification.progressBarShown)
-        assertEquals(serviceNotification.imageNetworkDisabled, serviceNotification.currentIcon)
+        assertEquals(true, serviceNotification.getProgressBarShown())
+        assertEquals(serviceNotification.imageNetworkDisabled, serviceNotification.getCurrentIcon())
         delay(1000)
 
         // Bootstrapped
-        assertEquals("Bootstrapped 95%", serviceNotification.currentContentText)
+        assertEquals("Bootstrapped 95%", serviceNotification.getCurrentContentText())
         delay(1000)
 
-        assertEquals("Bootstrapped 100%", serviceNotification.currentContentText)
-        assertEquals(false, serviceNotification.progressBarShown)
-        assertEquals(serviceNotification.imageNetworkEnabled, serviceNotification.currentIcon)
+        assertEquals("Bootstrapped 100%", serviceNotification.getCurrentContentText())
+        assertEquals(false, serviceNotification.getProgressBarShown())
+        assertEquals(serviceNotification.imageNetworkEnabled, serviceNotification.getCurrentIcon())
         delay(1000)
 
         // Data transfer
         val bandwidth = testTorService.bandwidth1000
         val contentTextString =
             ServiceUtilities.getFormattedBandwidthString(bandwidth.toLong(), bandwidth.toLong())
-        assertEquals(contentTextString, serviceNotification.currentContentText)
-        assertEquals(serviceNotification.imageDataTransfer, serviceNotification.currentIcon)
+        assertEquals(contentTextString, serviceNotification.getCurrentContentText())
+        assertEquals(serviceNotification.imageDataTransfer, serviceNotification.getCurrentIcon())
         delay(1000)
 
-        assertEquals(serviceNotification.imageNetworkEnabled, serviceNotification.currentIcon)
+        assertEquals(serviceNotification.imageNetworkEnabled, serviceNotification.getCurrentIcon())
         delay(1000)
 
         // Ensure Receivers were registered
@@ -273,7 +273,7 @@ internal class TorServiceUnitTest {
             // Registered with the system
             assertEquals(testTorService.torServiceReceiver, it.broadcastReceiver)
             // Boolean value is correct
-            assertEquals(true, TorServiceReceiver.isRegistered)
+            assertEquals(true, TorServiceReceiver.isRegistered())
         }
 
         // Test TorServicePrefsListener is working (will refresh Loggers if tor is _not_ off)
@@ -295,20 +295,20 @@ internal class TorServiceUnitTest {
         var statePair = testTorService.getSimulatedTorStates()
         assertEquals(TorState.STOPPING, statePair.first)
         assertEquals(TorNetworkState.ENABLED, statePair.second)
-        assertEquals(TorState.STOPPING, serviceNotification.currentContentTitle)
-        assertEquals("Stopping Service...", serviceNotification.currentContentText)
+        assertEquals(TorState.STOPPING, serviceNotification.getCurrentContentTitle())
+        assertEquals("Stopping Service...", serviceNotification.getCurrentContentText())
         delay(1000)
 
         statePair = testTorService.getSimulatedTorStates()
         assertEquals(TorState.STOPPING, statePair.first)
         assertEquals(TorNetworkState.DISABLED, statePair.second)
-        assertEquals(TorState.STOPPING, serviceNotification.currentContentTitle)
+        assertEquals(TorState.STOPPING, serviceNotification.getCurrentContentTitle())
         delay(1000)
 
         statePair = testTorService.getSimulatedTorStates()
         assertEquals(TorState.OFF, statePair.first)
         assertEquals(TorNetworkState.DISABLED, statePair.second)
-        assertEquals(TorState.OFF, serviceNotification.currentContentTitle)
+        assertEquals(TorState.OFF, serviceNotification.getCurrentContentTitle())
         delay(1000)
 
         // Ensure Receivers were unregistered
@@ -316,7 +316,7 @@ internal class TorServiceUnitTest {
             // Registered with the system
             assertNull(it.broadcastReceiver)
             // Boolean value is correct
-            assertEquals(false, TorServiceReceiver.isRegistered)
+            assertEquals(false, TorServiceReceiver.isRegistered())
         }
 
         // Test TorServicePrefsListener is unregistered

--- a/topl-service/src/test/java/io/matthewnelson/topl_service/service/TorServiceUnitTest.kt
+++ b/topl-service/src/test/java/io/matthewnelson/topl_service/service/TorServiceUnitTest.kt
@@ -74,7 +74,6 @@ package io.matthewnelson.topl_service.service
 import android.app.Application
 import android.content.ComponentName
 import android.content.Intent
-import android.os.Looper.getMainLooper
 import androidx.test.core.app.ApplicationProvider
 import io.matthewnelson.test_helpers.application_provided_classes.TestEventBroadcaster
 import io.matthewnelson.test_helpers.application_provided_classes.TestTorSettings
@@ -91,7 +90,7 @@ import io.matthewnelson.topl_service.service.components.receiver.TorServiceRecei
 import io.matthewnelson.topl_service.lifecycle.BackgroundManager
 import io.matthewnelson.topl_service.service.components.binding.TorServiceConnection
 import io.matthewnelson.topl_service_base.BaseServiceConsts.PrefKeyBoolean
-import io.matthewnelson.topl_service.util.ServiceConsts.ServiceActionName
+import io.matthewnelson.topl_service_base.BaseServiceConsts.ServiceActionName
 import io.matthewnelson.topl_service_base.ServiceUtilities
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.TestCoroutineDispatcher


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
This PR merges in development features & bug fixes in preparation for 2.1.0 release.  

The following **features** were added:
 - `topl-service:TorService` Lifecycle Events are now broadcast to `TorServiceEventBroadcaster`
 - `topl-service-base:ServiceExecutionHooks` have been implemented such that library users can 
 leverage suspension functions at key points of `TorService`'s operation, and allow for synchronous code execution.
 - Moved `topl-service:ServiceActionName` String definitions to `topl-service-base` to expose them 
 such that library users can utilize them in their implementation of `TorServiceEventBroadcaster`

The following **bug fixes** were tended to:
 - Kotlin internal visibility modifier is public from Java code. See #100 
 - Duplicate v3 Client Authentication files were inhibiting Tor from starting properly. See #105 
 - Tor notice messages were modified between 0.4.4.0 and 0.4.5.4-rc, which caused `topl-service:ServiceEventBroadcaster`'s notice message filter to miss broadcasting of ports. See #110 

And Dependencies have been bumped to latest available stable versions.


## Type of change
<!--    [x] = check mark on preview     -->
<!--    [ ] = empty box on preview      -->
<!---->
<!-- Please REMOVE unchecked selections -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Change Status
<!-- Please REMOVE unchecked selections -->

- [x] Complete, tested, ready to review and merge

# Checklist
<!-- Please KEEP unchecked selections -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit/ui tests pass locally with my changes
- [x] There are no merge conflicts
